### PR TITLE
Update to syn 0.15

### DIFF
--- a/intercom-attributes/Cargo.toml
+++ b/intercom-attributes/Cargo.toml
@@ -12,7 +12,7 @@ proc-macro = true
 
 [dependencies]
 intercom-common = { version = "0.2.0", path = "../intercom-common" }
-syn = { version = "0.14", features = [ "full" ] }
+syn = { version = "0.15", features = [ "full" ] }
 quote = { version = "0.6" }
 
 [dev-dependencies]

--- a/intercom-common/Cargo.toml
+++ b/intercom-common/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/Rantanen/intercom"
 description = "See 'intercom'"
 
 [dependencies]
-syn = { version = "0.14", features = [ "full", "extra-traits", "parsing" ] }
+syn = { version = "0.15", features = [ "full", "extra-traits", "parsing" ] }
 quote = { version = "0.6" }
 proc-macro2 = "0.4"
 sha1 = "0.3.0"

--- a/intercom-common/src/ast_converters.rs
+++ b/intercom-common/src/ast_converters.rs
@@ -148,6 +148,8 @@ impl GetIdent for Item {
             Item::Impl( ref i ) => return i.self_ty.get_ident(),
             Item::Macro( ref m ) => return m.mac.path.get_ident(),
             Item::Macro2( ref i ) => i.ident.clone(),
+            Item::Existential( ref i ) => i.ident.clone(),
+            Item::TraitAlias( ref i ) => i.ident.clone(),
 
             Item::Use( .. )
                 | Item::ForeignMod( .. )
@@ -183,6 +185,8 @@ impl GetAttributes for Item {
             Item::Macro2( ref i ) => i.attrs.clone(),
             Item::Use( ref i ) => i.attrs.clone(),
             Item::ForeignMod( ref i ) => i.attrs.clone(),
+            Item::Existential( ref i ) => i.attrs.clone(),
+            Item::TraitAlias( ref i ) => i.attrs.clone(),
             Item::Verbatim( .. ) => vec![],
         } )
     }

--- a/intercom-common/src/model/comstruct.rs
+++ b/intercom-common/src/model/comstruct.rs
@@ -48,9 +48,9 @@ impl ComStruct
     ) -> ParseResult< ComStruct >
     {
         let attr : ComStructAttr = ::syn::parse2( attr_params )
-            .map_err( |_| ParseError::ComStruct(
+            .map_err( |e| ParseError::ComStruct(
                     item.ident.to_string(),
-                    "Attribute syntax error".into() ) )?;
+                    format!( "Attribute syntax error: {}", e ) ) )?;
 
         // First attribute parameter is the CLSID. Parse it.
         let clsid_attr = attr.clsid()

--- a/intercom-common/src/model/macros.rs
+++ b/intercom-common/src/model/macros.rs
@@ -31,7 +31,7 @@ impl Parse for StrOption {
             return Ok( StrOption::None );
         }
 
-        return Err( input.error( "Expected string or `None`" ) );
+        Err( input.error( "Expected string or `None`" ) )
     }
 }
 

--- a/intercom-common/src/model/macros.rs
+++ b/intercom-common/src/model/macros.rs
@@ -1,23 +1,38 @@
 
-/// Type that implements `Synom` but fails parsing.
+use syn::parse::{Parse, ParseStream, Result};
+
+/// An empty type that cannot be parsed.
 ///
-/// Use this for defining attribute parsing that accepts only named arguments.
+/// Used especially with attributes that don't take positional arguments.
+#[derive(Debug)]
 pub enum NoParams {}
-impl ::syn::synom::Synom for NoParams {
-    named!(parse -> Self, reject!() );
+impl Parse for NoParams {
+    fn parse( input: ParseStream ) -> Result<Self> {
+        Err( input.error( "Attribute does not accept positional parameters" ) )
+    }
 }
 
 /// Literal string or 'None' if there should be no value.
+#[derive(Debug)]
 pub enum StrOption {
     Str( ::syn::LitStr ),
     None
 }
-impl ::syn::synom::Synom for StrOption {
-    named!(parse -> Self, alt!(
-        syn!( ::syn::LitStr ) => { StrOption::Str }
-        |
-        custom_keyword!( None ) => { |_| StrOption::None }
-    ) );
+
+impl Parse for StrOption {
+    fn parse( input: ParseStream ) -> Result<Self> {
+
+        if input.peek( ::syn::LitStr ) {
+            return Ok( StrOption::Str( input.parse()? ) );
+        }
+
+        let ident : ::syn::Ident = input.parse()?;
+        if ident == "None" {
+            return Ok( StrOption::None );
+        }
+
+        return Err( input.error( "Expected string or `None`" ) );
+    }
 }
 
 /// Defines intercom attribute parameter parsing.
@@ -44,52 +59,46 @@ macro_rules! intercom_attribute {
     ( $attr:ident < $attr_param:ident, $params:ident > { $( $name:ident : $type:ident, )* } ) => {
 
         #[allow(non_camel_case_types)]
+        #[derive(Debug)]
         enum $attr_param {
             $( $name ( $type ), )*
             args( $params ),
         }
 
-        impl ::syn::synom::Synom for $attr_param {
-            named!( parse -> Self, alt!(
-                $(
-                    do_parse!(
-                        custom_keyword!( $name ) >>
-                        punct!(=) >>
-                        value : syn!( $type ) >>
-                        ( $attr_param::$name( value ) )
-                    )
-                    |
-                )*
-                do_parse!( a : syn!( $params ) >> ( $attr_param::args( a ) ) )
-            ) );
+        impl ::syn::parse::Parse for $attr_param {
+            fn parse( input : ::syn::parse::ParseStream ) -> ::syn::parse::Result<Self> {
+
+                if ! input.peek2( Token![=] ) {
+                    return Ok( $attr_param::args( input.parse()? ) );
+                }
+
+                let ident : ::syn::Ident = input.parse()?;
+                let _punct : Token![=] = input.parse()?;
+                Ok( match ident.to_string().as_ref() {
+                    $(
+                        stringify!( $name ) => $attr_param::$name( input.parse()? ),
+                    )*
+                    other => return Err( input.error( format!( "Unexpected parameter: `{}`", other ) ) )
+                } )
+            }
         }
 
         struct $attr( Vec<$attr_param> );
-        impl ::syn::synom::Synom for $attr {
-            named!(parse -> Self, alt!(
+        impl ::syn::parse::Parse for $attr {
+            fn parse( input : ::syn::parse::ParseStream ) -> ::syn::parse::Result<Self> {
 
                 // When parsing #[foo(bar)] attributes with syn, syn will include
                 // the parenthess in the tts:
                 // > ( bar )
-                do_parse!(
-                    p: parens!( call!( ::syn::punctuated::Punctuated::<$attr_param, ::syn::token::Comma>::parse_terminated ) ) >>
-                    ( $attr( p.1.into_iter().collect() ) )
-                )
+                let params = match ::syn::group::parse_parens( &input ) {
+                    Ok( parens ) => parens.content.call(
+                        ::syn::punctuated::Punctuated::<$attr_param, ::syn::token::Comma>::parse_terminated )?,
+                    Err( _ ) => input.call(
+                        ::syn::punctuated::Punctuated::<$attr_param, ::syn::token::Comma>::parse_terminated )?,
+                };
 
-                |
-
-                // When the same attribute appears as a proc macro attribute, rustc will omit the
-                // parentheses from the parameter tokens:
-                // > bar
-                //
-                // This also supports empty token streams, which occur with empty parentheses
-                // "#[foo()]" in proc macros or omitting parentheses "#[foo]" in both proc macros
-                // and syn.
-                do_parse!(
-                    p: call!( ::syn::punctuated::Punctuated::<$attr_param, ::syn::token::Comma>::parse_terminated ) >>
-                    ( $attr( p.into_iter().collect() ) )
-                )
-            ) );
+                Ok( $attr( params.into_iter().collect() ) )
+            }
         }
 
         #[allow(dead_code)]


### PR DESCRIPTION
The only real change was the change from a Nom-styled parser to a new parser API.

This meant rewriting the attribute parameter parsing logic.