### PR TITLE
Raw type system support for strings

### DIFF
--- a/intercom-attributes/tests/data/com_impl.source.rs
+++ b/intercom-attributes/tests/data/com_impl.source.rs
@@ -36,6 +36,7 @@ impl Foo
     fn tuple_result_method(&self) -> Result<(u8, u16, u32), i32> { Ok(0) }
 
     fn string_method(&self, input : String) -> String { input }
+    fn string_result_method(&self, input : String) -> ComResult<String> { Ok(input) }
 
     fn complete_method(&mut self, a: u16, b: i16) -> ComResult<bool>
     {

--- a/intercom-attributes/tests/data/com_impl.target.rs
+++ b/intercom-attributes/tests/data/com_impl.target.rs
@@ -120,6 +120,9 @@ impl Foo {
     fn tuple_result_method(&self) -> Result<(u8, u16, u32), i32> { Ok(0) }
 
     fn string_method(&self, input: String) -> String { input }
+    fn string_result_method(&self, input: String) -> ComResult<String> {
+        Ok(input)
+    }
 
     fn complete_method(&mut self, a: u16, b: i16) -> ComResult<bool> {
         Ok(true)
@@ -370,13 +373,61 @@ unsafe extern "C" fn __Foo_Foo_Automation_string_method_Automation(self_vtable:
                  let __result =
                      self_struct.string_method(<String as
                                                    ::intercom::FromWithTemporary<&::intercom::BStr>>::from_temporary(&mut __input_temporary)?);
-                 Ok({ ::intercom::BString::from(__result).into_ptr() })
+                 Ok({
+                        ::intercom::ComInto::<::intercom::BString>::com_into(__result)?.into_ptr()
+                    })
              })();
     use ::intercom::ErrorValue;
     match result {
         Ok(v) => v,
         Err(err) =>
         <::intercom::raw::OutBSTR as
+            ErrorValue>::from_error(::intercom::return_hresult(err)),
+    }
+}
+#[allow(non_snake_case)]
+#[allow(dead_code)]
+#[doc(hidden)]
+unsafe extern "C" fn __Foo_Foo_Automation_string_result_method_Automation(self_vtable:
+                                                                                    ::intercom::RawComPtr,
+                                                                                input:
+                                                                                    ::intercom::raw::InBSTR,
+                                                                                __out:
+                                                                                    *mut ::intercom::raw::OutBSTR)
+ -> ::intercom::HRESULT {
+    let result: Result<::intercom::HRESULT, ::intercom::ComError> =
+        (||
+             {
+                 let self_combox =
+                     (self_vtable as usize -
+                          __Foo_Foo_AutomationVtbl_offset()) as
+                         *mut ::intercom::ComBox<Foo>;
+                 let mut __input_temporary =
+                     <String as
+                         ::intercom::FromWithTemporary<&::intercom::BStr>>::to_temporary(::intercom::BStr::from_ptr(input))?;
+                 let self_struct: &Foo = &**self_combox;
+                 let __result =
+                     self_struct.string_result_method(<String as
+                                                          ::intercom::FromWithTemporary<&::intercom::BStr>>::from_temporary(&mut __input_temporary)?);
+                 Ok({
+                        match __result {
+                            Ok(v1) => {
+                                *__out =
+                                    ::intercom::ComInto::<::intercom::BString>::com_into(v1)?.into_ptr();
+                                ::intercom::S_OK
+                            }
+                            Err(e) => {
+                                *__out = ::std::ptr::null_mut();
+                                ::intercom::return_hresult(e)
+                            }
+                        }
+                    })
+             })();
+    use ::intercom::ErrorValue;
+    match result {
+        Ok(v) => v,
+        Err(err) =>
+        <::intercom::HRESULT as
             ErrorValue>::from_error(::intercom::return_hresult(err)),
     }
 }
@@ -443,6 +494,8 @@ const __Foo_Foo_AutomationVtbl_INSTANCE: __Foo_AutomationVtbl =
                              __Foo_Foo_Automation_tuple_result_method_Automation,
                          string_method_Automation:
                              __Foo_Foo_Automation_string_method_Automation,
+                         string_result_method_Automation:
+                             __Foo_Foo_Automation_string_result_method_Automation,
                          complete_method_Automation:
                              __Foo_Foo_Automation_complete_method_Automation,};
 #[allow(non_snake_case)]
@@ -667,9 +720,9 @@ unsafe extern "C" fn __Foo_Foo_Raw_tuple_result_method_Raw(self_vtable:
 unsafe extern "C" fn __Foo_Foo_Raw_string_method_Raw(self_vtable:
                                                                ::intercom::RawComPtr,
                                                            input:
-                                                               ::intercom::raw::InBSTR)
- -> ::intercom::raw::OutBSTR {
-    let result: Result<::intercom::raw::OutBSTR, ::intercom::ComError> =
+                                                               ::intercom::raw::InCStr)
+ -> ::intercom::raw::OutCStr {
+    let result: Result<::intercom::raw::OutCStr, ::intercom::ComError> =
         (||
              {
                  let self_combox =
@@ -677,18 +730,65 @@ unsafe extern "C" fn __Foo_Foo_Raw_string_method_Raw(self_vtable:
                          *mut ::intercom::ComBox<Foo>;
                  let mut __input_temporary =
                      <String as
-                         ::intercom::FromWithTemporary<&::intercom::BStr>>::to_temporary(::intercom::BStr::from_ptr(input))?;
+                         ::intercom::FromWithTemporary<&::intercom::CStr>>::to_temporary(::intercom::CStr::from_ptr(input))?;
                  let self_struct: &Foo = &**self_combox;
                  let __result =
                      self_struct.string_method(<String as
-                                                   ::intercom::FromWithTemporary<&::intercom::BStr>>::from_temporary(&mut __input_temporary)?);
-                 Ok({ ::intercom::BString::from(__result).into_ptr() })
+                                                   ::intercom::FromWithTemporary<&::intercom::CStr>>::from_temporary(&mut __input_temporary)?);
+                 Ok({
+                        ::intercom::ComInto::<::intercom::CString>::com_into(__result)?.into_raw()
+                    })
              })();
     use ::intercom::ErrorValue;
     match result {
         Ok(v) => v,
         Err(err) =>
-        <::intercom::raw::OutBSTR as
+        <::intercom::raw::OutCStr as
+            ErrorValue>::from_error(::intercom::return_hresult(err)),
+    }
+}
+#[allow(non_snake_case)]
+#[allow(dead_code)]
+#[doc(hidden)]
+unsafe extern "C" fn __Foo_Foo_Raw_string_result_method_Raw(self_vtable:
+                                                                      ::intercom::RawComPtr,
+                                                                  input:
+                                                                      ::intercom::raw::InCStr,
+                                                                  __out:
+                                                                      *mut ::intercom::raw::OutCStr)
+ -> ::intercom::HRESULT {
+    let result: Result<::intercom::HRESULT, ::intercom::ComError> =
+        (||
+             {
+                 let self_combox =
+                     (self_vtable as usize - __Foo_Foo_RawVtbl_offset()) as
+                         *mut ::intercom::ComBox<Foo>;
+                 let mut __input_temporary =
+                     <String as
+                         ::intercom::FromWithTemporary<&::intercom::CStr>>::to_temporary(::intercom::CStr::from_ptr(input))?;
+                 let self_struct: &Foo = &**self_combox;
+                 let __result =
+                     self_struct.string_result_method(<String as
+                                                          ::intercom::FromWithTemporary<&::intercom::CStr>>::from_temporary(&mut __input_temporary)?);
+                 Ok({
+                        match __result {
+                            Ok(v1) => {
+                                *__out =
+                                    ::intercom::ComInto::<::intercom::CString>::com_into(v1)?.into_raw();
+                                ::intercom::S_OK
+                            }
+                            Err(e) => {
+                                *__out = ::std::ptr::null_mut();
+                                ::intercom::return_hresult(e)
+                            }
+                        }
+                    })
+             })();
+    use ::intercom::ErrorValue;
+    match result {
+        Ok(v) => v,
+        Err(err) =>
+        <::intercom::HRESULT as
             ErrorValue>::from_error(::intercom::return_hresult(err)),
     }
 }
@@ -746,5 +846,7 @@ const __Foo_Foo_RawVtbl_INSTANCE: __Foo_RawVtbl =
                   tuple_result_method_Raw:
                       __Foo_Foo_Raw_tuple_result_method_Raw,
                   string_method_Raw: __Foo_Foo_Raw_string_method_Raw,
+                  string_result_method_Raw:
+                      __Foo_Foo_Raw_string_result_method_Raw,
                   complete_method_Raw: __Foo_Foo_Raw_complete_method_Raw,};
 impl ::intercom::HasInterface<Foo> for Foo { }

--- a/intercom-attributes/tests/data/com_interface.target.rs
+++ b/intercom-attributes/tests/data/com_interface.target.rs
@@ -347,8 +347,8 @@ pub struct __Foo_RawVtbl {
     pub string_method_Raw: unsafe extern "C" fn(self_vtable:
                                                           ::intercom::RawComPtr,
                                                       msg:
-                                                          ::intercom::raw::InBSTR)
-                               -> ::intercom::raw::OutBSTR,
+                                                          ::intercom::raw::InCStr)
+                               -> ::intercom::raw::OutCStr,
     pub comitf_method_Raw: unsafe extern "C" fn(self_vtable:
                                                           ::intercom::RawComPtr,
                                                       itf:

--- a/intercom-common/src/generators/cpp.rs
+++ b/intercom-common/src/generators/cpp.rs
@@ -143,6 +143,7 @@ impl<'s> CppTypeInfo<'s> for TypeInfo<'s> {
         match type_name.as_str() {
             "RawComPtr" => "*void".to_owned(),
             "InBSTR" | "OutBSTR" => "intercom::BSTR".to_owned(),
+            "InCStr" | "OutCStr" => "char*".to_owned(),
             "usize" => "size_t".to_owned(),
             "i8" => "int8_t".to_owned(),
             "u8" => "uint8_t".to_owned(),

--- a/intercom-common/src/generators/cpp.rs
+++ b/intercom-common/src/generators/cpp.rs
@@ -461,7 +461,7 @@ mod test {
                     methods : vec![
                         CppMethod {
                             name : "AllocBstr".to_owned(),
-                            ret_type : "intercom::BSTR".to_owned(),
+                            ret_type : "char*".to_owned(),
                             args : vec![
                                 CppArg {
                                     name : "text".to_owned(),
@@ -479,7 +479,7 @@ mod test {
                             args : vec![
                                 CppArg {
                                     name : "bstr".to_owned(),
-                                    arg_type : "intercom::BSTR".to_owned(),
+                                    arg_type : "char*".to_owned(),
                                 },
                             ]
                         },
@@ -545,18 +545,18 @@ mod test {
             #[com_impl]
             impl CoClass {
                 pub fn new() -> CoClass { CoClass }
-                pub fn bstr_method( &self, b : String ) -> String {}
+                pub fn cstr_method( &self, b : String ) -> String {}
             }
         "# ] ).expect( "Could not parse test crate" );
 
         let expected_method =
             CppMethod {
-                name : "BstrMethod".to_owned(),
-                ret_type : "intercom::BSTR".to_owned(),
+                name : "CstrMethod".to_owned(),
+                ret_type : "char*".to_owned(),
                 args : vec![
                     CppArg {
                         name : "b".to_owned(),
-                        arg_type : "intercom::BSTR".to_owned(),
+                        arg_type : "char*".to_owned(),
                     },
                 ]
             };
@@ -570,7 +570,7 @@ mod test {
                         .unwrap()
                     .methods
                         .iter()
-                        .find( |m| m.name == "BstrMethod" )
+                        .find( |m| m.name == "CstrMethod" )
                         .unwrap();
 
         assert_eq!( &expected_method, actual_method );

--- a/intercom-common/src/generators/idl.rs
+++ b/intercom-common/src/generators/idl.rs
@@ -304,6 +304,7 @@ impl<'s> IdlTypeInfo<'s> for TypeInfo<'s> {
         match type_name.as_str() {
             "RawComPtr" => "void*".to_owned(),
             "InBSTR" | "OutBSTR" => "BSTR".to_owned(),
+            "InCStr" | "OutCStr" => "char*".to_owned(),
             "usize" => "size_t".to_owned(),
             "u64" => "uint64".to_owned(),
             "i64" => "int64".to_owned(),

--- a/intercom/src/lib.rs
+++ b/intercom/src/lib.rs
@@ -122,6 +122,9 @@ pub type REFCLSID = *const IID;
 pub mod raw {
     pub type InBSTR = *const u16;
     pub type OutBSTR = *mut u16;
+
+    pub type InCStr = *const ::std::os::raw::c_char;
+    pub type OutCStr = *mut ::std::os::raw::c_char;
     
     #[repr(C)]
     pub struct InterfacePtr<I: ?Sized> {

--- a/intercom/src/strings.rs
+++ b/intercom/src/strings.rs
@@ -355,14 +355,196 @@ impl<'a> FromWithTemporary<'a, String>
     }
 }
 
+impl<'a> FromWithTemporary<'a, &'a BStr>
+        for &'a CStr {
+
+    type Temporary = CString;
+
+    fn to_temporary( source : &'a BStr ) -> Result<Self::Temporary, ComError> {
+        let string = source.to_string()
+                .map_err( |_| ComError::new_hr( intercom::E_INVALIDARG ) )?;
+
+        CString::new( string )
+                .map_err( |_| ComError::new_hr( intercom::E_INVALIDARG ) )
+    }
+
+    fn from_temporary( temp : &'a mut Self::Temporary ) -> Result<Self, ComError> {
+        Ok( &**temp )
+    }
+}
+
 pub trait ComInto<TTarget> {
     fn com_into( self ) -> Result<TTarget, ComError>;
+}
+
+impl<T> ComInto<T> for T {
+    fn com_into( self ) -> Result<T, ComError> {
+        Ok( self )
+    }
 }
 
 impl ComInto<String> for BString {
     fn com_into( self ) -> Result<String, ComError> {
         let mut bstr : &BStr = &self;
-        String::from_temporary( &mut bstr )
+        < String as FromWithTemporary<&BStr> >::from_temporary( &mut bstr )
+    }
+}
+
+impl ComInto<BString> for String {
+    fn com_into( self ) -> Result<BString, ComError> {
+        Ok( BString::from( self ) )
+    }
+}
+
+impl ComInto<String> for CString {
+    fn com_into( self ) -> Result<String, ComError> {
+        self.into_string()
+                .map_err( |_| ComError::new_hr( intercom::E_INVALIDARG ) )
+    }
+}
+
+impl ComInto<CString> for String {
+    fn com_into( self ) -> Result<CString, ComError> {
+        CString::new( self )
+                .map_err( |_| ComError::new_hr( intercom::E_INVALIDARG ) )
+    }
+}
+
+impl ComInto<BString> for CString {
+    fn com_into( self ) -> Result<BString, ComError> {
+        self.to_str()
+                .map( BString::from )
+                .map_err( |_| ComError::new_hr( intercom::E_INVALIDARG ) )
+    }
+}
+
+impl ComInto<CString> for BString {
+    fn com_into( self ) -> Result<CString, ComError> {
+        let string = self.to_string()
+                .map_err( |_| ComError::new_hr( intercom::E_INVALIDARG ) )?;
+
+        CString::new( string )
+                .map_err( |_| ComError::new_hr( intercom::E_INVALIDARG ) )
+    }
+}
+
+pub type CStr = std::ffi::CStr;
+pub type CString = std::ffi::CString;
+
+impl<'a> FromWithTemporary<'a, &'a CStr > 
+        for CString {
+
+    type Temporary = &'a CStr;
+
+    fn to_temporary( cstr : &'a CStr ) -> Result<Self::Temporary, ComError> { Ok(cstr) }
+    fn from_temporary( temp : &'a mut Self::Temporary ) -> Result<Self, ComError> {
+        Ok( (*temp).to_owned() )
+    }
+}
+
+impl<'a> FromWithTemporary<'a, &'a CStr>
+        for &'a str {
+
+    type Temporary = String;
+
+    fn to_temporary( cstr : &'a CStr ) -> Result<Self::Temporary, ComError> {
+        cstr.to_str()
+            .map( |s| s.to_string() )
+            .map_err( |_| ComError::new_hr( intercom::E_INVALIDARG ) )
+    }
+
+    fn from_temporary( temp : &'a mut Self::Temporary ) -> Result<Self, ComError> {
+        Ok( &**temp ) 
+    }
+}
+
+impl<'a> FromWithTemporary<'a, &'a CStr>
+        for String {
+
+    type Temporary = &'a CStr;
+
+    fn to_temporary( cstr : &'a CStr ) -> Result<Self::Temporary, ComError> {
+        Ok( cstr )
+    }
+
+    fn from_temporary( temp : &'a mut Self::Temporary ) -> Result<Self, ComError> {
+        temp.to_str()
+            .map( |s| s.to_string() )
+            .map_err( |_| ComError::new_hr( intercom::E_INVALIDARG ) )
+    }
+}
+
+impl<'a> FromWithTemporary<'a, CString > 
+        for &'a CStr {
+
+    type Temporary = CString;
+
+    fn to_temporary( source : CString ) -> Result<Self::Temporary, ComError> {
+        Ok( source )
+    }
+
+    fn from_temporary( temp : &'a mut Self::Temporary ) -> Result<Self, ComError> {
+        Ok( &**temp )
+    }
+}
+
+impl<'a> FromWithTemporary<'a, &'a str>
+        for &'a CStr {
+
+    type Temporary = CString;
+
+    fn to_temporary( source : &'a str ) -> Result<Self::Temporary, ComError> {
+        CString::new( source ).map_err( |_| ComError::new_hr( intercom::E_INVALIDARG ) )
+    }
+
+    fn from_temporary( temp : &'a mut Self::Temporary ) -> Result<Self, ComError> {
+        Ok( &**temp )
+    }
+}
+
+impl<'a> FromWithTemporary<'a, String>
+        for &'a CStr {
+
+    type Temporary = CString;
+
+    fn to_temporary( source : String ) -> Result<Self::Temporary, ComError> {
+        CString::new( source ).map_err( |_| ComError::new_hr( intercom::E_INVALIDARG ) )
+    }
+
+    fn from_temporary( temp : &'a mut Self::Temporary ) -> Result<Self, ComError> {
+        Ok( &**temp )
+    }
+}
+
+impl<'a> FromWithTemporary<'a, &'a CStr>
+        for BString {
+
+    type Temporary = &'a CStr;
+
+    fn to_temporary( source : &'a CStr ) -> Result<Self::Temporary, ComError> {
+        Ok( source )
+    }
+
+    fn from_temporary( temp : &'a mut Self::Temporary ) -> Result<Self, ComError> {
+        temp.to_str()
+            .map( |s| s.into() )
+            .map_err( |_| ComError::new_hr( intercom::E_INVALIDARG ) )
+    }
+}
+
+impl<'a> FromWithTemporary<'a, &'a CStr>
+        for &'a BStr {
+
+    type Temporary = BString;
+
+    fn to_temporary( source : &'a CStr ) -> Result<Self::Temporary, ComError> {
+        source.to_str()
+            .map( |s| s.into() )
+            .map_err( |_| ComError::new_hr( intercom::E_INVALIDARG ) )
+    }
+
+    fn from_temporary( temp : &'a mut Self::Temporary ) -> Result<Self, ComError> {
+        Ok( &**temp )
     }
 }
 

--- a/test/cpp-raw/strings.cpp
+++ b/test/cpp-raw/strings.cpp
@@ -1,6 +1,8 @@
 
 #include <functional>
 #include <cstdint>
+#include <string>
+using std::char_traits;
 
 #include "../cpp-utility/os.hpp"
 #include "../cpp-utility/catch.hpp"
@@ -52,43 +54,70 @@ TEST_CASE( "Using BSTR in interface works" )
     REQUIRE( hr == intercom::SC_OK );
 
     // Construct string test interface.
-    IStringTests_Automation* pStringTests = nullptr;
+    IStringTests_Automation* pStringTestsAutomation = nullptr;
     hr = CreateInstance(
         CLSID_StringTests,
         IID_IStringTests_Automation,
-        &pStringTests );
+        &pStringTestsAutomation );
     REQUIRE( hr == intercom::SC_OK );
+
+	IStringTests_Raw* pStringTestsRaw = nullptr;
+	hr = pStringTestsAutomation->QueryInterface(
+			IID_IStringTests_Raw,
+			OUT reinterpret_cast< void** >( &pStringTestsRaw ) );
+	REQUIRE( hr == intercom::SC_OK );
+
+	const int DESC_IDX = 0;
+	const int UTF16_IDX = 1;
+	const int UTF8_IDX = 2;
+	std::tuple< const char*, const char16_t*, const char* > test_data[] = {
+		std::make_tuple(
+				"<empty>",
+				nullptr,
+				u8""
+		),
+		std::make_tuple( 
+				"\"Test\"",
+				u"Test",
+				u8"Test"
+		),
+		std::make_tuple( 
+				"Multibyte UTF-8",  // Scandinavian letters: öäå
+				u"\u00f6\u00e4\u00e5",
+				u8"\u00f6\u00e4\u00e5"
+		),
+		std::make_tuple( 
+				"Multibyte UTF-16",  // Crab: 🦀
+				u"\U0001F980",
+				u8"\U0001F980"
+		)
+	};
 
     SECTION( "String parameters work." )
     {
-        uint32_t multibyte_codepoint = 0x131d4;
-        uint32_t multibyte_high = 0xdc00 + ( 0x031d4 >> 10 );
-        uint32_t multibyte_low = 0xdc00 + ( 0x031d4 && 0x3ff );
-        
-
-        std::tuple< uint32_t, const char16_t*, const char* > test_data[] = {
-            std::make_tuple( 0, nullptr, "<empty>" ),
-            std::make_tuple( 4, u"Test", "\"Test\"" ),
-            std::make_tuple( 3, u"\u00f6\u00e4\u00e5", "Multibyte UTF-8" ),  // Scandinavian letters: öäå
-            std::make_tuple( 2, u"\U0001F980", "Multibyte UTF-16" ),  // Crab: 🦀
-        };
-
         for( uint32_t i = 0; i < sizeof( test_data ) / sizeof( *test_data ); i++ )
         {
-            auto& pair = test_data[ i ];
-            SECTION( std::string( "Passing BSTR: " ) + std::get<2>( pair ) )
+            auto& tuple = test_data[ i ];
+			const char* desc = std::get< DESC_IDX >( tuple );
+
+			const char16_t* utf16_text = std::get< UTF16_IDX >( tuple );
+			const size_t utf16_len = utf16_text == nullptr ? 0 : char_traits<char16_t>::length( utf16_text );
+			const uint32_t utf16_len32 = static_cast< uint32_t >( utf16_len );
+
+            SECTION( std::string( "Passing BSTR: " ) + desc )
             {
                 intercom::BSTR test_text = pAllocator->AllocBstr(
                         const_cast< uint16_t* >(
                             reinterpret_cast< const uint16_t* >(
-                                std::get<1>( pair ) ) ),
-                        std::get<0>( pair ) );
+								utf16_text ) ),
+						utf16_len32 );
 
+				// Check the allocation succeeded.
                 REQUIRE( test_text != nullptr );
-                REQUIRE( *reinterpret_cast< uint32_t* >( test_text - 2 ) == std::get<0>( pair ) * 2 );
+                REQUIRE( *reinterpret_cast< uint32_t* >( test_text - 2 ) == utf16_len32 * 2 );
 
                 uint32_t result;
-                intercom::HRESULT hr = pStringTests->StringToIndex( test_text, OUT &result );
+                intercom::HRESULT hr = pStringTestsAutomation->StringToIndex( test_text, OUT &result );
                 REQUIRE( hr == intercom::SC_OK );
 
                 pAllocator->FreeBstr( test_text );
@@ -96,16 +125,43 @@ TEST_CASE( "Using BSTR in interface works" )
                 REQUIRE( result == i );
             }
 
-            SECTION( std::string( "Receiving BSTR: " ) + std::get<2>( pair ) )
+            SECTION( std::string( "Receiving BSTR: " ) + desc )
             {
                 intercom::BSTR test_text = nullptr;
-                intercom::HRESULT hr = pStringTests->IndexToString( i, OUT &test_text );
+                intercom::HRESULT hr = pStringTestsAutomation->IndexToString( i, OUT &test_text );
                 REQUIRE( hr == intercom::SC_OK );
 
-                check_equal( std::get<0>( pair ), std::get<1>( pair ), test_text );
+                check_equal( utf16_len32, utf16_text, test_text );
 
                 pAllocator->FreeBstr( test_text );
             }
+
+			const char* utf8_text = std::get< UTF8_IDX >( tuple );
+			const size_t utf8_len = utf8_text == nullptr ? 0 : char_traits<char>::length( utf8_text );
+			const uint32_t utf8_len32 = static_cast< uint32_t >( utf8_len );
+
+            SECTION( std::string( "Passing C-string: " ) + desc )
+            {
+                uint32_t result;
+                intercom::HRESULT hr = pStringTestsRaw->StringToIndex(
+						const_cast< char* >( utf8_text ),
+						OUT &result );
+                REQUIRE( hr == intercom::SC_OK );
+
+                REQUIRE( result == i );
+            }
+
+            SECTION( std::string( "Receiving C-string: " ) + desc )
+            {
+                char* test_text = nullptr;
+                intercom::HRESULT hr = pStringTestsRaw->IndexToString( i, OUT &test_text );
+                REQUIRE( hr == intercom::SC_OK );
+
+				REQUIRE( strcmp( test_text, utf8_text ) == 0 );
+
+                pAllocator->Free( test_text );
+            }
+
         }
 
         SECTION( "BSTR into &intercom::BStr is not re-allocated" ) {
@@ -115,7 +171,7 @@ TEST_CASE( "Using BSTR in interface works" )
                         reinterpret_cast< const uint16_t* >( u"Test string" ) ),
                     11 );
 
-            intercom::HRESULT hr = pStringTests->BstrParameter(
+            intercom::HRESULT hr = pStringTestsAutomation->BstrParameter(
                     test_text, reinterpret_cast< uintptr_t >( test_text ) );
 
             pAllocator->FreeBstr( test_text );
@@ -128,7 +184,7 @@ TEST_CASE( "Using BSTR in interface works" )
             intercom::BSTR test_text = nullptr;
             uintptr_t test_ptr = 0;
 
-            intercom::HRESULT hr = pStringTests->BstrReturnValue(
+            intercom::HRESULT hr = pStringTestsAutomation->BstrReturnValue(
                     OUT &test_text,
                     OUT &test_ptr );
             REQUIRE( hr == intercom::SC_OK );
@@ -138,6 +194,32 @@ TEST_CASE( "Using BSTR in interface works" )
 
             pAllocator->FreeBstr( test_text );
         }
+
+        SECTION( "char* into &intercom::CStr is not re-allocated" ) {
+
+            char* test_text = u8"Test string";
+
+            intercom::HRESULT hr = pStringTestsRaw->CstrParameter(
+                    test_text, reinterpret_cast< uintptr_t >( test_text ) );
+
+            REQUIRE( hr == intercom::SC_OK );
+        }
+
+        SECTION( "BString return value is not re-allocated" ) {
+
+            char* test_text = nullptr;
+            uintptr_t test_ptr = 0;
+
+            intercom::HRESULT hr = pStringTestsRaw->CstrReturnValue(
+                    OUT &test_text,
+                    OUT &test_ptr );
+            REQUIRE( hr == intercom::SC_OK );
+
+            REQUIRE( test_text != nullptr );
+            REQUIRE( reinterpret_cast< uintptr_t >( test_text ) == test_ptr );
+
+            pAllocator->Free( test_text );
+        }
     }
 
     SECTION( "Invalid UTF-16 results in E_INVALIDARG" )
@@ -146,11 +228,13 @@ TEST_CASE( "Using BSTR in interface works" )
         uint16_t data[] = { 0xdfff, 0xd800 };
         intercom::BSTR test_text = pAllocator->AllocBstr( data, 2 );
 
-        intercom::HRESULT hr = pStringTests->InvalidString( test_text );
+        intercom::HRESULT hr = pStringTestsAutomation->InvalidString( test_text );
         REQUIRE( hr == intercom::EC_INVALIDARG );
 
         pAllocator->FreeBstr( test_text );
     }
 
-    REQUIRE( pStringTests->Release() == 0 );
+    REQUIRE( pAllocator->Release() == 0 );
+    REQUIRE( pStringTestsRaw->Release() == 1 );
+    REQUIRE( pStringTestsAutomation->Release() == 0 );
 }

--- a/test/testlib/src/lib.rs
+++ b/test/testlib/src/lib.rs
@@ -326,6 +326,23 @@ impl StringTests
         Ok( ( bs, ptr ) )
     }
 
+    pub fn cstr_parameter( &self, s : &CStr, ptr : usize ) -> ComResult<()> {
+
+        if s.as_ptr() as usize == ptr {
+            Ok(())
+        } else {
+            Err( intercom::E_FAIL )
+        }
+    }
+
+    pub fn cstr_return_value( &self ) -> ComResult<( CString, usize )> {
+
+        let bs : CString = CString::new( "some string" ).unwrap();
+        let ptr = bs.as_ptr() as usize;
+
+        Ok( ( bs, ptr ) )
+    }
+
     pub fn invalid_string( &self, s : &str ) -> ComResult<()> {
 
         // Don't do any validation here.


### PR DESCRIPTION
The raw type system uses raw C-strings (null terminated strings with 1-byte characters). This isn't necessarily the final form and is up for debate, but I wanted some sort of support for raw type system strings so we can test the type system infrastructure works.

On the other hand I do feel there is some value in supporting C-strings as well. I wonder if it would make sense to support 3 type systems instead of the current two:

- Automation
- Raw (C-type system)
- Intercom (Length prefixed C-strings for performance reasons)