### PR TITLE
Upgrade to Syn 0.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,9 @@ env:
     - CC=gcc-5 CXX=g++-5 RUSTFLAGS='-C link-dead-code'
 
 script:
-    - cargo install rustfmt-nightly --force
-    - (! cargo install clippy --force ) || cargo clippy --all-features --all -- -D warnings
+    - rustup component add rustfmt-preview
+    - rustup component add clippy-preview
+    - cargo clippy --all-features --all -- -D warnings
     - cargo test --all-features
     - mkdir build
     - ( cd build && cmake .. && make )

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,19 +8,19 @@ os:
 
 environment:
     matrix:
-    - TARGET: nightly-x86_64-pc-windows-msvc
+    - TARGET: x86_64-pc-windows-msvc
 
       # Disable the GNU target for now as it's broken. Rust #47029
       #- TARGET: nightly-x86_64-pc-windows-gnu
 
 
 install:
-    - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-${env:TARGET}.exe" -FileName "rust-install.exe"
-    - ps: .\rust-install.exe /VERYSILENT /NORESTART /DIR="C:\rust" | Out-Null
-    - ps: $env:PATH="$env:PATH;C:\rust\bin"
+    - curl -sSf -o rustup-init.exe https://win.rustup.rs
+    - rustup-init.exe --default-host %TARGET% --default-toolchain nightly -y
+    - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
     - rustc -vV
     - cargo -vV
-    - cargo install rustfmt-nightly --force
+    - rustup component add rustfmt-preview
 
 before_build:
     - nuget restore test\cs\cs.sln

--- a/circle.yml
+++ b/circle.yml
@@ -16,12 +16,13 @@ jobs:
                     rustc -vV
                     cargo -vV
             - run:
-                name: "Install rustfmt-nightly"
+                name: "Install rustfmt"
                 command: |
-                    cargo install rustfmt-nightly --force
+                    rustup component add rustfmt-preview
             - run:
                 name: "Cargo test"
                 command: |
+                    export RUST_BACKTRACE=1
                     cargo test --all-features
             - run:
                 name: "C++ test"

--- a/intercom-attributes/Cargo.toml
+++ b/intercom-attributes/Cargo.toml
@@ -16,7 +16,8 @@ syn = { version = "0.14", features = [ "full" ] }
 quote = { version = "0.6" }
 
 [dev-dependencies]
-difference = "1.0.0"
+difference = "2"
+term = "0.5"
 intercom-fmt = { version = "0.1.0", path = "../intercom-fmt" }
 intercom = { version = "0.2.0", path = "../intercom" }
 regex = "0.2"

--- a/intercom-attributes/Cargo.toml
+++ b/intercom-attributes/Cargo.toml
@@ -12,8 +12,8 @@ proc-macro = true
 
 [dependencies]
 intercom-common = { version = "0.2.0", path = "../intercom-common" }
-syn = { version = "0.12", features = [ "full" ] }
-quote = { version = "0.4" }
+syn = { version = "0.14", features = [ "full" ] }
+quote = { version = "0.6" }
 
 [dev-dependencies]
 difference = "1.0.0"

--- a/intercom-common/Cargo.toml
+++ b/intercom-common/Cargo.toml
@@ -7,8 +7,9 @@ repository = "https://github.com/Rantanen/intercom"
 description = "See 'intercom'"
 
 [dependencies]
-syn = { version = "0.12", features = [ "full", "extra-traits", "parsing" ] }
-quote = { version = "0.4" }
+syn = { version = "0.14", features = [ "full", "extra-traits", "parsing" ] }
+quote = { version = "0.6" }
+proc-macro2 = "0.4"
 sha1 = "0.3.0"
 ordermap = "0.3"
 toml = "0.4.5"

--- a/intercom-common/src/ast_converters.rs
+++ b/intercom-common/src/ast_converters.rs
@@ -1,4 +1,5 @@
 
+use prelude::*;
 use syn::*;
 
 /// Extract the underlying Type from various AST types.
@@ -18,7 +19,7 @@ impl GetType for FnArg {
             FnArg::SelfRef( ref s )
                 => Type::Reference( TypeReference {
                         and_token: parse_quote!( & ),
-                        lifetime: s.lifetime,
+                        lifetime: s.lifetime.clone(),
                         mutability: s.mutability,
                         elem: Box::new( parse_quote!( Self ) )
                 } ),
@@ -63,12 +64,12 @@ impl GetIdent for FnArg {
 
         Ok( match *self {
             FnArg::SelfRef(..) | FnArg::SelfValue(..)
-                => Ident::from( "self" ),
+                => Ident::new( "self", Span::call_site() ),
             FnArg::Captured( ref c ) => match c.pat {
-                Pat::Ident( ref i ) => i.ident,
+                Pat::Ident( ref i ) => i.ident.clone(),
                 _ => Err( format!( "Unsupported argument: {:?}", self ) )?,
             },
-            FnArg::Ignored(..) => Ident::from( "_" ),
+            FnArg::Ignored(..) => Ident::new( "_", Span::call_site() ),
             FnArg::Inferred(_)
                 => return Err( "Inferred arguments not supported".to_string() ),
         } )
@@ -79,7 +80,7 @@ impl GetIdent for Path {
 
     fn get_ident( &self ) -> Result<Ident, String> {
 
-        self.segments.last().map( |l| l.value().ident )
+        self.segments.last().map( |l| l.value().ident.clone() )
                 .ok_or_else( || "Empty path".to_owned() )
     }
 }
@@ -102,7 +103,7 @@ impl<'a> GetIdent for ::utils::AttrParam {
     {
         match *self {
             ::utils::AttrParam::Word( ref ident )
-                => Ok( *ident ),
+                => Ok( ident.clone() ),
             _ => Err( format!( "Unsupported AttrParam kind: {:?}", self ) ),
         }
     }
@@ -123,9 +124,9 @@ impl GetIdent for Meta {
     fn get_ident( &self ) -> Result<Ident, String>
     {
         Ok( match *self {
-            Meta::Word( ref i ) => *i,
-            Meta::List( ref ml ) => ml.ident,
-            Meta::NameValue( ref nv ) => nv.ident,
+            Meta::Word( ref i ) => i.clone(),
+            Meta::List( ref ml ) => ml.ident.clone(),
+            Meta::NameValue( ref nv ) => nv.ident.clone(),
         } )
     }
 }
@@ -134,19 +135,19 @@ impl GetIdent for Item {
     fn get_ident( &self ) -> Result<Ident, String>
     {
         Ok( match *self {
-            Item::ExternCrate( ref i ) => i.ident,
-            Item::Static( ref i ) => i.ident,
-            Item::Const( ref i ) => i.ident,
-            Item::Fn( ref i ) => i.ident,
-            Item::Mod( ref i ) => i.ident,
-            Item::Type( ref i ) => i.ident,
-            Item::Struct( ref i ) => i.ident,
-            Item::Enum( ref i ) => i.ident,
-            Item::Union( ref i ) => i.ident,
-            Item::Trait( ref i ) => i.ident,
+            Item::ExternCrate( ref i ) => i.ident.clone(),
+            Item::Static( ref i ) => i.ident.clone(),
+            Item::Const( ref i ) => i.ident.clone(),
+            Item::Fn( ref i ) => i.ident.clone(),
+            Item::Mod( ref i ) => i.ident.clone(),
+            Item::Type( ref i ) => i.ident.clone(),
+            Item::Struct( ref i ) => i.ident.clone(),
+            Item::Enum( ref i ) => i.ident.clone(),
+            Item::Union( ref i ) => i.ident.clone(),
+            Item::Trait( ref i ) => i.ident.clone(),
             Item::Impl( ref i ) => return i.self_ty.get_ident(),
             Item::Macro( ref m ) => return m.mac.path.get_ident(),
-            Item::Macro2( ref i ) => i.ident,
+            Item::Macro2( ref i ) => i.ident.clone(),
 
             Item::Use( .. )
                 | Item::ForeignMod( .. )

--- a/intercom-common/src/attributes/com_impl.rs
+++ b/intercom-common/src/attributes/com_impl.rs
@@ -1,4 +1,5 @@
 
+use prelude::*;
 use super::common::*;
 
 use std::iter;
@@ -28,9 +29,9 @@ pub fn expand_com_impl(
     let imp = model::ComImpl::parse( &item_tokens.to_string() )?;
     let struct_ident = imp.struct_name();
     let itf_ident = imp.interface_name();
-    let vtable_struct_ident = idents::vtable_struct( itf_ident );
-    let vtable_instance_ident = idents::vtable_instance( struct_ident, itf_ident );
-    let vtable_offset = idents::vtable_offset( struct_ident, itf_ident );
+    let vtable_struct_ident = idents::vtable_struct( &itf_ident );
+    let vtable_instance_ident = idents::vtable_instance( &struct_ident, &itf_ident );
+    let vtable_offset = idents::vtable_offset( &struct_ident, &itf_ident );
 
     /////////////////////
     // #itf::QueryInterface, AddRef & Release
@@ -46,7 +47,7 @@ pub fn expand_com_impl(
     // QueryInterface
     let calling_convetion = get_calling_convetion();
     let query_interface_ident = idents::method_impl(
-            struct_ident, itf_ident, "query_interface" );
+            &struct_ident, &itf_ident, "query_interface" );
     output.push( quote!(
             #[allow(non_snake_case)]
             #[doc(hidden)]
@@ -68,7 +69,7 @@ pub fn expand_com_impl(
 
     // AddRef
     let add_ref_ident = idents::method_impl(
-            struct_ident, itf_ident, "add_ref" );
+            &struct_ident, &itf_ident, "add_ref" );
     output.push( quote!(
             #[allow(non_snake_case)]
             #[allow(dead_code)]
@@ -83,7 +84,7 @@ pub fn expand_com_impl(
 
     // Release
     let release_ident = idents::method_impl(
-            struct_ident, itf_ident, "release" );
+            &struct_ident, &itf_ident, "release" );
     output.push( quote!(
             #[allow(non_snake_case)]
             #[allow(dead_code)]
@@ -119,9 +120,9 @@ pub fn expand_com_impl(
     // method to the vtable fields.
     for method_info in imp.methods() {
 
-        let method_ident = method_info.name;
+        let method_ident = &method_info.name;
         let method_impl_ident = idents::method_impl(
-                struct_ident, itf_ident, method_ident.as_ref() );
+                &struct_ident, &itf_ident, &method_ident.to_string() );
 
         let in_out_args = method_info.raw_com_args()
                 .into_iter()
@@ -140,7 +141,7 @@ pub fn expand_com_impl(
         // Format stack variables if the conversion requires
         // temporary variable.
         let stack_variables = method_info.args.iter()
-                .filter_map( |ca| match ca.handler.com_to_rust( ca.name ).stack {
+                .filter_map( |ca| match ca.handler.com_to_rust( &ca.name ).stack {
                     Some( stack ) => Some( quote!( #stack ) ),
                     None => None
                 } );
@@ -149,11 +150,11 @@ pub fn expand_com_impl(
         let in_params = method_info.args
                 .iter()
                 .map( |ca| {
-                    let conversion = ca.handler.com_to_rust( ca.name ).conversion;
+                    let conversion = ca.handler.com_to_rust( &ca.name ).conversion;
                     quote!( #conversion )
                 } );
 
-        let return_ident = Ident::from( "__result" );
+        let return_ident = Ident::new( "__result", Span::call_site() );
         let return_statement = method_info
                 .returnhandler
                 .rust_to_com_return( &return_ident );

--- a/intercom-common/src/attributes/com_interface.rs
+++ b/intercom-common/src/attributes/com_interface.rs
@@ -1,4 +1,5 @@
 
+use prelude::*;
 use super::common::*;
 
 use std::iter;
@@ -57,10 +58,10 @@ pub fn expand_com_interface(
     // Create a vector for the virtual table fields and insert the base
     // interface virtual table in it if required.
     let mut fields = vec![];
-    if let Some( base ) = *itf.base_interface() {
-        let vtbl = match base.as_ref() {
+    if let Some( ref base ) = *itf.base_interface() {
+        let vtbl = match base.to_string().as_ref() {
             "IUnknown" => quote!( ::intercom::IUnknownVtbl ),
-            _ => { let vtbl = idents::vtable_struct( base ); quote!( #vtbl ) }
+            _ => { let vtbl = idents::vtable_struct( &base ); quote!( #vtbl ) }
         };
         fields.push( quote!( pub __base : #vtbl ) );
     }
@@ -130,7 +131,7 @@ pub fn expand_com_interface(
                     let name = com_arg.arg.name;
                     match com_arg.dir {
                         Direction::In => {
-                            let param = com_arg.arg.handler.rust_to_com( name );
+                            let param = com_arg.arg.handler.rust_to_com( &name );
                             quote!( #param )
                         },
                         Direction::Out | Direction::Retval
@@ -144,7 +145,7 @@ pub fn expand_com_interface(
         let params = iter::once( quote!( comptr ) ).chain( params );
 
         // Create the return statement. 
-        let return_ident = Ident::from( "__result" );
+        let return_ident = Ident::new( "__result", Span::call_site() );
         let return_statement = method_info
                 .returnhandler
                 .com_to_rust_return( &return_ident );

--- a/intercom-common/src/attributes/com_library.rs
+++ b/intercom-common/src/attributes/com_library.rs
@@ -1,4 +1,5 @@
 
+use prelude::*;
 use super::common::*;
 
 use idents;
@@ -6,9 +7,7 @@ use utils;
 use model;
 use builtin_model;
 
-extern crate proc_macro;
 extern crate quote;
-use self::proc_macro::TokenStream;
 
 /// Expands the `com_library` attribute.
 ///
@@ -17,9 +16,9 @@ use self::proc_macro::TokenStream;
 /// - `DllGetClassObject` extern function implementation.
 /// - `IntercomListClassObjects` extern function implementation.
 pub fn expand_com_library(
-    attr_tokens: &TokenStream,
-    item_tokens: TokenStream,
-) -> Result<TokenStream, model::ParseError>
+    attr_tokens: &TokenStreamNightly,
+    item_tokens: TokenStreamNightly,
+) -> Result<TokenStreamNightly, model::ParseError>
 {
     let mut output = vec![];
     let lib = model::ComLibrary::parse( &lib_name(), &attr_tokens.to_string() )?;
@@ -30,7 +29,7 @@ pub fn expand_com_library(
     for struct_ident in lib.coclasses() {
 
         // Construct the match pattern.
-        let clsid_name = idents::clsid( *struct_ident );
+        let clsid_name = idents::clsid( struct_ident );
         match_arms.push( quote!(
             self::#clsid_name =>
                 Ok( ::intercom::ComBox::new(
@@ -86,8 +85,8 @@ pub fn expand_com_library(
 }
 
 fn get_dll_get_class_object_function(
-    match_arms: &[quote::Tokens]
-) -> quote::Tokens
+    match_arms: &[TokenStream]
+) -> TokenStream
 {
     let calling_convetion = get_calling_convetion();
     quote!(
@@ -126,8 +125,8 @@ fn get_dll_get_class_object_function(
 }
 
 fn get_intercom_list_class_objects_function(
-    clsid_tokens: &[quote::Tokens]
-) -> quote::Tokens
+    clsid_tokens: &[TokenStream]
+) -> TokenStream
 {
     let calling_convetion = get_calling_convetion();
     let token_count = clsid_tokens.len();

--- a/intercom-common/src/attributes/common.rs
+++ b/intercom-common/src/attributes/common.rs
@@ -1,10 +1,10 @@
 
+use prelude::*;
+
 use std;
 use std::env;
 use std::iter::FromIterator;
 
-extern crate proc_macro;
-use self::proc_macro::TokenStream;
 use quote;
 
 /// Resolve the name of the package being compiled.
@@ -17,12 +17,12 @@ pub fn lib_name() -> String {
                  Ensure CARGO_PKG_NAME environment variable is defined." )
 }
 
-pub fn tokens_to_tokenstream<T: IntoIterator<Item=quote::Tokens>>(
-    original : TokenStream,
+pub fn tokens_to_tokenstream<T: IntoIterator<Item=TokenStream>>(
+    original : TokenStreamNightly,
     tokens : T,
-) -> TokenStream
+) -> TokenStreamNightly
 {
-    TokenStream::from_iter(
+    TokenStreamNightly::from_iter(
         std::iter::once( original )
             .chain( tokens.into_iter().map( |t| t.into() ) ) )
 }

--- a/intercom-common/src/attributes/common.rs
+++ b/intercom-common/src/attributes/common.rs
@@ -5,8 +5,6 @@ use std;
 use std::env;
 use std::iter::FromIterator;
 
-use quote;
-
 /// Resolve the name of the package being compiled.
 pub fn lib_name() -> String {
 

--- a/intercom-common/src/builtin_model.rs
+++ b/intercom-common/src/builtin_model.rs
@@ -2,13 +2,14 @@
 //! Defines the default Intercom type model.
 //!
 
+use prelude::*;
 use model::{ ComInterface, ComStruct, ComImpl };
 
 pub struct BuiltinTypeInfo {
     pub interface: ComInterface,
     pub class: ComStruct,
     pub implementation: ComImpl,
-    pub ctor : ::quote::Tokens,
+    pub ctor : TokenStream,
 }
 
 pub fn builtin_intercom_types( lib_name: &str ) -> Vec<BuiltinTypeInfo> {

--- a/intercom-common/src/foreign_ty.rs
+++ b/intercom-common/src/foreign_ty.rs
@@ -1,5 +1,6 @@
 extern crate std;
 
+use prelude::*;
 use model::ComCrate;
 use syn;
 use type_parser::*;
@@ -7,7 +8,7 @@ use type_parser::*;
 pub trait ForeignTypeHandler
 {
     /// Gets the name for the 'ty'.
-    fn get_name( &self, krate : &ComCrate, ty : syn::Ident ) -> String;
+    fn get_name( &self, krate : &ComCrate, ty : &Ident ) -> String;
 
     /// Gets the COM type for a Rust type.
     fn get_ty<'a, 'b: 'a>(
@@ -24,10 +25,10 @@ impl ForeignTypeHandler for CTypeHandler
     fn get_name(
         &self,
         krate: &ComCrate,
-        ident: syn::Ident,
+        ident: &Ident,
     ) -> String
     {
-        self.get_name_for_ty( krate, ident.as_ref() )
+        self.get_name_for_ty( krate, &ident.to_string() )
     }
 
     fn get_ty<'a, 'b: 'a>(

--- a/intercom-common/src/generators/cpp.rs
+++ b/intercom-common/src/generators/cpp.rs
@@ -224,7 +224,7 @@ impl CppModel {
                         .ok_or_else( || GeneratorError::UnsupportedType(
                                         utils::ty_to_string( &ret_ty ) ) )?;
                 Ok( CppMethod {
-                    name: utils::pascal_case( m.name.as_ref() ),
+                    name: utils::pascal_case( m.name.to_string() ),
                     ret_type: ret_ty.to_cpp( methodinfo::Direction::Retval, c ),
                     args
                 } )
@@ -234,7 +234,7 @@ impl CppModel {
             Ok( CppInterface {
                 name: foreign.get_name( c, itf.name() ),
                 iid_struct: guid_as_struct( itf.iid() ),
-                base: itf.base_interface().as_ref().map( |i| foreign.get_name( c, *i ) ),
+                base: itf.base_interface().as_ref().map( |i| foreign.get_name( c, i ) ),
                 methods,
             } )
 
@@ -244,11 +244,11 @@ impl CppModel {
         let classes = lib.coclasses().iter().map( |class_name| {
 
             // Get the class details by matching the name.
-            let coclass  = &c.structs()[ class_name.as_ref() ];
+            let coclass  = &c.structs()[ &class_name.to_string() ];
 
             // Create a list of interfaces to be declared in the class descriptor.
             let interfaces = coclass.interfaces().iter().map(|itf_name| {
-                foreign.get_name( c, *itf_name )
+                foreign.get_name( c, itf_name )
             } ).collect();
 
             let clsid = coclass.clsid().as_ref()

--- a/intercom-common/src/generators/idl.rs
+++ b/intercom-common/src/generators/idl.rs
@@ -132,7 +132,7 @@ impl IdlModel {
                         .ok_or_else( || GeneratorError::UnsupportedType(
                                         utils::ty_to_string( &ret_ty ) ) )?;
                 Ok( IdlMethod {
-                    name: utils::pascal_case( m.name.as_ref() ),
+                    name: utils::pascal_case( m.name.to_string() ),
                     idx: i,
                     ret_type: ret_ty.to_idl( c ),
                     args
@@ -144,7 +144,7 @@ impl IdlModel {
             // interface definition.
             Ok( IdlInterface {
                 name: foreign.get_name( c, itf.name() ),
-                base: itf.base_interface().as_ref().map( |i| foreign.get_name( c, *i ) ),
+                base: itf.base_interface().as_ref().map( |i| foreign.get_name( c, i ) ),
                 iid: format!( "{:-X}", itf.iid() ),
                 methods,
             } )
@@ -160,11 +160,11 @@ impl IdlModel {
         let classes = lib.coclasses().iter().map(|class_name| {
 
             // Get the class details by matching the name.
-            let coclass = &c.structs()[ class_name.as_ref() ];
+            let coclass = &c.structs()[ &class_name.to_string() ];
 
             // Get the interfaces the class implements.
             let interfaces = coclass.interfaces().iter().map(|itf_name| {
-                foreign.get_name( c, *itf_name )
+                foreign.get_name( c, itf_name )
             } ).collect();
 
             let clsid = coclass.clsid().as_ref()

--- a/intercom-common/src/generators/manifest.rs
+++ b/intercom-common/src/generators/manifest.rs
@@ -49,7 +49,7 @@ impl ManifestModel {
         // Gather all the com classes. These need to be declared in the manifest.
         let classes = lib.coclasses().iter().map(|class_name| {
 
-            let coclass = &c.structs()[ class_name.as_ref() ];
+            let coclass = &c.structs()[ &class_name.to_string() ];
             let clsid = coclass.clsid().as_ref()
                     .ok_or_else( || GeneratorError::MissingClsid(
                                         coclass.name().to_string() ) )?;

--- a/intercom-common/src/idents.rs
+++ b/intercom-common/src/idents.rs
@@ -1,59 +1,64 @@
 
+use prelude::*;
 use syn::*;
 
 pub fn clsid(
-    struct_name: Ident
+    struct_name: &Ident
 ) -> Ident
 {
-    Ident::from( format!( "CLSID_{}", struct_name ) )
+    new_ident( &format!( "CLSID_{}", struct_name ) )
 }
 
 pub fn iid(
-    itf_name: Ident
+    itf_name: &Ident
 ) -> Ident
 {
-    Ident::from( format!( "IID_{}", itf_name ) )
+    new_ident( &format!( "IID_{}", itf_name ) )
 }
 
 pub fn method_impl(
-    struct_ident : Ident,
-    itf_ident : Ident,
+    struct_ident : &Ident,
+    itf_ident : &Ident,
     method_name: &str
 ) -> Ident
 {
-    Ident::from( format!( "__{}_{}_{}",
+    new_ident( &format!( "__{}_{}_{}",
             struct_ident, itf_ident, method_name ) )
 }
 
 pub fn vtable_struct(
-    itf_ident : Ident
+    itf_ident : &Ident
 ) -> Ident
 {
-    Ident::from( format!( "__{}Vtbl", itf_ident ) )
+    new_ident( &format!( "__{}Vtbl", itf_ident ) )
 }
 
 pub fn vtable_instance(
-    struct_name : Ident,
-    itf_ident : Ident,
+    struct_name : &Ident,
+    itf_ident : &Ident,
 ) -> Ident
 {
-    Ident::from( format!( "__{}_{}Vtbl_INSTANCE",
+    new_ident( &format!( "__{}_{}Vtbl_INSTANCE",
                         struct_name,
                         itf_ident ) )
 }
 
 pub fn vtable_list(
-    struct_ident : Ident
+    struct_ident : &Ident
 ) -> Ident
 {
-    Ident::from( format!( "__{}VtblList", struct_ident ) )
+    new_ident( &format!( "__{}VtblList", struct_ident ) )
 }
 
 pub fn vtable_offset(
-    s : Ident,
-    i : Ident
+    s : &Ident,
+    i : &Ident
 ) -> Ident
 {
-    Ident::from( format!( "__{}_{}Vtbl_offset", s, i ) )
+    new_ident( &format!( "__{}_{}Vtbl_offset", s, i ) )
 }
 
+
+fn new_ident( s : &str ) -> Ident {
+    Ident::new( s, Span::call_site() )
+}

--- a/intercom-common/src/lib.rs
+++ b/intercom-common/src/lib.rs
@@ -3,6 +3,7 @@
 
 #[macro_use] extern crate quote;
 #[macro_use] extern crate syn;
+extern crate proc_macro2;
 extern crate sha1;
 extern crate ordermap;
 extern crate toml;
@@ -26,3 +27,4 @@ pub mod builtin_model;
 pub mod foreign_ty;
 pub mod attributes;
 pub mod type_parser;
+pub mod prelude;

--- a/intercom-common/src/methodinfo.rs
+++ b/intercom-common/src/methodinfo.rs
@@ -227,6 +227,8 @@ fn hresult_ty() -> Type {
 
 #[cfg(test)]
 mod tests {
+
+    use prelude::*;
     use super::*;
 
     #[test]
@@ -299,10 +301,10 @@ mod tests {
 
         assert_eq!( info.args.len(), 2 );
 
-        assert_eq!( info.args[0].name, Ident::from( "a" ) );
+        assert_eq!( info.args[0].name, Ident::new( "a", Span::call_site() ) );
         assert_eq!( info.args[0].ty, parse_quote!( u32 ) );
 
-        assert_eq!( info.args[1].name, Ident::from( "b" ) );
+        assert_eq!( info.args[1].name, Ident::new( "b", Span::call_site() ) );
         assert_eq!( info.args[1].ty, parse_quote!( f32 ) );
     }
 
@@ -310,7 +312,7 @@ mod tests {
 
         let item = parse_str( code ).unwrap();
         let ( ident, decl, unsafety ) = match item {
-            Item::Fn( ref f ) => ( f.ident, f.decl.as_ref(), f.unsafety.is_some() ),
+            Item::Fn( ref f ) => ( f.ident.clone(), f.decl.as_ref(), f.unsafety.is_some() ),
             _ => panic!( "Code isn't function" ),
         };
         ComMethodInfo::new_from_parts( ident, decl, unsafety ).unwrap()

--- a/intercom-common/src/methodinfo.rs
+++ b/intercom-common/src/methodinfo.rs
@@ -98,7 +98,7 @@ impl ComMethodInfo {
         m : &MethodSig
     ) -> Result<ComMethodInfo, ComMethodInfoError>
     {
-        Self::new_from_parts( m.ident, &m.decl, m.unsafety.is_some() )
+        Self::new_from_parts( m.ident.clone(), &m.decl, m.unsafety.is_some() )
     }
 
     pub fn new_from_parts(

--- a/intercom-common/src/prelude.rs
+++ b/intercom-common/src/prelude.rs
@@ -1,0 +1,7 @@
+
+extern crate proc_macro;
+pub use proc_macro2::{Span, TokenStream};
+pub use syn::Ident;
+
+pub use self::proc_macro::TokenStream as TokenStreamNightly;
+

--- a/intercom-common/src/utils.rs
+++ b/intercom-common/src/utils.rs
@@ -1,7 +1,7 @@
 
+use prelude::*;
 use syn::*;
 use syn::synom::Parser;
-use quote::{Tokens};
 
 use error::MacroError;
 use super::*;
@@ -56,7 +56,7 @@ pub fn get_ident_and_fns(
                         *unsafety ) )
             },
         Item::Trait( ItemTrait {
-                ident,
+                ref ident,
                 unsafety,
                 ref items,
                 .. } )
@@ -69,7 +69,7 @@ pub fn get_ident_and_fns(
 
             match methods {
                 Some( m ) => Some( (
-                        ident,
+                        ident.clone(),
                         m,
                         InterfaceType::Trait,
                         unsafety,
@@ -191,7 +191,7 @@ pub fn parameter_to_guid(
 ) -> Result< Option< guid::GUID >, String >
 {
     if let AttrParam::Word( ref i ) = *p {
-        return Ok( match i.as_ref() {
+        return Ok( match i.to_string().as_ref() {
             "AUTO_GUID" =>
                 Some( generate_guid( crate_name, item_name, item_type ) ),
             "NO_GUID" =>
@@ -278,7 +278,7 @@ pub fn unit_ty() -> Type
 
 pub fn get_guid_tokens(
     g : &guid::GUID
-) -> Tokens
+) -> TokenStream
 {
     let d1 = g.data1;
     let d2 = g.data2;
@@ -300,7 +300,8 @@ pub fn get_guid_tokens(
 }
 
 /// Convert the Rust identifier from `snake_case` to `PascalCase`
-pub fn pascal_case( input : &str ) -> String {
+pub fn pascal_case<T: AsRef<str>>( input : T ) -> String {
+    let input = input.as_ref();
 
     // Allocate the output string. We'll never increase the amount of
     // characters so we can reserve string buffer using the input string length.


### PR DESCRIPTION
Figured we'd need this at some point anyway and I wanted the `custom_keyword!` macro for parsing attribute parameters.

Also fun times moving from `Ident` to `&Ident` again after going the other way to satisfy Clippy a while back. \o/

(Most of the changes are simple `Ident` <-> `&Ident` changes.)