### PR TITLE
Use "C" as the calling convention for non-Windows platforms

### DIFF
--- a/intercom-attributes/src/lib.rs
+++ b/intercom-attributes/src/lib.rs
@@ -936,7 +936,7 @@ fn tokens_to_tokenstream<T: IntoIterator<Item=quote::Tokens>>(
 
 // https://msdn.microsoft.com/en-us/library/984x0h58.aspx
 #[cfg(windows)]
-fn get_calling_convetion() -> &'static str { "\"stdcall\"" }
+fn get_calling_convetion() -> &'static str { "stdcall" }
 
 #[cfg(not(windows))]
 fn get_calling_convetion() -> &'static str { "C" }

--- a/intercom-attributes/tests/lib.rs
+++ b/intercom-attributes/tests/lib.rs
@@ -68,7 +68,13 @@ fn check_expansions() {
         target_code = target_code.replace( "\r", "" );
         source_code = source_code.replace( "\r", "" );
 
-        // 
+        // Normalize the calling conventions.
+        // The expected results use "stdcall". "C" is more likely
+        // to appear in the tests on its own.
+        // See https://github.com/Rantanen/intercom/pull/31#issuecomment-353516541
+        target_code = target_code.replace( "stdcall", "C" );
+        source_code = source_code.replace( "stdcall", "C" );
+
         // Use rustfmt to format both pieces of code so that we have a
         // canonical format for them. Without rustfmt we'd need to match the
         // compiler pretty print format in the reference target files - which,

--- a/intercom/src/combox.rs
+++ b/intercom/src/combox.rs
@@ -224,6 +224,7 @@ impl<T: CoClass> ComBox<T> {
     }
 
     /// Pointer variant of the `query_interface` function.
+    #[cfg(windows)]
     pub unsafe extern "stdcall" fn query_interface_ptr(
         self_iunk : RawComPtr,
         riid : REFIID,
@@ -233,7 +234,19 @@ impl<T: CoClass> ComBox<T> {
         ComBox::query_interface( ComBox::<T>::from_ptr( self_iunk ), riid, out )
     }
 
+    /// Pointer variant of the `query_interface` function.
+    #[cfg(not(windows))]
+    pub unsafe extern "C" fn query_interface_ptr(
+        self_iunk : RawComPtr,
+        riid : REFIID,
+        out : *mut RawComPtr,
+    ) -> HRESULT
+    {
+        ComBox::query_interface( ComBox::<T>::from_ptr( self_iunk ), riid, out )
+    }
+
     /// Pointer variant of the `add_ref` function.
+    #[cfg(windows)]
     pub unsafe extern "stdcall" fn add_ref_ptr(
         self_iunk : RawComPtr
     ) -> u32
@@ -241,7 +254,17 @@ impl<T: CoClass> ComBox<T> {
         ComBox::add_ref( ComBox::<T>::from_ptr( self_iunk ) )
     }
 
+    /// Pointer variant of the `add_ref` function.
+    #[cfg(not(windows))]
+    pub unsafe extern "C" fn add_ref_ptr(
+        self_iunk : RawComPtr
+    ) -> u32
+    {
+        ComBox::add_ref( ComBox::<T>::from_ptr( self_iunk ) )
+    }
+
     /// Pointer variant of the `release` function.
+    #[cfg(windows)]
     pub unsafe extern "stdcall" fn release_ptr(
         self_iunk : RawComPtr
     ) -> u32
@@ -250,7 +273,29 @@ impl<T: CoClass> ComBox<T> {
     }
 
     /// Pointer variant of the `release` function.
+    #[cfg(not(windows))]
+    pub unsafe extern "C" fn release_ptr(
+        self_iunk : RawComPtr
+    ) -> u32
+    {
+        ComBox::release( self_iunk as *mut ComBox< T > )
+    }
+
+    /// Pointer variant of the `release` function.
+    #[cfg(windows)]
     pub unsafe extern "stdcall" fn interface_supports_error_info_ptr(
+        self_iunk : RawComPtr,
+        riid : REFIID,
+    ) -> HRESULT
+    {
+        ComBox::interface_supports_error_info(
+                ComBox::<T>::from_ptr( self_iunk ),
+                riid )
+    }
+
+    /// Pointer variant of the `release` function.
+    #[cfg(not(windows))]
+    pub unsafe extern "C" fn interface_supports_error_info_ptr(
         self_iunk : RawComPtr,
         riid : REFIID,
     ) -> HRESULT


### PR DESCRIPTION
This can be refined once a sane CMake setup has been established and
we can easily ask someone else to test the project on different platforms.
