### PR TITLE
Implemented thread-safe reference counting

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ reasons and could be worked around if we needed to get to stable quickly:
 - `try_from`, tracking issue: [#33417](https://github.com/rust-lang/rust/issues/33417)
 - `try_trait`, tracking issue: [#42327](https://github.com/rust-lang/rust/issues/42327)
 - `catch_expr`, tracking issue: [#31436](https://github.com/rust-lang/rust/issues/31436)
+- `integer_atomics`, tracking issue: [#32976](https://github.com/rust-lang/rust/issues/32976)
 
 
 ## Technical details

--- a/intercom/src/lib.rs
+++ b/intercom/src/lib.rs
@@ -45,10 +45,10 @@
 //!     var calculator = new CalculatorLib.Calculator();
 //!     Console.WriteLine( calculator.Add( 1, 2 ) );
 //! }
-//! ``` 
+//! ```
 
 #![crate_type="dylib"]
-#![feature(proc_macro, try_from, fundamental, specialization, non_exhaustive)]
+#![feature(proc_macro, try_from, fundamental, specialization, non_exhaustive, integer_atomics)]
 
 #[cfg(feature = "generators")]
 extern crate intercom_common;


### PR DESCRIPTION
We could implement the reference counter
with AtomicISize if we need to get to the stable quickly.