### PR TITLE
Support for exceptions with detailed error information

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -40,6 +40,16 @@
         "streambuf": "cpp",
         "system_error": "cpp",
         "thread": "cpp",
-        "typeinfo": "cpp"
+        "typeinfo": "cpp",
+        "__config": "cpp",
+        "atomic": "cpp",
+        "strstream": "cpp",
+        "codecvt": "cpp",
+        "complex": "cpp",
+        "csignal": "cpp",
+        "cstdarg": "cpp",
+        "future": "cpp",
+        "valarray": "cpp",
+        "*.ipp": "cpp"
     }
 }

--- a/intercom-cpp/intercom.h
+++ b/intercom-cpp/intercom.h
@@ -2,3 +2,7 @@
 #include "src/callingconvention.h"
 #include "src/comdef.h"
 #include "src/classfactory.h"
+
+// Exceptions.
+#include "src/no_such_interface.h"
+#include "src/runtime_error.h"

--- a/intercom-cpp/src/classfactory.h
+++ b/intercom-cpp/src/classfactory.h
@@ -41,7 +41,11 @@ namespace intercom
             // Need an activator to create objects.
             intercom::HRESULT preparation = prepare_activator();
             if( preparation != S_OK )
-                throw std::exception();
+            {
+                throw intercom::RuntimeError( preparation,
+                        std::stringstream() << "Preparing activator for the class factory of class \""
+                        << TClass::ID << "\" failed." );
+            }
 
             return m_activator->create<TInterface>();
         }
@@ -79,6 +83,10 @@ namespace intercom
             {
                 std::call_once(m_initializationGuard, [&](){
                         this->m_activator = std::make_unique< Activator >( TClass::Library::NAME, TClass::ID ); } );
+            }
+            catch( std::bad_alloc )
+            {
+                return E_OUTOFMEMORY;
             }
             catch( ... )
             {

--- a/intercom-cpp/src/detail/hresult.h
+++ b/intercom-cpp/src/detail/hresult.h
@@ -48,7 +48,7 @@ namespace hresult
         {
         }
 
-        constexpr uint8_t error_code() const noexcept { return m_error_code; }
+        constexpr uint16_t error_code() const noexcept { return m_error_code; }
 
     private:
         uint16_t m_error_code;
@@ -88,7 +88,7 @@ namespace hresult
          return ((HRESULT)
                 ( static_cast< uint32_t >( intercom::detail::hresult::SEVERITY_ERROR ) << 31) |
                 ( static_cast< uint32_t >( facility ) << 16) |
-                ( static_cast< uint32_t >( error_code ) ) );
+                ( static_cast< uint16_t >( error_code ) ) );
      }
 
     /**
@@ -126,7 +126,7 @@ namespace hresult
      */
     constexpr bool succeeded(
          intercom::HRESULT error_code
-     )
+     ) noexcept
      {
          // The first bit of HRESULT codes is always '1' if the error code indicates a failure.
          return static_cast< int32_t >( error_code ) >= 0;
@@ -141,7 +141,7 @@ namespace hresult
      */
      constexpr bool failed(
          intercom::HRESULT error_code
-     )
+     ) noexcept
      {
          // The first bit of HRESULT codes is always '1' if the error code indicates a failure.
          return static_cast< int32_t >( error_code ) < 0;

--- a/intercom-cpp/src/detail/hresult.h
+++ b/intercom-cpp/src/detail/hresult.h
@@ -1,0 +1,153 @@
+
+#ifndef INTERCOM_CPP_DETAIL_HRESULT_H
+#define INTERCOM_CPP_DETAIL_HRESULT_H
+
+
+#include "../datatypes.h"
+
+namespace intercom
+{
+namespace detail
+{
+/**
+ * @brief Defines helpers for working with HRESULT error codes returned by COM methods on Windows platform.
+ *
+ * The same concepts are used in intercom to enable cross-platform development.
+ *
+ */
+namespace hresult
+{
+      /**
+     * @brief Error code for HRESULTs.
+     *
+     */
+    typedef uint16_t HRESULT_CODE;
+
+    // Source: https://blogs.msdn.microsoft.com/heaths/2005/07/21/deciphering-an-hresult/
+    static const uint8_t SEVERITY_SUCCESS = 0b0;
+    static const uint8_t SEVERITY_INFORMATIONAL = 0b01;
+    static const uint8_t SEVERITY_WARNING = 0b10;
+    static const uint8_t SEVERITY_ERROR = 0b11;
+
+    // Source: https://msdn.microsoft.com/en-us/library/windows/desktop/ms690088(v=vs.85).aspx
+    static const uint8_t FACILITY_NULL = 0;
+    static const uint8_t FACILITY_WIN32 = 7;
+
+    /**
+     * @brief Error type for defining error codes.
+     *
+     */
+    class Error
+    {
+    public:
+
+        constexpr Error(
+            uint16_t error_code
+        ) :
+        m_error_code( error_code )
+        {
+        }
+
+        constexpr uint8_t error_code() const noexcept { return m_error_code; }
+
+    private:
+        uint16_t m_error_code;
+    };
+
+    /**
+     * @brief Error type for FACILITY_NULL errors.
+     *
+     */
+    class NullError : public Error
+    {
+        using Error::Error;
+    };
+
+    /**
+     * @brief Error type for FACILITY_WIN32 errors.
+     *
+     */
+    class Win32Error : public Error
+    {
+        using Error::Error;
+    };
+
+     /**
+     * @brief Creates HRESULT error code from the specified values.
+     *
+     * @param severity The severity of the error.
+     * @param facility
+     * @param error_code The actual error code.
+     * @return constexpr HRESULT
+     */
+     constexpr ::intercom::HRESULT error(
+         uint8_t facility,
+         HRESULT_CODE error_code
+     ) noexcept
+     {
+         return ((HRESULT)
+                ( static_cast< uint32_t >( intercom::detail::hresult::SEVERITY_ERROR ) << 31) |
+                ( static_cast< uint32_t >( facility ) << 16) |
+                ( static_cast< uint32_t >( error_code ) ) );
+     }
+
+    /**
+     * @brief Creates HRESULT error code from the specified values.
+     *
+     * @param null_error The actual error code.
+     * @return constexpr HRESULT
+     */
+     constexpr ::intercom::HRESULT null_error(
+         NullError null_error
+     ) noexcept
+     {
+         return error( intercom::detail::hresult::FACILITY_NULL, null_error.error_code() );
+     }
+
+     /**
+     * @brief Creates HRESULT error code from the specified values.
+     *
+     * @param win32_error The actual error code.
+     * @return constexpr HRESULT
+     */
+     constexpr ::intercom::HRESULT win32_error(
+         Win32Error win32_error
+     ) noexcept
+     {
+         return error( intercom::detail::hresult::FACILITY_WIN32, win32_error.error_code() );
+     }
+
+    /**
+     * @brief Checks whether the error represents success.
+     *
+     * @param error_code Specifies the error code.
+     * @return true If the error code represents success.
+     * @return false If the error code represents failure.
+     */
+    constexpr bool succeeded(
+         intercom::HRESULT error_code
+     )
+     {
+         // The first bit of HRESULT codes is always '1' if the error code indicates a failure.
+         return static_cast< int32_t >( error_code ) >= 0;
+     }
+
+    /**
+     * @brief Checks whether the error represents failure.
+     *
+     * @param error_code
+     * @return true If the error code represents failure.
+     * @return false If the error code represents success.
+     */
+     constexpr bool failed(
+         intercom::HRESULT error_code
+     )
+     {
+         // The first bit of HRESULT codes is always '1' if the error code indicates a failure.
+         return static_cast< int32_t >( error_code ) < 0;
+     }
+}
+}
+}
+
+#endif

--- a/intercom-cpp/src/detail/hresult_errors.h
+++ b/intercom-cpp/src/detail/hresult_errors.h
@@ -21,8 +21,10 @@ namespace hresult
     static const NullError ERROR_POINTER = NullError( 0x4003 );
     static const NullError ERROR_ABORT = NullError( 0x4003 );
     static const NullError ERROR_FAIL = NullError( 0x4005 );
+    static_assert( NullError( 0x4005 ).error_code() == 0x4005, "Internal check failed: Invalid error code storage." );
 
     // "FACILITY_WIN32" error codes.
+    static const Win32Error ERROR_OUTOFMEMORY = Win32Error( 0x000E );
     static const Win32Error ERROR_INVALIDARG = Win32Error( 0x0057 );
 
     static const HRESULT S_OK = 0;
@@ -32,6 +34,7 @@ namespace hresult
     static const HRESULT E_ABORT = null_error( ERROR_ABORT );
     static const HRESULT E_FAIL = null_error( ERROR_FAIL );
 
+    static const HRESULT E_OUTOFMEMORY = win32_error( ERROR_OUTOFMEMORY );
     static const HRESULT E_INVALIDARG = win32_error( ERROR_INVALIDARG );
 }
 }

--- a/intercom-cpp/src/detail/hresult_errors.h
+++ b/intercom-cpp/src/detail/hresult_errors.h
@@ -1,0 +1,40 @@
+
+#ifndef INTERCOM_CPP_DETAIL_HRESULTERRORS_H
+#define INTERCOM_CPP_DETAIL_HRESULTERRORS_H
+
+#include "hresult.h"
+
+namespace intercom
+{
+namespace detail
+{
+/**
+ * @brief Defines the HRESULT codes used by intercom.
+ *
+ */
+namespace hresult
+{
+
+    // "FACILITY_NULL" error codes.
+    static const NullError ERROR_NOTIMPL = NullError( 0x4001 );
+    static const NullError ERROR_NOINTERFACE = NullError( 0x4002 );
+    static const NullError ERROR_POINTER = NullError( 0x4003 );
+    static const NullError ERROR_ABORT = NullError( 0x4003 );
+    static const NullError ERROR_FAIL = NullError( 0x4005 );
+
+    // "FACILITY_WIN32" error codes.
+    static const Win32Error ERROR_INVALIDARG = Win32Error( 0x0057 );
+
+    static const HRESULT S_OK = 0;
+    static const HRESULT E_NOTIMPL = null_error( ERROR_NOTIMPL );
+    static const HRESULT E_NOINTERFACE = null_error( ERROR_NOINTERFACE );
+    static const HRESULT E_POINTER = null_error( ERROR_POINTER );
+    static const HRESULT E_ABORT = null_error( ERROR_ABORT );
+    static const HRESULT E_FAIL = null_error( ERROR_FAIL );
+
+    static const HRESULT E_INVALIDARG = win32_error( ERROR_INVALIDARG );
+}
+}
+}
+
+#endif

--- a/intercom-cpp/src/detail/utility.h
+++ b/intercom-cpp/src/detail/utility.h
@@ -1,0 +1,77 @@
+
+#ifndef INTERCOM_CPP_DETAIL_UTILITY_H
+#define INTERCOM_CPP_DETAIL_UTILITY_H
+
+
+#include <cstring>
+#include <iomanip>
+#include <sstream>
+#include <type_traits>
+
+namespace intercom
+{
+namespace detail
+{
+
+    /**
+     * @brief Tests whether the machine is little endian or not.
+     *
+     * @return true The machine is little endian.
+     * @return false The machine is big endian.
+     */
+    inline bool is_little_endian()
+    {
+        // Create a copy of the data with memcpy.
+        // Directly casting with e.g. reinterpret_cast will lead to UB.
+        int test_value = 1;
+        std::array< uint8_t, sizeof( int ) > asBytes;
+        std::memcpy( &asBytes, &test_value, sizeof( int ) );
+        return asBytes[ 0 ] == 1;
+    }
+
+    /**
+     * @brief Writes the specified binary data into the stream as hex.
+     *
+     * @param stream Target stream.
+     * @param converter The binary data to write.
+     * @return std::ostream& Returns the stream.
+     */
+    template< typename TData >
+    inline std::ostream& write_as_hex(
+        std::ostream& stream,
+        TData data
+    )
+    {
+        // Create a copy of the data with memcpy.
+        // Directly casting with e.g. reinterpret_cast will lead to UB.
+        std::array< uint8_t, sizeof(TData) > asBytes;
+        std::memcpy( &asBytes, &data, sizeof( TData ) );
+
+        // Determine the order in which we need to print the data.
+        stream << std::hex << std::uppercase;
+        if( is_little_endian() )
+        {
+            // On little-endian machine the bytes are on reverse order.
+            for( auto byte = asBytes.rbegin(); byte != asBytes.rend(); ++byte )
+            {
+                // Explicit cast required, otherwise byte is treated as unsigned char.
+                stream << static_cast< unsigned int >( ( *byte & 0xF0 ) >> 4 );
+                stream << static_cast< unsigned int >( *byte & 0x0F );
+            }
+        }
+        else
+        {
+            for( auto byte = asBytes.begin(); byte != asBytes.end(); ++byte )
+            {
+                // Explicit cast required, otherwise byte is treated as unsigned char.
+                stream << static_cast< unsigned int >( ( *byte & 0xF0 ) >> 4 );
+                stream << static_cast< unsigned int >( *byte & 0x0F );
+            }
+        }
+
+        return stream;
+    }
+}
+}
+
+#endif

--- a/intercom-cpp/src/error_codes.h
+++ b/intercom-cpp/src/error_codes.h
@@ -7,22 +7,7 @@
 #include<Winerror.h>
 #else
 
-// TODO: Implement proper mechanism for constructing HRESULT based errors.
-// The values have internal structure, they are not just simplistic numbers.
-
-#include <inttypes.h>
-
-// Success.
-#define S_OK 0
-
-// Not implemented.
-#define E_NOTIMPL 0x80004001
-
-// Not implemented.
-#define E_INVALIDARG 0x80070057
-
-// 	Unspecified failure.
-#define E_FAIL 0x80004005
+#include "posix/error_codes.h"
 
 #endif
 #endif

--- a/intercom-cpp/src/no_such_interface.h
+++ b/intercom-cpp/src/no_such_interface.h
@@ -1,0 +1,98 @@
+
+#ifndef INTERCOM_CPP_NOSUCHINTERFACE_H
+#define INTERCOM_CPP_NOSUCHINTERFACE_H
+
+#include <stdexcept>
+#include <sstream>
+
+#include "guiddef.h"
+#include "error_codes.h"
+
+namespace intercom
+{
+
+/**
+ * @brief Exception thrown when a COM object does not implement the requested interface.
+ *
+ */
+class NoSuchInterface : public std::invalid_argument
+{
+public:
+
+    /**
+     * @brief Error code associated with the exception.
+     *
+     */
+    static const HRESULT ERROR_CODE = intercom::E_NOINTERFACE;
+
+    explicit NoSuchInterface(
+        const intercom::IID& interface_id
+    ) :
+        std::invalid_argument( get_error_message( interface_id ) ),
+        m_interface_id( interface_id )
+    {
+    }
+
+    explicit NoSuchInterface(
+        const intercom::CLSID& class_id,
+        const intercom::IID& interface_id
+    ) :
+        std::invalid_argument( get_error_message( class_id, interface_id ) ),
+        m_interface_id( interface_id )
+    {
+    }
+
+    /**
+     * @brief Returns the error associated with this exception.
+     *
+     * @return intercom::HRESULT Returns the error code.
+     */
+    intercom::HRESULT error_code() const noexcept { return ERROR_CODE; }
+
+    /**
+     * @brief Gets the interface id associated with the error.
+     *
+     * @return intercom::IID interface_id cosnt
+     */
+    intercom::IID interface_id() const noexcept { return m_interface_id; }
+
+private:
+
+    /**
+     * @brief Constructs error message for the exception from
+     *
+     * @return std::string Returns message.
+     */
+    static std::string get_error_message(
+        const intercom::IID& interface_id
+    )
+    {
+        std::stringstream fmt;
+        fmt << "Interface \"" << interface_id << "\" not available.";
+        return fmt.str();
+    }
+
+    /**
+     * @brief Constructs error message for the exception from
+     *
+     * @return std::string Returns message.
+     */
+    static std::string get_error_message(
+        const intercom::CLSID& class_id,
+        const intercom::IID& interface_id
+    )
+    {
+        std::stringstream fmt;
+        fmt << "Interface \"" << interface_id << "\" not available for the class \"" << class_id << "\".";
+        return fmt.str();
+    }
+
+private:
+
+     const intercom::IID m_interface_id;
+};
+
+
+}
+
+#endif

--- a/intercom-cpp/src/posix/error_codes.h
+++ b/intercom-cpp/src/posix/error_codes.h
@@ -13,7 +13,10 @@ namespace intercom
     static const intercom::HRESULT S_OK = intercom::detail::hresult::S_OK;
     static const intercom::HRESULT E_FAIL = intercom::detail::hresult::E_FAIL;
     static const intercom::HRESULT E_NOTIMPL = intercom::detail::hresult::E_NOTIMPL;
+    static const intercom::HRESULT E_NOINTERFACE = intercom::detail::hresult::E_NOINTERFACE;
+    static const intercom::HRESULT E_OUTOFMEMORY = intercom::detail::hresult::E_OUTOFMEMORY;
     static const intercom::HRESULT E_INVALIDARG = intercom::detail::hresult::E_INVALIDARG;
+    static_assert( E_FAIL == 0x80004005, "Internal check failed: Invalid error code structure." );
 }
 
 #ifdef INTERCOM_FLATTEN_DECLARATIONS
@@ -21,6 +24,8 @@ namespace intercom
 static const intercom::HRESULT S_OK = intercom::S_OK;
 static const intercom::HRESULT E_FAIL = intercom::E_FAIL;
 static const intercom::HRESULT E_NOTIMPL = intercom::E_NOTIMPL;
+static const intercom::HRESULT E_NOINTERFACE = intercom::E_NOINTERFACE;
+static const intercom::HRESULT E_OUTOFMEMORY = intercom::E_OUTOFMEMORY;
 static const intercom::HRESULT E_INVALIDARG = intercom::E_INVALIDARG;
 
 #endif

--- a/intercom-cpp/src/posix/error_codes.h
+++ b/intercom-cpp/src/posix/error_codes.h
@@ -1,0 +1,28 @@
+#ifndef INTERCOM_CPP_POSIX_ERRRORCODES_H
+#define INTERCOM_CPP_POSIX_ERRRORCODES_H
+
+#include <inttypes.h>
+#include "../detail/hresult_errors.h"
+
+/**
+ * @brief Defines the error codes use by "intercom".
+ *
+ */
+namespace intercom
+{
+    static const intercom::HRESULT S_OK = intercom::detail::hresult::S_OK;
+    static const intercom::HRESULT E_FAIL = intercom::detail::hresult::E_FAIL;
+    static const intercom::HRESULT E_NOTIMPL = intercom::detail::hresult::E_NOTIMPL;
+    static const intercom::HRESULT E_INVALIDARG = intercom::detail::hresult::E_INVALIDARG;
+}
+
+#ifdef INTERCOM_FLATTEN_DECLARATIONS
+
+static const intercom::HRESULT S_OK = intercom::S_OK;
+static const intercom::HRESULT E_FAIL = intercom::E_FAIL;
+static const intercom::HRESULT E_NOTIMPL = intercom::E_NOTIMPL;
+static const intercom::HRESULT E_INVALIDARG = intercom::E_INVALIDARG;
+
+#endif
+
+#endif

--- a/intercom-cpp/src/posix/guiddef.h
+++ b/intercom-cpp/src/posix/guiddef.h
@@ -3,6 +3,10 @@
 #define INTERCOM_CPP_POSIX_GUIDDEF_H
 
 #include <inttypes.h>
+#include <iomanip>
+#include <sstream>
+
+#include "../detail/utility.h"
 
 namespace intercom
 {
@@ -25,7 +29,49 @@ typedef IID CLSID;
 typedef const IID& REFCLSID;
 typedef const IID& REFIID;
 
+    /**
+     * @brief Writes the specified IID into a stream.
+     *
+     * @param stream Target stream.
+     * @param iid IID to write to the stream.
+     * @return std::ostream& Returns the stream.
+     */
+    inline std::ostream& operator<<(
+        std::ostream& stream,
+        const IID& iid
+    )
+    {
+        stream << "{";
+        intercom::detail::write_as_hex( stream, iid.Data1 );
+        stream << "-";
+        intercom::detail::write_as_hex( stream, iid.Data2 );
+        stream << "-";
+        intercom::detail::write_as_hex( stream, iid.Data3 );
+        stream << "-";
+        intercom::detail::write_as_hex( stream, iid.Data4[0] );
+        intercom::detail::write_as_hex( stream, iid.Data4[1] );
+        stream << "-";
+        for( size_t d = 2; d < sizeof( iid.Data4 ); ++d )
+            intercom::detail::write_as_hex( stream, iid.Data4[d] );
+        stream << "}";
+        return stream;
+    }
 
+    /**
+     * @brief Compares two interface ids.
+     *
+     * @param lhs Left side of the operator.
+     * @param rhs Right side of the operator.
+     * @return true
+     * @return false
+     */
+    inline bool operator==(
+        const intercom::IID& lhs,
+        const intercom::IID& rhs
+    ) noexcept
+    {
+        return memcmp( &lhs, &rhs, sizeof( intercom::IID ) ) == 0;
+    }
 }
 
 // Visual C++ does not declare the structs in their own namespace.

--- a/intercom-cpp/src/runtime_error.h
+++ b/intercom-cpp/src/runtime_error.h
@@ -1,0 +1,86 @@
+
+#ifndef INTERCOM_CPP_RUNTIMERROR_H
+#define INTERCOM_CPP_RUNTIMERROR_H
+
+#include <memory>
+#include <stdexcept>
+#include <sstream>
+
+#include "guiddef.h"
+#include "error_codes.h"
+
+namespace intercom
+{
+
+/**
+ * @brief A generic runtime error thrown by the intercom.
+ *
+ */
+class RuntimeError : public std::runtime_error
+{
+public:
+
+    /**
+     * @brief Initializes new RuntimeError.
+     *
+     */
+    RuntimeError(
+        intercom::HRESULT error_code,
+        const char* message
+    ) :
+        std::runtime_error( message ),
+        m_error_code( error_code )
+    {
+    }
+
+    /**
+     * @brief Initializes new RuntimeError.
+     *
+     */
+    RuntimeError(
+        intercom::HRESULT error_code,
+        const std::string& message
+    ) :
+        std::runtime_error( message ),
+        m_error_code( error_code )
+    {
+    }
+
+    /**
+     * @brief Initializes new RuntimeError.
+     *
+     */
+    RuntimeError(
+        intercom::HRESULT error_code,
+        std::ostream& stream
+    ) :
+        std::runtime_error( stream_to_string( stream ) ),
+        m_error_code( error_code )
+    {
+    }
+
+    /**
+     * @brief Returns the error associated with this exception.
+     *
+     * @return intercom::HRESULT Returns the error code.
+     */
+    intercom::HRESULT error_code() const noexcept { return m_error_code; }
+
+private:
+
+    static std::string stream_to_string(
+         std::ostream& stream
+    )
+    {
+        stream.flush();
+        std::ostringstream message;
+        message << stream.rdbuf();
+        return message.str();
+    }
+
+    intercom::HRESULT m_error_code;
+};
+
+}
+
+#endif

--- a/intercom/src/classfactory.rs
+++ b/intercom/src/classfactory.rs
@@ -139,9 +139,7 @@ impl< T: Fn( REFCLSID ) -> ComResult< RawComPtr > > ClassFactory<T> {
         ((**iunk_ptr).query_interface)(
             iunk_ptr as RawComPtr,
             riid,
-            out );
-
-        S_OK
+            out )
     }
 
     unsafe fn lock_server_agnostic(

--- a/intercom/src/classfactory.rs
+++ b/intercom/src/classfactory.rs
@@ -136,10 +136,16 @@ impl< T: Fn( REFCLSID ) -> ComResult< RawComPtr > > ClassFactory<T> {
             Err( hr ) => return hr,
         } as *const *const IUnknownVtbl;
 
-        ((**iunk_ptr).query_interface)(
+        let query_result = ((**iunk_ptr).query_interface)(
             iunk_ptr as RawComPtr,
             riid,
-            out )
+            out );
+
+        // Avoid leaking memory in case query_interface fails.
+        if query_result != S_OK {
+            drop( Box::from_raw( iunk_ptr as RawComPtr ) );
+        }
+        query_result
     }
 
     unsafe fn lock_server_agnostic(

--- a/test/cpp-raw/CMakeLists.txt
+++ b/test/cpp-raw/CMakeLists.txt
@@ -11,6 +11,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Define source files.
 set(PROJECT_SRCS
+${PROJECT_SOURCE_DIR}/exceptions.cpp
 ${PROJECT_SOURCE_DIR}/error_info.cpp
 ${PROJECT_SOURCE_DIR}/interface_params.cpp
 ${PROJECT_SOURCE_DIR}/iunknown.cpp
@@ -20,6 +21,7 @@ ${PROJECT_SOURCE_DIR}/result.cpp
 ${PROJECT_SOURCE_DIR}/return_interfaces.cpp
 ${PROJECT_SOURCE_DIR}/stateful.cpp
 ${PROJECT_SOURCE_DIR}/interface_wrappers.cpp
+${PROJECT_SOURCE_DIR}/utility/dummy_interface.cpp
 )
 
 # Specify additional compiler specific helpers.

--- a/test/cpp-raw/exceptions.cpp
+++ b/test/cpp-raw/exceptions.cpp
@@ -1,0 +1,83 @@
+
+#include <functional>
+
+#include "os.h"
+#include "catch.hpp"
+
+#include "testlib.h"
+#include "utility/dummy_interface.h"
+
+TEST_CASE( "Exceptions have correct error message." )
+{
+    SECTION( "NoSuchInterface with only interface id set has correct error message." )
+    {
+        try
+        {
+            throw intercom::NoSuchInterface( IID_IUnknown );
+            FAIL( "Exception not thrown." );
+        }
+        catch( intercom::NoSuchInterface& ex )
+        {
+            CHECK( std::string( "Interface \"{00000000-0000-0000-C000-000000000046}\" not available." )
+                    == ex.what() );
+        }
+    }
+
+    SECTION( "NoSuchInterface with both interface id and class id set has correct error message." )
+    {
+        try
+        {
+            throw intercom::NoSuchInterface(
+                    cppraw::utility::DummyInterfaceDescriptor::ID,
+                    cppraw::utility::IDummyInterface::ID );
+            FAIL( "Exception not thrown." );
+        }
+        catch( intercom::NoSuchInterface& ex )
+        {
+            CHECK( std::string( "Interface \"{12345678-0000-0000-1234-567800000000}\" not "\
+                    "available for the class \"{12345678-1234-1234-1234-567800000000}\"." ) == ex.what() );
+        }
+    }
+
+    SECTION( "RuntimeError preserves error message." )
+    {
+        try
+        {
+            throw intercom::RuntimeError( intercom::E_FAIL, "This message is preserved." );
+            FAIL( "Exception not thrown." );
+        }
+        catch( intercom::RuntimeError& ex )
+        {
+            CHECK( std::string( "This message is preserved." ) == ex.what() );
+        }
+    }
+}
+
+TEST_CASE( "Exception specific data is passed correctly." )
+{
+    SECTION( "NoSuchInterface preserves interface id." )
+    {
+        try
+        {
+            throw intercom::NoSuchInterface( IID_IUnknown );
+            FAIL( "Exception not thrown." );
+        }
+        catch( intercom::NoSuchInterface& ex )
+        {
+            CHECK( IID_IUnknown == ex.interface_id() );
+        }
+    }
+
+    SECTION( "RuntimeError preserved its error code." )
+    {
+        try
+        {
+            throw intercom::RuntimeError( intercom::E_INVALIDARG, "This message is preserved." );
+            FAIL( "Exception not thrown." );
+        }
+        catch( intercom::RuntimeError& ex )
+        {
+            CHECK( E_INVALIDARG == ex.error_code() );
+        }
+    }
+}

--- a/test/cpp-raw/interface_wrappers.cpp
+++ b/test/cpp-raw/interface_wrappers.cpp
@@ -5,6 +5,7 @@
 #include "catch.hpp"
 
 #include "testlib.h"
+#include "utility/dummy_interface.h"
 
  #ifdef __GNUC__
 
@@ -85,6 +86,11 @@ TEST_CASE( "Using interface wrappers works" )
         REQUIRE( expectedRefCount == refCountOps.get() );
         REQUIRE( anotherCounter->GetRefCount() == 1 );
         REQUIRE( refCountOps->GetRefCount() == 1 );
+    }
+
+    SECTION( "Creating an object with non-existant interface throws correct exception." )
+    {
+        REQUIRE_THROWS_AS( refCountFactory.create< cppraw::utility::IDummyInterface >(), intercom::NoSuchInterface );
     }
 
 	UninitializeRuntime();

--- a/test/cpp-raw/interface_wrappers.cpp
+++ b/test/cpp-raw/interface_wrappers.cpp
@@ -93,6 +93,20 @@ TEST_CASE( "Using interface wrappers works" )
         REQUIRE_THROWS_AS( refCountFactory.create< cppraw::utility::IDummyInterface >(), intercom::NoSuchInterface );
     }
 
+    SECTION( "Requesting unimplemented interface in creation fails appropriately." )
+    {
+        try
+        {
+            intercom::RawInterface<ISharedInterface> wrongInterface =
+                    std::move( refCountFactory.create< test_lib::raw::ISharedInterface >() );
+            FAIL( "Requesting invalid interface succeeded." );
+        }
+        catch( intercom::NoSuchInterface& ex )
+        {
+            REQUIRE( ex.error_code() == intercom::E_NOINTERFACE );
+        }
+    }
+
 	UninitializeRuntime();
 }
 

--- a/test/cpp-raw/utility/dummy_interface.cpp
+++ b/test/cpp-raw/utility/dummy_interface.cpp
@@ -1,0 +1,18 @@
+
+#include "dummy_interface.h"
+
+#ifdef _MSC_VER
+    const char cppraw::utility::DummyLibDescriptor::NAME[] = "dummy_lib.dll";
+#else
+    const char cppraw::utility::DummyLibDescriptor::NAME[] = "libdummy_lib.so";
+#endif
+
+const char cppraw::utility::DummyLibDescriptor::WINDOWS_NAME[] = "dummy_lib.dll";
+const char cppraw::utility::DummyLibDescriptor::POSIX_NAME[] = "libdummy_lib.so";
+
+const intercom::IID cppraw::utility::IDummyInterface::ID = {0x12345678,0x0,0x0,{0x12,0x34,0x56,0x78,0x00,0x00,0x00,0x00}};
+
+const intercom::CLSID cppraw::utility::DummyInterfaceDescriptor::ID = {0x12345678,0x1234,0x1234,{0x12,0x34,0x56,0x78,0x00,0x00,0x00,0x00}};
+const std::array<intercom::IID, 1> cppraw::utility::DummyInterfaceDescriptor::INTERFACES = {
+            cppraw::utility::IDummyInterface::ID
+};

--- a/test/cpp-raw/utility/dummy_interface.h
+++ b/test/cpp-raw/utility/dummy_interface.h
@@ -1,0 +1,45 @@
+
+#ifndef CPPRAW_DUMMYINTERFACE_H
+#define CPPRAW_DUMMYINTERFACE_H
+
+#include <intercom.h>
+
+namespace cppraw
+{
+namespace utility
+{
+
+class DummyLibDescriptor
+{
+public:
+    static const char NAME[];
+    static const char WINDOWS_NAME[];
+    static const char POSIX_NAME[];
+};
+
+/**
+ * @brief An interface which does not exist in the library.
+ *
+ */
+struct IDummyInterface : IUnknown
+{
+    static const intercom::IID ID;
+};
+
+class DummyInterfaceDescriptor
+{
+public:
+    static const intercom::CLSID ID;
+
+    static const std::array<intercom::IID, 1> INTERFACES;
+
+    using Library = DummyLibDescriptor;
+
+    DummyInterfaceDescriptor() = delete;
+    ~DummyInterfaceDescriptor() = delete;
+};
+
+}
+}
+
+#endif


### PR DESCRIPTION
I decided not to introduce additional hierarchy and inherited the exceptions directly from appropriate std exceptions instead.

This resolves issue #45.