### PR TITLE
Update to Rust 1.31 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ and deallocated using [`IIntercomAllocator`]
 ## Nightly requirement
 
 Intercom requires nightly Rust version for few unstable features. By far the
-most important of these is the procedural macro attributes.
+most important of these is the procedural macro attributes. Unfortunately these
+are not properly feature gated.
 
 The features with feature gates and tracking issues that Intercom depends on are
 listed below:
@@ -101,8 +102,6 @@ listed below:
   Tracking issue: [#31844](https://github.com/rust-lang/rust/issues/31844)
 - `non_exhaustive` - There are some types that we may want to add items to.
   Tracking issue: [#44109](https://github.com/rust-lang/rust/issues/44109)
-- `tool_lints` - Because clippy wants this now.
-  Tracking issue: [#44690](https://github.com/rust-lang/rust/issues/44690)
 
 The following features are currently in use, but more for 'nice to have'
 reasons and could be worked around if we needed to get to stable quickly:

--- a/intercom-attributes/src/lib.rs
+++ b/intercom-attributes/src/lib.rs
@@ -12,7 +12,6 @@
 //! macros.
 
 #![allow(unused_imports)]
-#![feature(tool_lints)]
 
 extern crate intercom_common;
 use intercom_common::attributes::*;

--- a/intercom-common/src/lib.rs
+++ b/intercom-common/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(non_exhaustive, tool_lints)]
+#![feature(non_exhaustive)]
 #![recursion_limit="128"]
 
 #![allow(clippy::match_bool)]

--- a/intercom/src/lib.rs
+++ b/intercom/src/lib.rs
@@ -46,7 +46,7 @@
 //! ```
 
 #![crate_type="dylib"]
-#![feature(try_from, specialization, non_exhaustive, integer_atomics, tool_lints)]
+#![feature(try_from, specialization, non_exhaustive, integer_atomics)]
 
 #[cfg(not(windows))]
 extern crate libc;


### PR DESCRIPTION
Removed tool_lints feature gate. This feature is now stable.