### PR TITLE
Disable false positives from clippy

### DIFF
--- a/intercom-attributes/src/lib.rs
+++ b/intercom-attributes/src/lib.rs
@@ -51,6 +51,7 @@ use proc_macro::{TokenStream, LexError};
 /// which provides the clients a way to perform reference counting and the
 /// ability to query for other interfaces the object might implement.
 #[proc_macro_attribute]
+#[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
 pub fn com_interface(
     attr: TokenStream,
     tokens: TokenStream,
@@ -76,6 +77,7 @@ pub fn com_interface(
 /// as arguments and return values for the interface methods. The automatic
 /// FFI layer handles conversion between these types and FFI compatible types.
 #[proc_macro_attribute]
+#[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
 pub fn com_impl(
     attr: TokenStream,
     tokens: TokenStream,
@@ -105,6 +107,7 @@ pub fn com_impl(
 /// by the clients. It can still be returned as a return value from other
 /// intercom methods.
 #[proc_macro_attribute]
+#[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
 pub fn com_class(
     attr: TokenStream,
     tokens: TokenStream,
@@ -134,6 +137,7 @@ pub fn com_class(
 /// infrastructure that allows external clients to load the library and
 /// instantiate the specified types.
 #[proc_macro_attribute]
+#[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
 pub fn com_library(
     attr: TokenStream,
     tokens: TokenStream,


### PR DESCRIPTION
The function parameters are defined by the proc_macro_attribute and
we cannot change them.

Full lint error:
"
error: this argument is passed by value, but not consumed in the function body
  --> intercom-attributes/src/lib.rs:55:11
   |
55 |     attr: TokenStream,
   |           ^^^^^^^^^^^ help: consider taking a reference instead: `&TokenStream`
   |
   = note: `-D needless-pass-by-value` implied by `-D warnings`
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.198/index.html#needless_pass_by_value
"