### PR TITLE
Return structured information from parsing a crate

### DIFF
--- a/intercom-common/src/foreign_ty.rs
+++ b/intercom-common/src/foreign_ty.rs
@@ -1,5 +1,44 @@
+extern crate std;
+
 use model::ComCrate;
 use syn;
+
+/// Detailed information of a Rust type.
+pub enum RustType<'e>
+{
+    Ident( &'e syn::Ident ),
+    Void,
+}
+
+/// Defines how a value is passed to/from Rust function.
+#[derive(PartialEq, PartialOrd, Clone)]
+pub enum PassBy
+{
+    Value,
+
+    Reference,
+
+    Ptr,
+}
+
+/// Details of a Rust type. Used for translation to other programming languages.
+pub struct TypeInfo<'s>
+{
+    /// The crate this type is associated with.
+    pub krate: &'s ComCrate,
+
+    /// The type in rust.
+    pub rust_type: RustType<'s>,
+
+    /// Specifies how the value is passed to/from a function. Default: PassBy::Value
+    pub pass_by: PassBy,
+
+    /// Is the Rust type defined as mutable? Default: false
+    pub is_mutable: bool,
+
+    /// The length of the array if the Rust type denotes an array.
+    pub array_length: Option<&'s syn::Expr>
+}
 
 pub trait ForeignTypeHandler
 {
@@ -7,53 +46,129 @@ pub trait ForeignTypeHandler
     fn get_name( &self, krate : &ComCrate, ty : &syn::Ident ) -> String;
 
     /// Gets the COM type for a Rust type.
-    fn get_ty( &self, krate : &ComCrate, ty : &syn::Type ) -> Option< String >;
+    fn get_ty<'a, 'b: 'a>( &self, krate : &'b ComCrate, ty : &'b syn::Type ) -> Option< TypeInfo<'a> >;
 }
 
 pub struct CTypeHandler;
+
+/// Collects details of a Rust type when the Rust crate is parsed.
+struct TypeInfoResolver<'s>
+{
+    /// The crate this type is associated with.
+    krate: &'s ComCrate,
+
+    /// The type in rust.
+    rust_type: RustType<'s>,
+
+    /// Specifies how the value is passed. Default: PassBy::Value
+    pass_by: Option<PassBy>,
+
+    /// Is the Rust type defined as mutable? Default: false
+    is_mutable: Option<bool>,
+
+    /// The length of the array if the Rust type denotes an array.
+    array_length: Option<&'s syn::Expr>
+}
+
 
 impl ForeignTypeHandler for CTypeHandler
 {
     /// Tries to apply renaming to the name.
     fn get_name(
         &self,
-        krate : &ComCrate,
-        ident : &syn::Ident,
+        krate: &ComCrate,
+        ident: &syn::Ident,
     ) -> String
     {
         self.get_name_for_ty( krate, ident.as_ref() )
     }
 
-    fn get_ty(
+    fn get_ty<'a, 'b: 'a>(
         &self,
-        krate : &ComCrate,
-        ty : &syn::Type,
-    ) -> Option< String >
+        krate: &'b ComCrate,
+        ty: &'b syn::Type,
+    ) -> Option<TypeInfo<'a>>
     {
-        Some( match *ty {
+        match TypeInfoResolver::from_type( krate, ty )
+        {
+            Some( resolver ) => Some( TypeInfo::from_resolver( resolver ) ),
+            None => None,
+        }
+    }
+}
 
-            // Pointer types.
-            syn::Type::Slice( ref slice )
-                => format!( "{}*", self.get_ty( krate, &slice.elem )? ),
-            syn::Type::Reference( syn::TypeReference { ref mutability, ref elem, .. } )
-                | syn::Type::Ptr( syn::TypePtr { ref mutability, ref elem, .. } )
-                => match *mutability {
-                    Some(_) => format!( "{}*", self.get_ty( krate, elem )? ),
-                    None => format!( "const {}*", self.get_ty( krate, elem )? ),
-                },
+impl<'s, 'p: 's> TypeInfo<'s> {
 
-            // This is quite experimental. Do IDLs even support staticly sized
-            // arrays? Currently this turns [u8; 3] into "uint8[3]" IDL type.
-            syn::Type::Array( ref arr )
-                => format!( "{}[{:?}]", self.get_ty( krate, &arr.elem )?, arr.len ),
+    /// Gets the name of the type in Rust.
+    pub fn get_name(
+        &self
+    ) -> String
+    {
+        format!( "{}", self.rust_type )
+    }
 
-            // Normal Rust struct/trait type.
-            syn::Type::Path( ref p )
-                => self.segment_to_ty( krate, p.path.segments.last().unwrap().value() )?,
+    /// Initializes the type info from resolver which has resolved the type.
+    fn from_resolver(
+        resolver: TypeInfoResolver<'p>
+    ) -> TypeInfo<'s>
+    {
+        // Resolve default values.
+        // NOTE: The existence of the array length value identifies an array type and
+        // is therefor passed as-is here.
+        let pass_by;
+        let is_mutable;
+        {
+            pass_by = match resolver.pass_by {
+                Some( ref v ) => v,
+                None => &PassBy::Value,
+            };
 
-            // Tuple with length 0, ie. Unit tuple: (). This is void-equivalent.
-            syn::Type::Tuple( ref t ) if t.elems.is_empty()
-                => "void".to_owned(),
+            is_mutable = match resolver.is_mutable {
+                Some( ref v ) => v.clone(),
+                None => false,
+            };
+        };
+
+        TypeInfo{
+            krate: resolver.krate,
+            rust_type: resolver.rust_type,
+            pass_by: pass_by.clone(),
+            is_mutable: is_mutable,
+            array_length: resolver.array_length,
+        }
+    }
+}
+
+impl<'s> std::fmt::Display for RustType<'s> {
+
+    fn fmt(
+        &self,
+        f: &mut std::fmt::Formatter
+    ) -> std::fmt::Result {
+        match self {
+            &RustType::Ident( syn_ident ) => write!( f, "{}", syn_ident ),
+            &RustType::Void => write!( f, "void" ),
+        }
+    }
+}
+
+impl<'s, 'p: 's> TypeInfoResolver<'s> {
+
+    /// Parses the type info from the specified Type.
+    fn from_type(
+        krate: &'p ComCrate,
+        syn_type: &'p syn::Type,
+    ) -> Option<TypeInfoResolver<'s>>
+    {
+        match *syn_type {
+
+            // Delegate to appropriate conversion.
+            syn::Type::Slice( ref slice ) => TypeInfoResolver::from_slice( krate, slice ),
+            syn::Type::Reference( ref reference ) => TypeInfoResolver::from_reference( krate, reference ),
+            syn::Type::Ptr( ref ptr ) => TypeInfoResolver::from_pointer( krate, ptr ),
+            syn::Type::Array( ref arr ) => TypeInfoResolver::from_array( krate, arr ),
+            syn::Type::Path( ref p ) => TypeInfoResolver::from_path( krate, p ),
+            syn::Type::Tuple( ref t ) if t.elems.is_empty() => Some( TypeInfoResolver::void( krate ) ),
 
             syn::Type::BareFn(..)
                 | syn::Type::Never(..)
@@ -65,24 +180,183 @@ impl ForeignTypeHandler for CTypeHandler
                 | syn::Type::Macro(..)
                 | syn::Type::Verbatim(..)
                 | syn::Type::Group(..)
-                => return None,
-        } )
+                => None,
+        }
     }
-}
 
-impl CTypeHandler
-{
-    /// Converts a path segment to a Type.
-    ///
-    /// The path segment should be the last segment for this to make any sense.
-    fn segment_to_ty(
-        &self,
-        krate : &ComCrate,
-        segment : &syn::PathSegment,
-    ) -> Option<String>
+    fn new(
+        krate: &'p ComCrate,
+        rust_type: RustType<'s>
+    ) -> TypeInfoResolver<'s>
+    {
+        TypeInfoResolver {
+            krate: krate,
+            rust_type: rust_type,
+            pass_by: None,
+            is_mutable: None,
+            array_length: None,
+        }
+    }
+
+    fn void(
+        krate: &'p ComCrate,
+    ) -> TypeInfoResolver<'s>
+    {
+        TypeInfoResolver::new( krate, RustType::Void )
+    }
+
+    fn pass_by_option(
+        resolver: Option<TypeInfoResolver<'s>>,
+        pass_by: PassBy,
+    ) -> Option<TypeInfoResolver<'s>>
+    {
+        match resolver {
+            Some( r ) => Some( TypeInfoResolver::pass_by( r, pass_by ) ),
+            None => None,
+        }
+    }
+
+    fn pass_by(
+        resolver: TypeInfoResolver<'s>,
+        pass_by: PassBy,
+    ) -> TypeInfoResolver<'s>
+    {
+        match resolver.pass_by {
+            Some( _ ) => panic!("Cannot set pass_by twice."),
+            None => {},
+        }
+
+        TypeInfoResolver {
+            krate: resolver.krate,
+            rust_type: resolver.rust_type,
+            pass_by: Some( pass_by ),
+            is_mutable: resolver.is_mutable,
+            array_length: resolver.array_length,
+        }
+    }
+
+    fn mutable_option(
+        resolver: Option<TypeInfoResolver<'s>>,
+        is_mutable: bool,
+    ) -> Option<TypeInfoResolver<'s>>
+    {
+        match resolver {
+            Some( r ) => Some( TypeInfoResolver::mutable( r, is_mutable ) ),
+            None => None,
+        }
+    }
+
+    fn mutable(
+        resolver: TypeInfoResolver<'s>,
+        is_mutable: bool,
+    ) -> TypeInfoResolver<'s>
+    {
+        match resolver.is_mutable {
+            Some(_) => panic!("Cannot set is_mutable twice."),
+            None => {}
+        }
+
+        TypeInfoResolver {
+            krate: resolver.krate,
+            rust_type: resolver.rust_type,
+            pass_by: resolver.pass_by,
+            is_mutable: Some( is_mutable ),
+            array_length: resolver.array_length,
+        }
+    }
+
+    fn array_option(
+        resolver: Option<TypeInfoResolver<'s>>,
+        array_length: &'p syn::Expr,
+    ) -> Option<TypeInfoResolver<'s>>
+    {
+        match resolver {
+            Some( r ) => Some( TypeInfoResolver::array( r, array_length ) ),
+            None => None,
+        }
+    }
+
+    fn array(
+        resolver: TypeInfoResolver<'s>,
+        array_length: &'p syn::Expr,
+    ) -> TypeInfoResolver<'s>
+    {
+        match resolver.array_length {
+            Some(_) => panic!("Cannot set array_length twice."),
+            None => {}
+        }
+
+        TypeInfoResolver {
+            krate: resolver.krate,
+            rust_type: resolver.rust_type,
+            pass_by: resolver.pass_by,
+            is_mutable: resolver.is_mutable,
+            array_length: Some( array_length ),
+        }
+    }
+
+    fn from_array(
+        krate : &'p ComCrate,
+        array: &'p syn::TypeArray,
+    ) -> Option<TypeInfoResolver<'s>>
+    {
+        TypeInfoResolver::array_option(
+            TypeInfoResolver::from_type( krate, &array.elem ),
+            &array.len,
+        )
+    }
+
+    fn from_slice(
+        krate : &'p ComCrate,
+        slice: &'p syn::TypeSlice,
+    ) -> Option<TypeInfoResolver<'s>>
+    {
+        TypeInfoResolver::from_type( krate, &slice.elem )
+    }
+
+    fn from_reference(
+        krate : &'p ComCrate,
+        reference : &'p syn::TypeReference,
+    ) -> Option<TypeInfoResolver<'s>>
+    {
+        TypeInfoResolver::pass_by_option(
+                TypeInfoResolver::mutable_option(
+                            TypeInfoResolver::from_type( krate, &reference.elem ),
+                            TypeInfoResolver::is_mutable( &reference.mutability )
+                        ),
+                PassBy::Reference,
+        )
+    }
+
+    fn from_pointer(
+        krate : &'p ComCrate,
+        ptr : &'p syn::TypePtr,
+    ) -> Option<TypeInfoResolver<'s>>
+    {
+        TypeInfoResolver::pass_by_option(
+            TypeInfoResolver::mutable_option(
+                TypeInfoResolver::from_type( krate, &ptr.elem ),
+                TypeInfoResolver::is_mutable( &ptr.mutability ),
+            ),
+            PassBy::Ptr,
+        )
+    }
+
+    fn from_path(
+        krate: &'p ComCrate,
+        type_path: &'p syn::TypePath,
+    ) -> Option<TypeInfoResolver<'s>>
+    {
+        TypeInfoResolver::from_segment( krate, type_path.path.segments.last().unwrap().value() )
+    }
+
+    fn from_segment(
+        krate: &'p ComCrate,
+        segment: &'p syn::PathSegment,
+    ) -> Option<TypeInfoResolver<'s>>
     {
         // Get the segment as a string.
-        let ty = format!( "{}", segment.ident );
+        let rust_type = format!( "{}", segment.ident );
 
         // Get the type information.
         let args = match segment.arguments {
@@ -98,38 +372,37 @@ impl CTypeHandler
                     => panic!( "Fn-types are unsupported." ),
         };
 
-        Some( match ty.as_str() {
-            
-            // Hardcoded handling for parameter types.
-            "ComRc" | "ComItf"
-                => format!( "{}*", self.get_ty(
+        match rust_type.as_str() {
+
+            // Extract a wrapped type.
+            "ComRc" | "ComItf" | "ComResult"
+                => TypeInfoResolver::pass_by_option( TypeInfoResolver::from_type(
                         krate,
                         match **args.unwrap().first().unwrap().value() {
                             syn::GenericArgument::Type( ref t ) => t,
                             _ => return None,
-                        } )? ),
-            "RawComPtr" => "*void".to_owned(),
-            "String" | "BStr" => "BSTR".to_owned(),
-            "usize" => "size_t".to_owned(),
-            "u64" => "uint64".to_owned(),
-            "i64" => "int64".to_owned(),
-            "u32" => "uint32".to_owned(),
-            "i32" => "int32".to_owned(),
-            "u16" => "uint16".to_owned(),
-            "i16" => "int16".to_owned(),
-            "u8" => "uint8".to_owned(),
-            "i8" => "int8".to_owned(),
-            "f64" => "double".to_owned(),
-            "f32" => "float".to_owned(),
-            "c_void" => "void".to_owned(),
+                        } ), PassBy::Ptr ),
 
-            // Default handling checks if we need to rename the type, such as
-            // Foo -> IFoo for implicit interfaces.
-            t => self.get_name_for_ty( krate, t ),
-        } )
+            // Bare type.
+            _t => Some( TypeInfoResolver::new( krate, RustType::Ident( &segment.ident ) ) ),
+        }
     }
 
-    fn get_name_for_ty(
+    /// Determines if the given type is mutable
+    fn is_mutable(
+        mutability: &Option<syn::token::Mut>
+    ) -> bool
+    {
+        match mutability {
+            &Some( _ ) => true,
+            &None => false,
+        }
+    }
+}
+
+impl CTypeHandler
+{
+     fn get_name_for_ty(
         &self,
         krate : &ComCrate,
         ty_name : &str
@@ -148,29 +421,3 @@ impl CTypeHandler
         }
     }
 }
-
-/// Converts a Rust type into applicable C++ type.
-pub fn to_cpp_type(
-    c: &ComCrate,
-    ty: &syn::Type,
-) -> Option<String> { //, GeneratorError> {
-
-    let foreign = CTypeHandler;
-    let name = foreign.get_ty( c, ty )?;
-            
-    Some( match name.as_ref() {
-        "int8" => "int8_t",
-        "uint8" => "uint8_t",
-        "int16" => "int16_t",
-        "uint16" => "uint16_t",
-        "uint16*" => "uint16_t*",
-        "int32" => "int32_t",
-        "uint32" => "uint32_t",
-        "int64" => "int64_t",
-        "uint64" => "uint64_t",
-        "BSTR" => "intercom::BSTR",
-        "HRESULT" => "intercom::HRESULT",
-        _ => return Some( name ),
-    }.to_owned() )
-}
-

--- a/intercom-common/src/generators/cpp.rs
+++ b/intercom-common/src/generators/cpp.rs
@@ -96,8 +96,12 @@ impl<'s> CppTypeInfo<'s> for TypeInfo<'s> {
         &self
     ) -> String {
 
+        // TODO: Enable once verified that the "const" works.
+        // We want to enable if for interface methods and parameters.
+        // let const_specifier = if self.is_mutable || self.pass_by != PassBy::Reference { "" } else { "const " };
+        let const_specifier = "";
+
         let type_name = self.get_cpp_type_name();
-        let const_specifier = if self.is_mutable || self.pass_by != PassBy::Reference { "" } else { "" };
         let ptr = match self.pass_by {
             PassBy::Value => "",
             PassBy::Reference | PassBy::Ptr => "*",

--- a/intercom-common/src/generators/cpp.rs
+++ b/intercom-common/src/generators/cpp.rs
@@ -13,6 +13,7 @@ use foreign_ty::*;
 use guid::*;
 use methodinfo;
 use model;
+use model::ComCrate;
 use utils;
 
 use handlebars::Handlebars;
@@ -53,6 +54,83 @@ pub struct CppCoClass {
     pub interfaces : Vec<String>,
 }
 
+/// Types that can have C++ representaion can implement this to allow code generation.
+trait CppTypeInfo<'s> {
+
+    /// Gets full type for C++.
+    fn to_cpp(
+        &self
+    ) -> String;
+
+    /// Gets the C++ compatile type name for this type.
+    fn get_cpp_type_name(
+        &self
+    ) -> String;
+}
+
+impl<'s> CppTypeInfo<'s> {
+
+    /// Gets the name of a custom type for C++.
+    fn get_cpp_name_for_custom_type(
+        krate : &ComCrate,
+        ty_name : &str
+    ) -> String {
+
+        let itf = if let Some( itf ) = krate.interfaces().get( ty_name ) {
+            itf
+        } else {
+            return ty_name.to_owned()
+        };
+
+        if itf.item_type() == ::utils::InterfaceType::Struct {
+            format!( "I{}", itf.name() )
+        } else {
+            ty_name.to_owned()
+        }
+    }
+}
+
+impl<'s> CppTypeInfo<'s> for TypeInfo<'s> {
+
+    fn to_cpp(
+        &self
+    ) -> String {
+
+        let type_name = self.get_cpp_type_name();
+        let const_specifier = if self.is_mutable || self.pass_by != PassBy::Reference { "" } else { "" };
+        let ptr = match self.pass_by {
+            PassBy::Value => "",
+            PassBy::Reference | PassBy::Ptr => "*",
+        };
+        format!("{}{}{}", const_specifier, type_name, ptr )
+    }
+
+    fn get_cpp_type_name(
+        &self
+    ) -> String {
+
+        let type_name = self.get_name();
+        match type_name.as_str() {
+            "RawComPtr" => "*void".to_owned(),
+            "BSTR" | "String" | "BStr" => "intercom::BSTR".to_owned(),
+            "usize" => "size_t".to_owned(),
+            "i8" => "int8_t".to_owned(),
+            "u8" => "uint8_t".to_owned(),
+            "i16" => "int16_t".to_owned(),
+            "u16" => "uint16_t".to_owned(),
+            "i32" => "int32_t".to_owned(),
+            "u32" => "uint32_t".to_owned(),
+            "i64" => "int64_t".to_owned(),
+            "u64" => "uint64_t".to_owned(),
+            "HRESULT" => "intercom::HRESULT".to_owned(),
+            "f64" => "double".to_owned(),
+            "f32" => "float".to_owned(),
+            "c_void" => "void".to_owned(),
+            t => CppTypeInfo::get_cpp_name_for_custom_type( self.krate, t ),
+        }
+    }
+}
+
 impl CppModel {
 
     /// Generates the model from files in the path.
@@ -89,29 +167,29 @@ impl CppModel {
                     let out_ptr = match a.dir {
                         methodinfo::Direction::In
                             => "",
-                        methodinfo::Direction::Out 
+                        methodinfo::Direction::Out
                             | methodinfo::Direction::Retval
                             => "*",
                     };
 
                     // Get the foreign type for the arg type in C++ format.
-                    let ty_name = to_cpp_type( c, &a.arg.ty )
+                    let type_info = foreign.get_ty( c, &a.arg.ty )
                             .ok_or_else( || GeneratorError::UnsupportedType(
                                             utils::ty_to_string( &a.arg.ty ) ) )?;
                     Ok( CppArg {
                         name : a.arg.name.to_string(),
-                        arg_type : format!( "{}{}", ty_name, out_ptr ),
+                        arg_type : format!( "{}{}", type_info.to_cpp(), out_ptr ),
                     } )
 
                 } ).collect::<Result<Vec<_>, GeneratorError>>()?;
 
                 let ret_ty = m.returnhandler.com_ty();
-                let ret_ty_name = to_cpp_type( c, &ret_ty )
+                let ret_ty = foreign.get_ty( c, &ret_ty )
                         .ok_or_else( || GeneratorError::UnsupportedType(
                                         utils::ty_to_string( &ret_ty ) ) )?;
                 Ok( CppMethod {
                     name: utils::pascal_case( m.name.as_ref() ),
-                    ret_type: ret_ty_name,
+                    ret_type: ret_ty.to_cpp(),
                     args: args
                 } )
 
@@ -257,11 +335,11 @@ mod test {
                             name : "Method".to_owned(),
                             ret_type : "intercom::HRESULT".to_owned(),
                             args : vec![
-                                CppArg { 
+                                CppArg {
                                     name : "a".to_owned(),
                                     arg_type : "uint32_t".to_owned(),
                                 },
-                                CppArg { 
+                                CppArg {
                                     name : "__out".to_owned(),
                                     arg_type : "bool*".to_owned(),
                                 },
@@ -278,7 +356,7 @@ mod test {
                             name : "ComMethod".to_owned(),
                             ret_type : "void".to_owned(),
                             args : vec![
-                                CppArg { 
+                                CppArg {
                                     name : "b".to_owned(),
                                     arg_type : "uint32_t".to_owned(),
                                 },
@@ -295,11 +373,11 @@ mod test {
                             name : "AllocBstr".to_owned(),
                             ret_type : "intercom::BSTR".to_owned(),
                             args : vec![
-                                CppArg { 
+                                CppArg {
                                     name : "text".to_owned(),
                                     arg_type : "intercom::BSTR".to_owned(),
                                 },
-                                CppArg { 
+                                CppArg {
                                     name : "len".to_owned(),
                                     arg_type : "uint32_t".to_owned(),
                                 },
@@ -309,7 +387,7 @@ mod test {
                             name : "FreeBstr".to_owned(),
                             ret_type : "void".to_owned(),
                             args : vec![
-                                CppArg { 
+                                CppArg {
                                     name : "bstr".to_owned(),
                                     arg_type : "intercom::BSTR".to_owned(),
                                 },
@@ -319,7 +397,7 @@ mod test {
                             name : "Alloc".to_owned(),
                             ret_type : "void*".to_owned(),
                             args : vec![
-                                CppArg { 
+                                CppArg {
                                     name : "len".to_owned(),
                                     arg_type : "size_t".to_owned(),
                                 },
@@ -329,7 +407,7 @@ mod test {
                             name : "Free".to_owned(),
                             ret_type : "void".to_owned(),
                             args : vec![
-                                CppArg { 
+                                CppArg {
                                     name : "ptr".to_owned(),
                                     arg_type : "void*".to_owned(),
                                 },
@@ -380,12 +458,12 @@ mod test {
             }
         "# ] ).expect( "Could not parse test crate" );
 
-        let expected_method = 
+        let expected_method =
             CppMethod {
                 name : "BstrMethod".to_owned(),
                 ret_type : "intercom::BSTR".to_owned(),
                 args : vec![
-                    CppArg { 
+                    CppArg {
                         name : "b".to_owned(),
                         arg_type : "intercom::BSTR".to_owned(),
                     },

--- a/intercom-common/src/generators/idl.rs
+++ b/intercom-common/src/generators/idl.rs
@@ -8,6 +8,7 @@ use super::GeneratorError;
 
 use utils;
 use model;
+use model::ComCrate;
 use methodinfo;
 use foreign_ty::*;
 
@@ -51,6 +52,20 @@ pub struct IdlCoClass {
     pub interfaces : Vec<String>,
 }
 
+/// Types that can have IDL representaion can implement this to allow code generation.
+trait IdlTypeInfo<'s> {
+
+    /// Gets full type for IDL.
+    fn to_idl(
+        &self
+    ) -> String;
+
+    /// Gets the IDL compatile type name for this type.
+    fn get_idl_type_name(
+        &self
+    ) -> String;
+}
+
 impl IdlModel {
 
     /// Generates the model from files in the path.
@@ -90,28 +105,28 @@ impl IdlModel {
                     };
 
                     // Get the foreign type for the arg type.
-                    let ty_name = foreign
+                    let idl_type = foreign
                         .get_ty( c, &a.arg.ty )
                         .ok_or_else( || GeneratorError::UnsupportedType(
                                         utils::ty_to_string( &a.arg.ty ) ) )?;
 
                     Ok( IdlArg {
                         name : a.arg.name.to_string(),
-                        arg_type : format!( "{}{}", ty_name, out_ptr ),
+                        arg_type : format!( "{}{}", idl_type.to_idl(), out_ptr ),
                         attributes : attrs.to_owned(),
                     } )
 
                 } ).collect::<Result<Vec<_>, GeneratorError>>()?;
 
                 let ret_ty = m.returnhandler.com_ty();
-                let ret_ty_name = foreign
+                let ret_ty = foreign
                         .get_ty( c, &ret_ty )
                         .ok_or_else( || GeneratorError::UnsupportedType(
                                         utils::ty_to_string( &ret_ty ) ) )?;
                 Ok( IdlMethod {
                     name: utils::pascal_case( m.name.as_ref() ),
                     idx: i,
-                    ret_type: ret_ty_name,
+                    ret_type: ret_ty.to_idl(),
                     args: args
                 } )
 
@@ -183,6 +198,69 @@ impl IdlModel {
     }
 }
 
+impl<'s> IdlTypeInfo<'s> {
+
+    /// Gets the name of a custom type for IDL.
+    fn get_idl_name_for_custom_type(
+        krate : &ComCrate,
+        ty_name : &str
+    ) -> String {
+
+        let itf = if let Some( itf ) = krate.interfaces().get( ty_name ) {
+            itf
+        } else {
+            return ty_name.to_owned()
+        };
+
+        if itf.item_type() == ::utils::InterfaceType::Struct {
+            format!( "I{}", itf.name() )
+        } else {
+            ty_name.to_owned()
+        }
+    }
+}
+
+impl<'s> IdlTypeInfo<'s> for TypeInfo<'s> {
+
+    fn to_idl(
+        &self
+    ) -> String {
+
+        let type_name = self.get_idl_type_name();
+        let const_specifier = if self.is_mutable || self.pass_by == PassBy::Value { "" } else { "" };
+        let ptr = match self.pass_by {
+            PassBy::Value => "",
+            PassBy::Reference | PassBy::Ptr => "*",
+        };
+        format!("{}{}{}", const_specifier, type_name, ptr )
+    }
+
+    /// Gets the name of the IDL type for this type.
+    fn get_idl_type_name(
+        &self
+    ) -> String {
+
+        let type_name = self.get_name();
+        match type_name.as_str() {
+            "RawComPtr" => "*void".to_owned(),
+            "String" | "BStr" => "BSTR".to_owned(),
+            "usize" => "size_t".to_owned(),
+            "u64" => "uint64".to_owned(),
+            "i64" => "int64".to_owned(),
+            "u32" => "uint32".to_owned(),
+            "i32" => "int32".to_owned(),
+            "u16" => "uint16".to_owned(),
+            "i16" => "int16".to_owned(),
+            "u8" => "uint8".to_owned(),
+            "i8" => "int8".to_owned(),
+            "f64" => "double".to_owned(),
+            "f32" => "float".to_owned(),
+            "c_void" => "void".to_owned(),
+            t => IdlTypeInfo::get_idl_name_for_custom_type( self.krate, t ),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -229,12 +307,12 @@ mod test {
                             idx : 0,
                             ret_type : "HRESULT".to_owned(),
                             args : vec![
-                                IdlArg { 
+                                IdlArg {
                                     name : "a".to_owned(),
                                     arg_type : "uint32".to_owned(),
                                     attributes : "in".to_owned(),
                                 },
-                                IdlArg { 
+                                IdlArg {
                                     name : "__out".to_owned(),
                                     arg_type : "bool*".to_owned(),
                                     attributes : "out, retval".to_owned(),
@@ -253,7 +331,7 @@ mod test {
                             idx : 0,
                             ret_type : "void".to_owned(),
                             args : vec![
-                                IdlArg { 
+                                IdlArg {
                                     name : "b".to_owned(),
                                     arg_type : "uint32".to_owned(),
                                     attributes : "in".to_owned(),
@@ -272,12 +350,12 @@ mod test {
                             idx : 0,
                             ret_type : "BSTR".to_owned(),
                             args : vec![
-                                IdlArg { 
+                                IdlArg {
                                     name : "text".to_owned(),
                                     arg_type : "BSTR".to_owned(),
                                     attributes : "in".to_owned(),
                                 },
-                                IdlArg { 
+                                IdlArg {
                                     name : "len".to_owned(),
                                     arg_type : "uint32".to_owned(),
                                     attributes : "in".to_owned(),
@@ -289,7 +367,7 @@ mod test {
                             idx : 1,
                             ret_type : "void".to_owned(),
                             args : vec![
-                                IdlArg { 
+                                IdlArg {
                                     name : "bstr".to_owned(),
                                     arg_type : "BSTR".to_owned(),
                                     attributes : "in".to_owned(),
@@ -301,7 +379,7 @@ mod test {
                             idx : 2,
                             ret_type : "void*".to_owned(),
                             args : vec![
-                                IdlArg { 
+                                IdlArg {
                                     name : "len".to_owned(),
                                     arg_type : "size_t".to_owned(),
                                     attributes : "in".to_owned(),
@@ -313,7 +391,7 @@ mod test {
                             idx : 3,
                             ret_type : "void".to_owned(),
                             args : vec![
-                                IdlArg { 
+                                IdlArg {
                                     name : "ptr".to_owned(),
                                     arg_type : "void*".to_owned(),
                                     attributes : "in".to_owned(),

--- a/intercom-common/src/generators/idl.rs
+++ b/intercom-common/src/generators/idl.rs
@@ -226,8 +226,12 @@ impl<'s> IdlTypeInfo<'s> for TypeInfo<'s> {
         &self
     ) -> String {
 
+        // TODO: Enable once verified that the "const" works.
+        // We want to enable if for interface methods and parameters.
+        // let const_specifier = if self.is_mutable || self.pass_by != PassBy::Reference { "" } else { "const " };
+        let const_specifier = "";
+
         let type_name = self.get_idl_type_name();
-        let const_specifier = if self.is_mutable || self.pass_by == PassBy::Value { "" } else { "" };
         let ptr = match self.pass_by {
             PassBy::Value => "",
             PassBy::Reference | PassBy::Ptr => "*",


### PR DESCRIPTION
The more structured type information in the generation stage
enables e.g. proper const modifiers for the C++ interfaces.

Output format specific conversion logic was moved
to appropriate generators.