### PR TITLE
Only build master branch on CI on push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ sudo: false
 rust:
     - nightly
 
+branches:
+    only:
+        - master
+
 addons:
     apt:
         sources:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,10 @@
 
 version: "{build}"
 
+branches:
+    only:
+        - master
+
 os:
     - Visual Studio 2017
       # - Visual Studio 2015


### PR DESCRIPTION
Currently PRs get build twice. Once on the push and once for the PR. This slows down things.