### PR TITLE
Fixed new clippy lints

### DIFF
--- a/intercom-common/src/foreign_ty.rs
+++ b/intercom-common/src/foreign_ty.rs
@@ -119,8 +119,8 @@ impl<'s, 'p: 's> TypeInfo<'s> {
         TypeInfo{
             krate: resolver.krate,
             rust_type: resolver.rust_type,
-            pass_by: pass_by,
-            is_mutable: is_mutable,
+            pass_by,
+            is_mutable,
             array_length: resolver.array_length,
         }
     }
@@ -177,8 +177,8 @@ impl<'s, 'p: 's> TypeInfoResolver<'s> {
     ) -> TypeInfoResolver<'s>
     {
         TypeInfoResolver {
-            krate: krate,
-            rust_type: rust_type,
+            krate,
+            rust_type,
             pass_by: None,
             is_mutable: None,
             array_length: None,

--- a/intercom-common/src/generators/cpp.rs
+++ b/intercom-common/src/generators/cpp.rs
@@ -194,7 +194,7 @@ impl CppModel {
                 Ok( CppMethod {
                     name: utils::pascal_case( m.name.as_ref() ),
                     ret_type: ret_ty.to_cpp(),
-                    args: args
+                    args
                 } )
 
             } ).collect::<Result<Vec<_>, GeneratorError>>()?;
@@ -203,7 +203,7 @@ impl CppModel {
                 name: foreign.get_name( c, itf.name() ),
                 iid_struct: guid_as_struct( itf.iid() ),
                 base: itf.base_interface().as_ref().map( |i| foreign.get_name( c, i ) ),
-                methods : methods,
+                methods,
             } )
 
         } ).collect::<Result<Vec<_>, GeneratorError>>()?;
@@ -227,14 +227,14 @@ impl CppModel {
                 name : class_name.to_string(),
                 clsid_struct : guid_as_struct( clsid ),
                 interface_count : coclass.interfaces().len(),
-                interfaces : interfaces,
+                interfaces,
             } )
 
         } ).collect::<Result<Vec<_>, GeneratorError>>()?;
 
         Ok( CppModel {
             lib_name : lib.name().to_owned(),
-            interfaces : interfaces,
+            interfaces,
             coclasses : classes,
         } )
     }

--- a/intercom-common/src/generators/idl.rs
+++ b/intercom-common/src/generators/idl.rs
@@ -127,7 +127,7 @@ impl IdlModel {
                     name: utils::pascal_case( m.name.as_ref() ),
                     idx: i,
                     ret_type: ret_ty.to_idl(),
-                    args: args
+                    args
                 } )
 
             } ).collect::<Result<Vec<_>, GeneratorError>>()?;
@@ -138,7 +138,7 @@ impl IdlModel {
                 name: foreign.get_name( c, itf.name() ),
                 base: itf.base_interface().as_ref().map( |i| foreign.get_name( c, i ) ),
                 iid: format!( "{:-X}", itf.iid() ),
-                methods: methods,
+                methods,
             } )
 
         } ).collect::<Result<Vec<_>, GeneratorError>>()?;
@@ -165,7 +165,7 @@ impl IdlModel {
             Ok( IdlCoClass {
                 name : coclass.name().to_string(),
                 clsid: format!( "{:-X}", clsid ),
-                interfaces: interfaces
+                interfaces
             } )
         } ).collect::<Result<_,GeneratorError>>()?;
 

--- a/intercom-common/src/methodinfo.rs
+++ b/intercom-common/src/methodinfo.rs
@@ -43,8 +43,8 @@ impl RustArg {
 
         let tyhandler = get_ty_handler( &ty );
         RustArg {
-            name: name,
-            ty: ty,
+            name,
+            ty,
             handler: tyhandler,
         }
     }
@@ -122,7 +122,7 @@ impl ComMethodInfo {
             ),
             _ => return Err( ComMethodInfoError::BadSelfArg ),
         } ;
-                
+
         // Process other arguments.
         let args = iter.map( | arg | {
             let ty = arg.get_ty()
@@ -156,13 +156,13 @@ impl ComMethodInfo {
                 .or( Err( ComMethodInfoError::BadReturnType ) )?;
         Ok( ComMethodInfo {
             name: *n,
-            is_const: is_const,
-            rust_self_arg: rust_self_arg,
-            rust_return_ty: rust_return_ty,
-            retval_type: retval_type,
-            return_type: return_type,
-            returnhandler: returnhandler,
-            args: args,
+            is_const,
+            rust_self_arg,
+            rust_return_ty,
+            retval_type,
+            return_type,
+            returnhandler,
+            args,
             is_unsafe: unsafety,
         } )
     }

--- a/intercom-common/src/model.rs
+++ b/intercom-common/src/model.rs
@@ -291,10 +291,10 @@ impl ComInterface
 
         Ok( ComInterface {
             name: itf_ident,
-            iid: iid,
-            visibility: visibility,
+            iid,
+            visibility,
             base_interface: base,
-            methods: methods,
+            methods,
             item_type: itf_type,
             is_unsafe : unsafety.is_some(),
         } )
@@ -377,7 +377,7 @@ impl ComImpl
             is_trait_impl: itf_ident_opt.is_some(),
             interface_name: itf_ident_opt
                     .unwrap_or_else( || struct_ident ),
-            methods: methods,
+            methods,
         } )
     }
 
@@ -521,7 +521,7 @@ impl ComCrate
                             _ => return Err( ParseError::CargoToml(
                                     "No 'name' parameter under [package]".into() ) ),
                         },
-                    _ => return Err( ParseError::CargoToml( 
+                    _ => return Err( ParseError::CargoToml(
                             "Could not find [package] in Cargo.toml".into() ) ),
                 };
 
@@ -580,7 +580,7 @@ impl ComCrate
     fn process_crate_items(
         crate_name : &str,
         path : Option< &Path >,
-        items : &[ ::syn::Item ], 
+        items : &[ ::syn::Item ],
         b : &mut ComCrateBuilder,
     ) -> ParseResult<()>
     {
@@ -638,13 +638,13 @@ impl ComCrate
                     => Self::process_crate_items( crate_name, path, mod_items, b )?
             }
         }
-        
+
         Ok(())
     }
 
     fn collect_items(
         crate_name : &str,
-        items : &[ ::syn::Item ], 
+        items : &[ ::syn::Item ],
         b : &mut ComCrateBuilder,
     ) -> ParseResult<()>
     {
@@ -927,7 +927,7 @@ mod test
         assert!( krate.lib.is_some() );
         assert_eq!( krate.lib.as_ref().unwrap().libid(),
             &GUID::parse( "12345678-1234-1234-1234-567890000000" ).unwrap() );
-        
+
         // The interfaces should contain the built-in interface.
         assert_eq!( krate.interfaces().len(), 2 );
         assert_eq!( krate.interfaces()[ "IFoo" ].iid(),

--- a/intercom/src/combox.rs
+++ b/intercom/src/combox.rs
@@ -116,7 +116,7 @@ impl<T: CoClass> ComBox<T> {
         Box::into_raw( Box::new( ComBox {
             vtable_list: T::create_vtable_list(),
             ref_count: AtomicU32::new( 0 ),
-            value: value,
+            value,
         } ) )
     }
 

--- a/intercom/src/comitf.rs
+++ b/intercom/src/comitf.rs
@@ -27,7 +27,7 @@ impl<T: ?Sized> ComItf<T> {
     /// of type `T`.
     pub unsafe fn wrap( ptr : RawComPtr ) -> ComItf<T> {
         ComItf {
-            ptr: ptr,
+            ptr,
             phantom: PhantomData,
         }
     }


### PR DESCRIPTION
Clippy now warns if both the name of a struct member and
the variable specified when instantiating a struct have
identical names.