### PR TITLE
Removed dependency to "rustfmt" from intercom-attributes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
     - CC=gcc-5 CXX=g++-5 RUSTFLAGS='-C link-dead-code'
 
 script:
+    - cargo install rustfmt-nightly --force
     - (! cargo install clippy --force ) || cargo clippy --all-features --all -- -D warnings
     - cargo test --all-features
     - mkdir build

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -52,6 +52,20 @@
                 "rust",
                 "cpp"
             ]
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug intercom-fmt",
+            "program": "${workspaceRoot}/target/debug/intercom-fmt",
+            "args": [
+                "${workspaceRoot}/intercom-attributes/tests/data/com_impl.source.rs"
+            ],
+            "cwd": "${workspaceRoot}/target/debug/",
+            "sourceLanguages": [
+                "rust",
+                "cpp"
+            ]
         }
     ]
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,6 @@ members = [
     "intercom",
     "intercom-cli",
     "intercom-build",
+    "intercom-fmt",
 ]
 exclude = [ "test" ]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,7 @@ install:
     - ps: $env:PATH="$env:PATH;C:\rust\bin"
     - rustc -vV
     - cargo -vV
+    - cargo install rustfmt-nightly --force
 
 before_build:
     - nuget restore test\cs\cs.sln

--- a/circle.yml
+++ b/circle.yml
@@ -7,9 +7,13 @@ jobs:
             - image: rustlang/rust:nightly
               environment:
                   RUSTFLAGS: -C link-dead-code
-          
+
         steps:
             - checkout
+            - run:
+                name: "Install rustfmt-nightly"
+                command: |
+                    cargo install rustfmt-nightly --force
             - run:
                 name: "Cargo test"
                 command: |

--- a/intercom-attributes/Cargo.toml
+++ b/intercom-attributes/Cargo.toml
@@ -17,5 +17,6 @@ quote = { version = "0.4" }
 
 [dev-dependencies]
 difference = "1.0.0"
-rustfmt-nightly = "0.8"
+intercom-fmt = { version = "0.1.0", path = "../intercom-fmt" }
+intercom = { version = "0.2.0", path = "../intercom" }
 regex = "0.2"

--- a/intercom-build/src/os/windows/mod.rs
+++ b/intercom-build/src/os/windows/mod.rs
@@ -51,7 +51,7 @@ pub fn build() {
     // Generate IDL using intercom_utils.
     {
         let mut idl = File::create( &idl_path )
-                .expect( &format!( "Could not create file: {:?}", idl_path ) );
+                .unwrap_or_else( |_| panic!( "Could not create file: {:?}", idl_path ) );
         let model = ::intercom_common::generators::idl::IdlModel::from_path(
                     Path::new( &toml_dir ) )
                 .expect( "Failed to form IDL from the sources" );
@@ -142,7 +142,7 @@ pub fn build() {
             // 'rc.exe' will result in 'foo.res'. We'll need 'foo.res.lib' as
             // rustc will insist on '.lib' extension.
             ::std::fs::rename( &res_path, &lib_path )
-                    .expect( &format!(
+                    .unwrap_or_else( |_| panic!(
                             "Failed to rename {:?} to {:?}",
                             res_path, lib_path ) );
 

--- a/intercom-build/src/os/windows/setup_configuration.rs
+++ b/intercom-build/src/os/windows/setup_configuration.rs
@@ -290,12 +290,8 @@ pub fn get_tool_paths() -> Result<ToolPaths, String> {
     Ok( ToolPaths {
         mt: kitroot.join( format!( r"bin\{}\x64\mt.exe", kitversion ) ),
         midl: kitroot.join( format!( r"bin\{}\x64\midl.exe", kitversion ) ),
-        rc: rc,
 
-        vs_bin: vs_bin,
-
-        libs: libs,
-        incs: incs,
+        rc, vs_bin, libs, incs
     } )
 }
 

--- a/intercom-common/src/attributes/com_class.rs
+++ b/intercom-common/src/attributes/com_class.rs
@@ -58,7 +58,7 @@ pub fn expand_com_class(
     // ISupportErrorInfo virtual table and having that at the beginning.
     let isupporterrorinfo_ident = Ident::from( "ISupportErrorInfo".to_owned() );
     let isupporterrorinfo_vtable_instance_ident =
-            idents::vtable_instance( struct_ident, &isupporterrorinfo_ident );
+            idents::vtable_instance( struct_ident, isupporterrorinfo_ident );
     let mut vtable_list_field_decls = vec![
         quote!( _ISupportErrorInfo : &'static ::intercom::ISupportErrorInfoVtbl ) ];
     let mut vtable_list_field_values = vec![
@@ -70,10 +70,10 @@ pub fn expand_com_class(
     for itf in cls.interfaces() {
 
         // Various idents.
-        let offset_ident = idents::vtable_offset( struct_ident, itf );
-        let iid_ident = idents::iid( itf );
-        let vtable_struct_ident = idents::vtable_struct( itf );
-        let vtable_instance_ident = idents::vtable_instance( struct_ident, itf );
+        let offset_ident = idents::vtable_offset( struct_ident, *itf );
+        let iid_ident = idents::iid( *itf );
+        let vtable_struct_ident = idents::vtable_struct( *itf );
+        let vtable_instance_ident = idents::vtable_instance( struct_ident, *itf );
 
         // Store the field offset globally. We need this offset when implementing
         // the delegating query_interface methods. The only place where we know

--- a/intercom-common/src/attributes/com_impl.rs
+++ b/intercom-common/src/attributes/com_impl.rs
@@ -119,7 +119,7 @@ pub fn expand_com_impl(
     // method to the vtable fields.
     for method_info in imp.methods() {
 
-        let method_ident = &method_info.name;
+        let method_ident = method_info.name;
         let method_impl_ident = idents::method_impl(
                 struct_ident, itf_ident, method_ident.as_ref() );
 
@@ -140,7 +140,7 @@ pub fn expand_com_impl(
         // Format stack variables if the conversion requires
         // temporary variable.
         let stack_variables = method_info.args.iter()
-                .filter_map( |ca| match ca.handler.com_to_rust( &ca.name ).stack {
+                .filter_map( |ca| match ca.handler.com_to_rust( ca.name ).stack {
                     Some( stack ) => Some( quote!( #stack ) ),
                     None => None
                 } );
@@ -149,7 +149,7 @@ pub fn expand_com_impl(
         let in_params = method_info.args
                 .iter()
                 .map( |ca| {
-                    let conversion = ca.handler.com_to_rust( &ca.name ).conversion;
+                    let conversion = ca.handler.com_to_rust( ca.name ).conversion;
                     quote!( #conversion )
                 } );
 

--- a/intercom-common/src/attributes/com_interface.rs
+++ b/intercom-common/src/attributes/com_interface.rs
@@ -57,7 +57,7 @@ pub fn expand_com_interface(
     // Create a vector for the virtual table fields and insert the base
     // interface virtual table in it if required.
     let mut fields = vec![];
-    if let Some( ref base ) = *itf.base_interface() {
+    if let Some( base ) = *itf.base_interface() {
         let vtbl = match base.as_ref() {
             "IUnknown" => quote!( ::intercom::IUnknownVtbl ),
             _ => { let vtbl = idents::vtable_struct( base ); quote!( #vtbl ) }
@@ -127,7 +127,7 @@ pub fn expand_com_interface(
         let params = method_info.raw_com_args()
                 .into_iter()
                 .map( |com_arg| {
-                    let name = &com_arg.arg.name;
+                    let name = com_arg.arg.name;
                     match com_arg.dir {
                         Direction::In => {
                             let param = com_arg.arg.handler.rust_to_com( name );

--- a/intercom-common/src/attributes/com_library.rs
+++ b/intercom-common/src/attributes/com_library.rs
@@ -27,7 +27,7 @@ pub fn expand_com_library(
     for struct_ident in lib.coclasses() {
 
         // Construct the match pattern.
-        let clsid_name = idents::clsid( struct_ident );
+        let clsid_name = idents::clsid( *struct_ident );
         match_arms.push( quote!(
             self::#clsid_name =>
                 Ok( ::intercom::ComBox::new(

--- a/intercom-common/src/builtin_model.rs
+++ b/intercom-common/src/builtin_model.rs
@@ -1,3 +1,6 @@
+//!
+//! Defines the default Intercom type model.
+//!
 
 use model::{ ComInterface, ComStruct, ComImpl };
 

--- a/intercom-common/src/foreign_ty.rs
+++ b/intercom-common/src/foreign_ty.rs
@@ -7,7 +7,7 @@ use type_parser::*;
 pub trait ForeignTypeHandler
 {
     /// Gets the name for the 'ty'.
-    fn get_name( &self, krate : &ComCrate, ty : &syn::Ident ) -> String;
+    fn get_name( &self, krate : &ComCrate, ty : syn::Ident ) -> String;
 
     /// Gets the COM type for a Rust type.
     fn get_ty<'a, 'b: 'a>(
@@ -24,7 +24,7 @@ impl ForeignTypeHandler for CTypeHandler
     fn get_name(
         &self,
         krate: &ComCrate,
-        ident: &syn::Ident,
+        ident: syn::Ident,
     ) -> String
     {
         self.get_name_for_ty( krate, ident.as_ref() )

--- a/intercom-common/src/generators/cpp.rs
+++ b/intercom-common/src/generators/cpp.rs
@@ -233,7 +233,7 @@ impl CppModel {
             Ok( CppInterface {
                 name: foreign.get_name( c, itf.name() ),
                 iid_struct: guid_as_struct( itf.iid() ),
-                base: itf.base_interface().as_ref().map( |i| foreign.get_name( c, i ) ),
+                base: itf.base_interface().as_ref().map( |i| foreign.get_name( c, *i ) ),
                 methods,
             } )
 
@@ -247,7 +247,7 @@ impl CppModel {
 
             // Create a list of interfaces to be declared in the class descriptor.
             let interfaces = coclass.interfaces().iter().map(|itf_name| {
-                foreign.get_name( c, itf_name )
+                foreign.get_name( c, *itf_name )
             } ).collect();
 
             let clsid = coclass.clsid().as_ref()

--- a/intercom-common/src/generators/idl.rs
+++ b/intercom-common/src/generators/idl.rs
@@ -144,7 +144,7 @@ impl IdlModel {
             // interface definition.
             Ok( IdlInterface {
                 name: foreign.get_name( c, itf.name() ),
-                base: itf.base_interface().as_ref().map( |i| foreign.get_name( c, i ) ),
+                base: itf.base_interface().as_ref().map( |i| foreign.get_name( c, *i ) ),
                 iid: format!( "{:-X}", itf.iid() ),
                 methods,
             } )
@@ -164,7 +164,7 @@ impl IdlModel {
 
             // Get the interfaces the class implements.
             let interfaces = coclass.interfaces().iter().map(|itf_name| {
-                foreign.get_name( c, itf_name )
+                foreign.get_name( c, *itf_name )
             } ).collect();
 
             let clsid = coclass.clsid().as_ref()
@@ -254,7 +254,7 @@ impl<'s> IdlTypeInfo<'s> for TypeInfo<'s> {
         let type_name = self.get_name();
         match type_name.as_str() {
             "RawComPtr" => "*void".to_owned(),
-            "String" | "BStr" | "str" => "BSTR".to_owned(),
+            "String" | "BString" | "BStr" | "str" => "BSTR".to_owned(),
             "usize" => "size_t".to_owned(),
             "u64" => "uint64".to_owned(),
             "i64" => "int64".to_owned(),

--- a/intercom-common/src/idents.rs
+++ b/intercom-common/src/idents.rs
@@ -2,22 +2,22 @@
 use syn::*;
 
 pub fn clsid(
-    struct_name: &Ident
+    struct_name: Ident
 ) -> Ident
 {
     Ident::from( format!( "CLSID_{}", struct_name ) )
 }
 
 pub fn iid(
-    itf_name: &Ident
+    itf_name: Ident
 ) -> Ident
 {
     Ident::from( format!( "IID_{}", itf_name ) )
 }
 
 pub fn method_impl(
-    struct_ident : &Ident,
-    itf_ident : &Ident,
+    struct_ident : Ident,
+    itf_ident : Ident,
     method_name: &str
 ) -> Ident
 {
@@ -26,15 +26,15 @@ pub fn method_impl(
 }
 
 pub fn vtable_struct(
-    itf_ident : &Ident
+    itf_ident : Ident
 ) -> Ident
 {
     Ident::from( format!( "__{}Vtbl", itf_ident ) )
 }
 
 pub fn vtable_instance(
-    struct_name : &Ident,
-    itf_ident : &Ident,
+    struct_name : Ident,
+    itf_ident : Ident,
 ) -> Ident
 {
     Ident::from( format!( "__{}_{}Vtbl_INSTANCE",
@@ -43,15 +43,15 @@ pub fn vtable_instance(
 }
 
 pub fn vtable_list(
-    struct_ident : &Ident
+    struct_ident : Ident
 ) -> Ident
 {
     Ident::from( format!( "__{}VtblList", struct_ident ) )
 }
 
 pub fn vtable_offset(
-    s : &Ident,
-    i : &Ident
+    s : Ident,
+    i : Ident
 ) -> Ident
 {
     Ident::from( format!( "__{}_{}Vtbl_offset", s, i ) )

--- a/intercom-common/src/methodinfo.rs
+++ b/intercom-common/src/methodinfo.rs
@@ -98,11 +98,11 @@ impl ComMethodInfo {
         m : &MethodSig
     ) -> Result<ComMethodInfo, ComMethodInfoError>
     {
-        Self::new_from_parts( &m.ident, &m.decl, m.unsafety.is_some() )
+        Self::new_from_parts( m.ident, &m.decl, m.unsafety.is_some() )
     }
 
     pub fn new_from_parts(
-        n: &Ident,
+        n: Ident,
         decl: &FnDecl,
         unsafety: bool,
     ) -> Result<ComMethodInfo, ComMethodInfoError>
@@ -155,7 +155,7 @@ impl ComMethodInfo {
         let returnhandler = get_return_handler( &retval_type, &return_type )
                 .or( Err( ComMethodInfoError::BadReturnType ) )?;
         Ok( ComMethodInfo {
-            name: *n,
+            name: n,
             is_const,
             rust_self_arg,
             rust_return_ty,

--- a/intercom-common/src/methodinfo.rs
+++ b/intercom-common/src/methodinfo.rs
@@ -313,6 +313,6 @@ mod tests {
             Item::Fn( ref f ) => ( f.ident, f.decl.as_ref(), f.unsafety.is_some() ),
             _ => panic!( "Code isn't function" ),
         };
-        ComMethodInfo::new_from_parts( &ident, decl, unsafety ).unwrap()
+        ComMethodInfo::new_from_parts( ident, decl, unsafety ).unwrap()
     }
 }

--- a/intercom-common/src/model.rs
+++ b/intercom-common/src/model.rs
@@ -175,7 +175,7 @@ impl ComStruct
     }
 
     /// Struct name.
-    pub fn name( &self ) -> &Ident { &self.name }
+    pub fn name( &self ) -> Ident { self.name }
 
     /// Struct CLSID.
     pub fn clsid( &self ) -> &Option<GUID> { &self.clsid }
@@ -301,7 +301,7 @@ impl ComInterface
     }
 
     /// Interface name.
-    pub fn name( &self ) -> &Ident { &self.name }
+    pub fn name( &self ) -> Ident { self.name }
 
     /// Interface IID.
     pub fn iid( &self ) -> &GUID { &self.iid }
@@ -382,10 +382,10 @@ impl ComImpl
     }
 
     /// Struct name that the trait is implemented for.
-    pub fn struct_name( &self ) -> &Ident { &self.struct_name }
+    pub fn struct_name( &self ) -> Ident { self.struct_name }
 
     /// Trait name that is implemented. Struct name if this is an implicit impl.
-    pub fn interface_name( &self ) -> &Ident { &self.interface_name }
+    pub fn interface_name( &self ) -> Ident { self.interface_name }
 
     /// True if a valid trait is implemented, false for implicit impls.
     pub fn is_trait_impl( &self ) -> bool { self.is_trait_impl }
@@ -445,7 +445,7 @@ impl ComCrateBuilder {
         for lib in &mut self.libs {
             for clsid in built_in_types.iter().filter_map( |bti|
                     if bti.class.clsid.is_some() {
-                        Some( *bti.class.name() )
+                        Some( bti.class.name() )
                     } else {
                         None
                     } ) {

--- a/intercom-common/src/returnhandlers.rs
+++ b/intercom-common/src/returnhandlers.rs
@@ -152,7 +152,7 @@ fn write_out_values(
     for ( ident, out_arg ) in idents.iter().zip( out_args ) {
 
         let arg_name = out_arg.name;
-        let ok_value = out_arg.handler.rust_to_com( ident );
+        let ok_value = out_arg.handler.rust_to_com( *ident );
         let err_value = out_arg.handler.default_value();
         ok_tokens.push( quote!( *#arg_name = #ok_value ) );
         err_tokens.push( quote!( *#arg_name = #err_value ) );

--- a/intercom-common/src/returnhandlers.rs
+++ b/intercom-common/src/returnhandlers.rs
@@ -168,7 +168,7 @@ fn get_ok_values(
     let mut tokens = vec![];
     for out_arg in out_args {
 
-        let arg_value = out_arg.handler.rust_to_com( &out_arg.name );
+        let arg_value = out_arg.handler.rust_to_com( out_arg.name );
         tokens.push( quote!( #arg_value ) );
     }
     tokens

--- a/intercom-common/src/tyhandlers.rs
+++ b/intercom-common/src/tyhandlers.rs
@@ -31,7 +31,7 @@ pub trait TypeHandler {
 
     /// Converts a COM parameter named by the ident into a Rust type.
     fn com_to_rust(
-        &self, ident : &Ident
+        &self, ident : Ident
     ) -> ComToRust
     {
         ComToRust {
@@ -42,7 +42,7 @@ pub trait TypeHandler {
 
     /// Converts a Rust parameter named by the ident into a COM type.
     fn rust_to_com(
-        &self, ident : &Ident
+        &self, ident : Ident
     ) -> Tokens
     {
         quote!( #ident.into() )
@@ -103,7 +103,7 @@ impl TypeHandler for StringParam
         parse_quote!( ::intercom::BStr )
     }
 
-    fn com_to_rust( &self, ident : &Ident ) -> ComToRust
+    fn com_to_rust( &self, ident : Ident ) -> ComToRust
     {
         ComToRust {
             stack: None,
@@ -111,7 +111,7 @@ impl TypeHandler for StringParam
         }
     }
 
-    fn rust_to_com( &self, ident : &Ident ) -> Tokens
+    fn rust_to_com( &self, ident : Ident ) -> Tokens
     {
         quote!( #ident.into() )
     }
@@ -128,7 +128,7 @@ impl TypeHandler for StringRefParam
         parse_quote!( ::intercom::BStr )
     }
 
-    fn com_to_rust( &self, ident : &Ident ) -> ComToRust
+    fn com_to_rust( &self, ident : Ident ) -> ComToRust
     {
         // Generate unique name for each stack variable to avoid conflicts with function
         // thay may have multiple parameters.
@@ -139,7 +139,7 @@ impl TypeHandler for StringRefParam
         }
     }
 
-    fn rust_to_com( &self, ident : &Ident ) -> Tokens
+    fn rust_to_com( &self, ident : Ident ) -> Tokens
     {
         quote!( #ident.into() )
     }
@@ -151,7 +151,7 @@ pub fn get_ty_handler(
 ) -> Rc<TypeHandler>
 {
     let type_info = ::type_parser::parse( arg_ty )
-            .expect( &format!( "Type {:?} could not be parsed.", arg_ty  ) );
+            .unwrap_or_else( || panic!( "Type {:?} could not be parsed.", arg_ty ) );
 
     map_by_name( type_info.get_name().as_ref(), type_info.original.clone() )
 }

--- a/intercom-common/src/type_parser.rs
+++ b/intercom-common/src/type_parser.rs
@@ -280,7 +280,7 @@ impl<'s, 'p: 's> TypeInfoResolver<'s> {
     {
         let resolver = TypeInfoResolver::from_type( &reference.elem )?;
         let resolver = TypeInfoResolver::mutable( resolver,
-                TypeInfoResolver::is_mutable( &reference.mutability ) );
+                TypeInfoResolver::is_mutable( reference.mutability ) );
 
         Some( TypeInfoResolver::pass_by( resolver, PassBy::Reference ) )
     }
@@ -291,7 +291,7 @@ impl<'s, 'p: 's> TypeInfoResolver<'s> {
     {
         let resolver = TypeInfoResolver::from_type( &ptr.elem )?;
         let resolver = TypeInfoResolver::mutable( resolver,
-                TypeInfoResolver::is_mutable( &ptr.mutability ) );
+                TypeInfoResolver::is_mutable( ptr.mutability ) );
 
         Some( TypeInfoResolver::pass_by( resolver, PassBy::Ptr ) )
     }
@@ -340,7 +340,7 @@ impl<'s, 'p: 's> TypeInfoResolver<'s> {
 
     /// Determines if the given type is mutable
     fn is_mutable(
-        mutability: &Option<syn::token::Mut>
+        mutability: Option<syn::token::Mut>
     ) -> bool
     {
         mutability.is_some()

--- a/intercom-fmt/Cargo.toml
+++ b/intercom-fmt/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "intercom-fmt"
+version = "0.1.0"
+authors = ["Juha Lepola <fluxie@fluxie.fi>"]
+description = "Formats Rust code with \"rustfmt\""
+
+[dependencies]
+intercom-common = { path = "../intercom-common", version = "0.2.0" }
+clap = { version = "2.27.1", default-features = false }
+failure = "0.1"

--- a/intercom-fmt/src/main.rs
+++ b/intercom-fmt/src/main.rs
@@ -1,0 +1,175 @@
+use std::path::Path;
+use std::fs::File;
+use std::process::Command;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+use std::io::{ BufWriter, Write };
+use std::path::{ PathBuf };
+
+extern crate intercom_common;
+
+#[macro_use]
+extern crate failure;
+
+#[macro_use]
+extern crate clap;
+use clap::{App, Arg, ArgMatches};
+
+/// Runs rustfmt for the given source file
+fn main() {
+
+    let parser = App::new( "Rust Formatter Utility" )
+            .version( crate_version!() )
+            .author( "Juha Lepola <fluxie@fluxie.fi>" )
+            .arg( Arg::with_name( "input" )
+                .short( "i" )
+                .help( "File to format" )
+                .index( 1 )
+            )
+            .arg( Arg::with_name( "output" )
+                .short( "o" )
+                .required( false )
+                .help( "Target for the formatted file" )
+                .index( 2 )
+            )
+            .arg( Arg::with_name( "preserve" )
+                .short( "p" )
+                .long( "preserve" )
+                .help( "Preserves the temporary crate created for the formatting.")
+            );
+
+    // Define the command line arguments using clap.
+    let matches = parser.get_matches();
+
+    // Run the command and report possiblecd  errors.
+    match run_cmd( &matches ) {
+        Ok( path ) => if ! matches.is_present( "preserve" ) {
+            std::fs::remove_dir_all( path ).expect( "Removing temporary directory failed");
+        },
+        Err( e ) => { eprintln!( "{}", e ); ::std::process::exit( -1 ); },
+    }
+}
+
+/// Executes the command based on the given command line parameters.
+fn run_cmd(
+    matches : &ArgMatches
+) -> Result<PathBuf, failure::Error>
+{
+    // Prepare a temporary location for generating the Rust package.
+    // We will execute "cargo fmt" within this package to format the input file.
+    let temp = std::env::temp_dir();
+    let unique_name;
+    {
+        let now = SystemTime::now().duration_since( UNIX_EPOCH ).unwrap();
+        unique_name = format!( "intercom-fmt-{0}_{1}", now.as_secs(), now.subsec_micros() );
+    }
+    let temp = temp.join( &unique_name );
+    std::fs::create_dir_all( &temp )?;
+
+    // Prepare the cargo package.
+    generate_cargo_toml( &unique_name, &temp )?;
+    let for_output = copy_as_source( &mut get_input( matches )?, &temp )?;
+
+    // Format the output with "cargo fmt".
+    run_cargo_fmt( &temp )?;
+
+    std::io::copy(
+                &mut File::open( for_output.as_ref() )?,
+                get_output( &matches )?.as_mut()
+            )?;
+    Ok( temp )
+}
+
+/// Gets input stream for reaing the Rust code that needs to be formatted.
+fn get_input(
+    matches : &ArgMatches
+) -> Result<Box<std::io::Read>, failure::Error>
+{
+    // Fallback to stdin if the input parameter was not specified.
+    let input_stream: Box<std::io::Read> = match matches.value_of( "input" )
+    {
+        Some( ref input ) => {
+            let input = Path::new( input );
+            if ! input.exists() { return Err( failure::err_msg( "Specified input file does not exist." ) ); }
+            Box::new( File::open( input )? )
+        },
+        None => Box::new( std::io::stdin() ),
+    };
+
+    Ok( input_stream )
+}
+
+
+/// Gets output stream for writing the formatted Rust code.
+fn get_output(
+    matches : &ArgMatches
+) -> Result<Box<std::io::Write>, failure::Error>
+{
+    // Fallback to stdout if the output file was not specified.
+    let output_stream: Box<std::io::Write> = match matches.value_of( "output" )
+    {
+        Some( ref output ) => {
+            let output = Path::new( output );
+            if output.exists() { return Err( failure::err_msg( "Target file already exists" ) ); };
+            Box::new( File::create( output )? )
+        },
+        None => Box::new( std::io::stdout() ),
+    };
+
+    Ok( output_stream )
+}
+
+/// Generates a minimal Cargo.toml for the crate in "dir".
+fn generate_cargo_toml(
+    package_name: &str,
+    dir: &Path,
+) -> Result<(), failure::Error>
+{
+    let cargo_toml = File::create( dir.join( "Cargo.toml" ) )?;
+    {
+        let mut w = BufWriter::new( cargo_toml );
+
+        writeln!( w, "[package]" )?;
+        writeln!( w, "name = \"{0}\"", package_name )?;
+        writeln!( w, "version = \"0.1.0\"" )?;
+    }
+
+    Ok( () )
+}
+
+/// Copies the input file as a source file for the project.
+fn copy_as_source(
+    input: &mut std::io::Read,
+    dir: &Path,
+) -> Result<Box<PathBuf>, failure::Error>
+{
+    // To support cargo source files must be in "src" directory.
+    let src = dir.join( "src" );
+    std::fs::create_dir_all( &src )?;
+
+    // By default the crate must have either lib.rs or main rs.
+    let target = src.join( "lib.rs" );
+    std::io::copy( input, &mut File::create( &target )? )?;
+
+    Ok( Box::new( target ) )
+}
+
+/// Executes the "cargo fmt" for the crate in "dir"
+fn run_cargo_fmt(
+    dir: &Path,
+) -> Result<(), failure::Error>
+{
+    let status = Command::new( "cargo" )
+                .arg( "fmt" )
+                .current_dir( dir )
+                .status()?;
+
+    if status.success() {
+        Ok( () )
+    }
+    else {
+        Err( format_err!(
+                "Executing \"cargo fmt\" failed with exit code \"{0}\".", status.code().unwrap() ) )
+    }
+}


### PR DESCRIPTION
Rustftm is sometimes out-of-sync with nightly.
This caused build problems.
    
Now the test in
"intercom-attributes" create a temporary crate from the
source file that needs to be formatted. Then "cargo fmt"
is executed in order to format the source files.
