### PR TITLE
Included the name of the library in the generated header

### DIFF
--- a/intercom-cpp/src/activator.h
+++ b/intercom-cpp/src/activator.h
@@ -23,11 +23,11 @@ public:
 public:
 
     Activator(
+        const char* name,
         intercom::REFCLSID classId  //!< Identifies the class constructed with this activator.
     ) :
         m_classId( classId ),
-        m_library( "libtest_lib.so",
-            DlWrapper::rtld::lazy ),
+        m_library( name, DlWrapper::rtld::lazy ),
         m_getClassObjectFunc( nullptr ),
         m_classFactory( nullptr )
     {

--- a/intercom-utils/src/cpp/implementation.rs
+++ b/intercom-utils/src/cpp/implementation.rs
@@ -1,0 +1,39 @@
+use std::collections::HashMap;
+use cpp::*;
+
+/// Generates implementation for the specified library.
+pub fn generate(
+    r : &ParseResult,
+    _rn : &HashMap<String, String>
+) -> String {
+
+    // Implementation of the library descriptor.
+    let library_descriptor = generate_library_descriptor( &r.libname );
+
+    // We got the required compontents, format the final implementation.
+    let raw_implementation: String = format!( r###"
+>       #include "{}.h"
+
+>       {}
+"###,
+        &r.libname, library_descriptor );
+    raw_implementation.replace( ">       ", "" )
+}
+
+/// Generates implementation for the library descriptor.
+fn generate_library_descriptor(
+    libname: &str
+) -> String {
+
+    // The name of the current platform.
+    let name = format!(
+            "#ifdef _MSC_VER\n{}const char {}::Descriptor::NAME[] = \"{}.dll\";\n#else\n{}const char {}::Descriptor::NAME[]= \"lib{}.so\";\n#endif",
+            get_indentation( 1 ), libname, libname, get_indentation( 1 ), libname, libname );
+
+    // Platform specific names.
+    let windows_name = format!( "const char {}::Descriptor::WINDOWS_NAME[] = \"{}.dll\";", libname, libname );
+    let posix_name = format!( "const char {}::Descriptor::POSIX_NAME[] = \"lib{}.so\";", libname, libname );
+
+    // Construct the final output.
+    format!("{}\n{}\n{}", name, windows_name, posix_name )
+}

--- a/intercom-utils/src/cpp/mod.rs
+++ b/intercom-utils/src/cpp/mod.rs
@@ -1,0 +1,85 @@
+
+extern crate std;
+
+use std::collections::HashMap;
+use parse::*;
+use clap::ArgMatches;
+use error::AppResult;
+use std::fs::File;
+use std::io::Write;
+use intercom_common::guid::*;
+
+mod header;
+mod implementation;
+
+/// Runs the 'cpp' subcommand.
+pub fn run( cpp_params : &ArgMatches ) -> AppResult {
+
+    // Parse the sources and convert the result into an IDL.
+    let ( renames, result ) = parse_crate(
+            cpp_params.value_of( "path" ).unwrap() )?;
+    let target = cpp_params.value_of( "output" ).expect( "Output path not specified." );
+    result_to_cpp( &result, &renames, target );
+    Ok(())
+}
+
+/// Gets an empty string for ind One level of indentation is four spaces.
+pub fn get_indentation(
+    level: usize
+) -> String {
+    let spaces = level * 4;
+    let indentation = format!( r###"{: <1$}"###, "", spaces );
+    indentation
+}
+
+/// Converts a Rust type into applicable C++ type.
+pub fn to_cpp_type(
+    ty: &str
+) -> &str {
+
+    match ty {
+        "int8" => "int8_t",
+        "uint8" => "uint8_t",
+        "int16" => "int16_t",
+        "uint16" => "uint16_t",
+        "int32" => "int32_t",
+        "uint32" => "uint32_t",
+        "int64" => "int64_t",
+        "uint64" => "uint64_t",
+        "BStr" => "intercom::BSTR",
+        "HRESULT" => "intercom::HRESULT",
+        _ => ty,
+    }
+}
+
+/// Converts a guid to binarys representation.
+pub fn guid_to_binary(
+    g: &GUID
+) -> String {
+
+    format!( "{{0x{:08x},0x{:04x},0x{:04x},{{0x{:02x},0x{:02x},0x{:02x},0x{:02x},0x{:02x},0x{:02x},0x{:02x},0x{:02x}}}}}",
+            g.data1, g.data2, g.data3,
+            g.data4[0], g.data4[1], g.data4[2], g.data4[3],
+            g.data4[4], g.data4[5], g.data4[6], g.data4[7] )
+}
+
+fn result_to_cpp(
+    r : &ParseResult,
+    rn : &HashMap<String, String>,
+    output : &str
+)
+{
+    // Generate the header.
+    let header = header::generate( r, rn );
+    let header_target = format!( "{}/{}.h", output, r.libname );
+    let header_target = File::create( &header_target )
+            .expect( &format!( "Creating file \"{}\" failed.", &header_target ) );
+    writeln!( &header_target, "{}", &header ).expect( "Writing header failed." );
+
+    // Generate the implementation.
+    let implementation = implementation::generate( r, rn );
+    let implementation_target = format!( "{}/{}.cpp", output, r.libname );
+    let implementation_target = File::create( &implementation_target )
+            .expect( &format!( "Creating file \"{}\" failed.", &implementation_target ) );
+    writeln!( &implementation_target, "{}", &implementation ).expect( "Writing implementation failed." );
+}

--- a/intercom-utils/src/main.rs
+++ b/intercom-utils/src/main.rs
@@ -47,6 +47,11 @@ fn main() {
                    .default_value( "." )
                    .index( 1 )
                 )
+                .arg( Arg::with_name( "output" )
+                   .help( "Target where the C++ header file and associated library implementation are generated." )
+                   .default_value( "." )
+                   .index( 2 )
+                )
             )
         .get_matches();
 

--- a/test/cpp-raw/CMakeLists.txt
+++ b/test/cpp-raw/CMakeLists.txt
@@ -25,6 +25,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 
 set(PROJECT_COMPILER_SPECIFIC_SRC
     ${PROJECT_SOURCE_DIR}/gcc/os.cpp
+    ${PROJECT_SOURCE_DIR}/gcc/test_lib.cpp
 )
 endif()
 

--- a/test/cpp-raw/gcc/os.cpp
+++ b/test/cpp-raw/gcc/os.cpp
@@ -20,7 +20,7 @@ void UninitializeRuntime()
 
 intercom::HRESULT CreateInstance( intercom::REFCLSID clsid, intercom::REFIID iid, void** pout )
 {
-	Activator activate( clsid );
+	Activator activate( test_lib::Descriptor::NAME, clsid );
 	activate.create( iid, pout );
 
 	return S_OK;

--- a/test/cpp-raw/gcc/test_lib.cpp
+++ b/test/cpp-raw/gcc/test_lib.cpp
@@ -1,0 +1,11 @@
+
+#include "test_lib.h"
+
+#ifdef _MSC_VER
+    const char test_lib::Descriptor::NAME[] = "test_lib.dll";
+#else
+    const char test_lib::Descriptor::NAME[]= "libtest_lib.so";
+#endif
+const char test_lib::Descriptor::WINDOWS_NAME[] = "test_lib.dll";
+const char test_lib::Descriptor::POSIX_NAME[] = "libtest_lib.so";
+

--- a/test/cpp-raw/gcc/test_lib.h
+++ b/test/cpp-raw/gcc/test_lib.h
@@ -1,8 +1,18 @@
 
+#ifndef INTERCOM_LIBRARY_test_lib_H
+#define INTERCOM_LIBRARY_test_lib_H
 #include <array>
 #include <intercom.h>
 namespace test_lib
 {
+    class Descriptor
+    {
+    public:
+        static const char NAME[];
+        static const char WINDOWS_NAME[];
+        static const char POSIX_NAME[];
+    };
+
 namespace raw
 {
     struct IRefCount;
@@ -18,14 +28,12 @@ namespace raw
     struct IRefCount : IUnknown
     {
         static constexpr intercom::IID ID = {0xaa5b7352,0x5d7a,0x35b9,{0x52,0x06,0x14,0x5b,0x04,0x1f,0x2c,0x1c}};
-
         virtual uint32_t INTERCOM_CC GetRefCount(  ) = 0;
     };
 
     struct IPrimitiveOperations : IUnknown
     {
         static constexpr intercom::IID ID = {0x12341234,0x1234,0x1234,{0x12,0x34,0x12,0x34,0x12,0x34,0x00,0x02}};
-
         virtual int8_t INTERCOM_CC I8( int8_t v ) = 0;
         virtual uint8_t INTERCOM_CC U8( uint8_t v ) = 0;
         virtual uint16_t INTERCOM_CC U16( uint16_t v ) = 0;
@@ -41,7 +49,6 @@ namespace raw
     struct IStatefulOperations : IUnknown
     {
         static constexpr intercom::IID ID = {0x2b9bddd2,0x31f5,0x3d4b,{0x79,0xa0,0xac,0x8e,0x8d,0x11,0xa9,0x3e}};
-
         virtual void INTERCOM_CC PutValue( int32_t v ) = 0;
         virtual int32_t INTERCOM_CC GetValue(  ) = 0;
     };
@@ -49,7 +56,6 @@ namespace raw
     struct IResultOperations : IUnknown
     {
         static constexpr intercom::IID ID = {0xffb673d9,0x7896,0x3a4c,{0x4f,0xa8,0xf7,0x24,0x06,0x58,0x8a,0xa1}};
-
         virtual intercom::HRESULT INTERCOM_CC SOk(  ) = 0;
         virtual intercom::HRESULT INTERCOM_CC NotImpl(  ) = 0;
         virtual intercom::HRESULT INTERCOM_CC Sqrt( double value, double* __out ) = 0;
@@ -59,7 +65,6 @@ namespace raw
     struct IClassCreator : IUnknown
     {
         static constexpr intercom::IID ID = {0x2e7e23e8,0xf66d,0x3779,{0x6c,0x74,0x61,0x89,0x8d,0x7b,0x40,0xcd}};
-
         virtual intercom::HRESULT INTERCOM_CC CreateRoot( int32_t id, ICreatedClass** __out ) = 0;
         virtual intercom::HRESULT INTERCOM_CC CreateChild( int32_t id, IParent* parent, ICreatedClass** __out ) = 0;
     };
@@ -67,7 +72,6 @@ namespace raw
     struct ICreatedClass : IUnknown
     {
         static constexpr intercom::IID ID = {0x104eb174,0xfd00,0x3ecf,{0x7e,0x0d,0xd9,0x65,0x56,0x42,0x79,0xe7}};
-
         virtual intercom::HRESULT INTERCOM_CC GetId( int32_t* __out ) = 0;
         virtual intercom::HRESULT INTERCOM_CC GetParentId( int32_t* __out ) = 0;
     };
@@ -75,14 +79,12 @@ namespace raw
     struct IParent : IUnknown
     {
         static constexpr intercom::IID ID = {0xcea1c199,0xbf71,0x3b0a,{0x5a,0x4c,0xee,0x3f,0x5a,0x0a,0xe5,0xce}};
-
         virtual int32_t INTERCOM_CC GetId(  ) = 0;
     };
 
     struct IRefCountOperations : IUnknown
     {
         static constexpr intercom::IID ID = {0x6b198a07,0x2d86,0x340e,{0x71,0x7e,0xf4,0x16,0xa3,0x90,0x5d,0x6e}};
-
         virtual intercom::HRESULT INTERCOM_CC GetNew( IRefCountOperations** __out ) = 0;
         virtual uint32_t INTERCOM_CC GetRefCount(  ) = 0;
     };
@@ -90,7 +92,6 @@ namespace raw
     struct ISharedInterface : IUnknown
     {
         static constexpr intercom::IID ID = {0x1df08ff6,0xaafb,0x37ec,{0x53,0xcf,0xcd,0xe2,0x49,0xce,0xeb,0x4b}};
-
         virtual uint32_t INTERCOM_CC GetValue(  ) = 0;
         virtual void INTERCOM_CC SetValue( uint32_t v ) = 0;
         virtual intercom::HRESULT INTERCOM_CC DivideBy( ISharedInterface* divisor, uint32_t* __out ) = 0;
@@ -99,83 +100,99 @@ namespace raw
     struct IErrorSource : IUnknown
     {
         static constexpr intercom::IID ID = {0x5505b7b6,0x5ca4,0x3e38,{0x66,0x7b,0xa9,0x82,0x3f,0x1d,0x5a,0x0f}};
-
         virtual intercom::HRESULT INTERCOM_CC StoreError( intercom::HRESULT hr, intercom::BSTR desc ) = 0;
     };
 
 
     class RefCountOperationsDescriptor
     {
+    public:
+
         static constexpr intercom::CLSID ID = {0xf06af5f0,0x745a,0x3b29,{0x48,0x39,0xd2,0xd3,0x9a,0x3f,0x08,0xcd}};
 
         static constexpr std::array<intercom::IID, 1> INTERFACES = {
             test_lib::raw::IRefCountOperations::ID
         };
 
+        using Library = test_lib::Descriptor;
+
         RefCountOperationsDescriptor() = delete;
         ~RefCountOperationsDescriptor() = delete;
 
     };
 
-
     class PrimitiveOperationsDescriptor
     {
+    public:
+
         static constexpr intercom::CLSID ID = {0x12341234,0x1234,0x1234,{0x12,0x34,0x12,0x34,0x12,0x34,0x00,0x01}};
 
         static constexpr std::array<intercom::IID, 1> INTERFACES = {
             test_lib::raw::IPrimitiveOperations::ID
         };
 
+        using Library = test_lib::Descriptor;
+
         PrimitiveOperationsDescriptor() = delete;
         ~PrimitiveOperationsDescriptor() = delete;
 
     };
 
-
     class StatefulOperationsDescriptor
     {
+    public:
+
         static constexpr intercom::CLSID ID = {0x694c1893,0x2fa8,0x3d4c,{0x6a,0xcf,0x69,0xc5,0x93,0x66,0x72,0x1e}};
 
         static constexpr std::array<intercom::IID, 1> INTERFACES = {
             test_lib::raw::IStatefulOperations::ID
         };
 
+        using Library = test_lib::Descriptor;
+
         StatefulOperationsDescriptor() = delete;
         ~StatefulOperationsDescriptor() = delete;
 
     };
 
-
     class ResultOperationsDescriptor
     {
+    public:
+
         static constexpr intercom::CLSID ID = {0xe5ce34c4,0xc1ad,0x34bc,{0x69,0xf6,0xd1,0xbf,0xa6,0xbb,0x25,0x96}};
 
         static constexpr std::array<intercom::IID, 1> INTERFACES = {
             test_lib::raw::IResultOperations::ID
         };
 
+        using Library = test_lib::Descriptor;
+
         ResultOperationsDescriptor() = delete;
         ~ResultOperationsDescriptor() = delete;
 
     };
 
-
     class ClassCreatorDescriptor
     {
+    public:
+
         static constexpr intercom::CLSID ID = {0x3323cccd,0x1a38,0x33a4,{0x4a,0xe1,0x4d,0xc9,0x2a,0x7e,0x8d,0xc5}};
 
         static constexpr std::array<intercom::IID, 1> INTERFACES = {
             test_lib::raw::IClassCreator::ID
         };
 
+        using Library = test_lib::Descriptor;
+
         ClassCreatorDescriptor() = delete;
         ~ClassCreatorDescriptor() = delete;
 
     };
 
-
     class CreatedClassDescriptor
     {
+    public:
+
         static constexpr intercom::CLSID ID = {0x51ed4fb8,0x35d8,0x36c6,{0x78,0xfd,0x6b,0xc5,0x82,0xc8,0x4b,0x19}};
 
         static constexpr std::array<intercom::IID, 3> INTERFACES = {
@@ -184,39 +201,46 @@ namespace raw
             test_lib::raw::IRefCount::ID
         };
 
+        using Library = test_lib::Descriptor;
+
         CreatedClassDescriptor() = delete;
         ~CreatedClassDescriptor() = delete;
 
     };
 
-
     class SharedImplementationDescriptor
     {
+    public:
+
         static constexpr intercom::CLSID ID = {0x88687644,0x9cb2,0x3bd6,{0x4c,0x23,0xdb,0x54,0x7d,0x39,0x90,0x29}};
 
         static constexpr std::array<intercom::IID, 1> INTERFACES = {
             test_lib::raw::ISharedInterface::ID
         };
 
+        using Library = test_lib::Descriptor;
+
         SharedImplementationDescriptor() = delete;
         ~SharedImplementationDescriptor() = delete;
 
     };
 
-
     class ErrorSourceDescriptor
     {
+    public:
+
         static constexpr intercom::CLSID ID = {0x2af563c2,0xdc1c,0x339a,{0x60,0x35,0xf5,0xf8,0x18,0x0f,0xae,0x86}};
 
         static constexpr std::array<intercom::IID, 1> INTERFACES = {
             test_lib::raw::IErrorSource::ID
         };
 
+        using Library = test_lib::Descriptor;
+
         ErrorSourceDescriptor() = delete;
         ~ErrorSourceDescriptor() = delete;
 
     };
-
 }
 }
 #ifdef INTERCOM_FLATTEN_DECLARATIONS
@@ -248,5 +272,6 @@ namespace raw
     static constexpr intercom::CLSID CLSID_CreatedClass = {0x51ed4fb8,0x35d8,0x36c6,{0x78,0xfd,0x6b,0xc5,0x82,0xc8,0x4b,0x19}};
     static constexpr intercom::CLSID CLSID_SharedImplementation = {0x88687644,0x9cb2,0x3bd6,{0x4c,0x23,0xdb,0x54,0x7d,0x39,0x90,0x29}};
     static constexpr intercom::CLSID CLSID_ErrorSource = {0x2af563c2,0xdc1c,0x339a,{0x60,0x35,0xf5,0xf8,0x18,0x0f,0xae,0x86}};
+#endif
 #endif
 


### PR DESCRIPTION
The name is used to load the library when objects from the library
are instantiated.

Also added include guard for the generated header.