### PR TITLE
Put InterfacePtr<T> into wider use

### DIFF
--- a/intercom-attributes/tests/data/com_interface.target.rs
+++ b/intercom-attributes/tests/data/com_interface.target.rs
@@ -254,7 +254,7 @@ impl Foo for ::intercom::ComItf<Foo> {
                                                                  &mut __out);
                          Ok({
                                 if __result == ::intercom::S_OK {
-                                    Ok(::intercom::ComItf::wrap(__out.ptr,
+                                    Ok(::intercom::ComItf::wrap(__out,
                                                                 ::intercom::TypeSystem::Automation))
                                 } else {
                                     Err(::intercom::get_last_error(__result))
@@ -287,7 +287,7 @@ impl Foo for ::intercom::ComItf<Foo> {
                                                           &mut __out);
                          Ok({
                                 if __result == ::intercom::S_OK {
-                                    Ok(::intercom::ComItf::wrap(__out.ptr,
+                                    Ok(::intercom::ComItf::wrap(__out,
                                                                 ::intercom::TypeSystem::Raw))
                                 } else {
                                     Err(::intercom::get_last_error(__result))

--- a/intercom-build/src/os/windows/setup_configuration.rs
+++ b/intercom-build/src/os/windows/setup_configuration.rs
@@ -136,7 +136,7 @@ fn find_path( roots : &[&PathBuf], path : &str ) -> Option< PathBuf > {
 fn get_compiler_paths( paths : &[ PathBuf ] ) -> Vec<PathBuf>
 {
     // Get the directory paths from the file paths.
-    let mut dir_paths = paths.into_iter()
+    let mut dir_paths = paths.iter()
         .filter_map(
             |p| p.parent().and_then(
                 |p| Some( p.to_owned() ) ) )

--- a/intercom-common/src/model/comimpl.rs
+++ b/intercom-common/src/model/comimpl.rs
@@ -58,7 +58,7 @@ impl ComImpl
         let itf_ident = itf_ident_opt.unwrap_or_else( || struct_ident.clone() );
 
         let variants = OrderMap::from_iter(
-            [ ModelTypeSystem::Automation, ModelTypeSystem::Raw ].into_iter().map( |&ts| {
+            [ ModelTypeSystem::Automation, ModelTypeSystem::Raw ].iter().map( |&ts| {
 
             let itf_unique_ident = Ident::new(
                     &format!( "{}_{:?}", itf_ident.to_string(), ts ), Span::call_site() );

--- a/intercom-common/src/model/cominterface.rs
+++ b/intercom-common/src/model/cominterface.rs
@@ -118,7 +118,7 @@ impl ComInterface
                 };
 
         let variants = OrderMap::from_iter(
-            [ ModelTypeSystem::Automation, ModelTypeSystem::Raw ].into_iter().map( |&ts| {
+            [ ModelTypeSystem::Automation, ModelTypeSystem::Raw ].iter().map( |&ts| {
 
             let itf_unique_ident = Ident::new( 
                     &format!( "{}_{:?}", itf_ident.to_string(), ts ), Span::call_site() );

--- a/intercom-common/src/tyhandlers.rs
+++ b/intercom-common/src/tyhandlers.rs
@@ -181,7 +181,7 @@ impl TypeHandler for ComItfParam {
         let ts = self.context.type_system.as_typesystem_tokens();
         TypeConversion {
             temporary: None,
-            value: quote!( ::intercom::ComItf::wrap( #ident.ptr, #ts ) ),
+            value: quote!( ::intercom::ComItf::wrap( #ident, #ts ) ),
         }
     }
 

--- a/intercom-common/src/utils.rs
+++ b/intercom-common/src/utils.rs
@@ -45,7 +45,7 @@ pub fn get_ident_and_fns(
             => {
 
             let methods : Option< Vec< &MethodSig > > = items
-                    .into_iter()
+                    .iter()
                     .map( |i| get_trait_method( i ) )
                     .collect();
 
@@ -93,7 +93,7 @@ fn get_impl_data_raw<'a>(
     };
 
     let methods_opt : Option< Vec< &MethodSig > > = items
-            .into_iter()
+            .iter()
             .map( |i| get_impl_method( i ) )
             .collect();
     let methods = methods_opt.unwrap_or_else( || vec![] );

--- a/intercom/src/combox.rs
+++ b/intercom/src/combox.rs
@@ -78,6 +78,7 @@ impl<T: CoClass> AsRef<ComBox<T>> for ComStruct<T>
 }
 
 impl<I: ComInterface + ?Sized, T: HasInterface<I>> From<ComStruct<T>> for ComItf<I> {
+
     fn from( source : ComStruct<T> ) -> ComItf<I> {
 
         let ( automation_ptr, raw_ptr ) = {
@@ -103,7 +104,9 @@ impl<I: ComInterface + ?Sized, T: HasInterface<I>> From<ComStruct<T>> for ComItf
         };
 
         std::mem::forget( source );
-        unsafe { ComItf::new( automation_ptr, raw_ptr ) }
+        unsafe { ComItf::new(
+                raw::InterfacePtr::new( automation_ptr ),
+                raw::InterfacePtr::new( raw_ptr ) ) }
     }
 }
 

--- a/intercom/src/comrc.rs
+++ b/intercom/src/comrc.rs
@@ -22,6 +22,21 @@ impl<T : ?Sized> ComRc<T> {
     pub fn attach( itf : ComItf<T> ) -> ComRc<T> {
         ComRc { itf }
     }
+
+    /// Creates a `ComItf<T>` from a raw type system COM interface pointer..
+    ///
+    /// Does not increment the reference count.
+    ///
+    /// # Safety
+    ///
+    /// The `ptr` __must__ be a valid COM interface pointer for an interface
+    /// of type `T`.
+    pub unsafe fn wrap(
+        ptr : raw::InterfacePtr<T>,
+        ts : TypeSystem
+    ) -> ComRc<T> {
+        ComRc::attach( ComItf::wrap( ptr, ts ) )
+    }
 }
 
 #[cfg(windows)]
@@ -29,12 +44,19 @@ impl<T: ComInterface + ?Sized> ComRc<T>
 {
     pub fn create( clsid : GUID ) -> ::ComResult< ComRc<T> > {
 
+        // Get the IID.
+        //
+        // The IID we are getting here is the Automation type system ID.
+        // This is the one that plays well with Windows' CoCreateInstance, etc.
         let iid = match T::iid( TypeSystem::Automation ) {
             Some( iid ) => iid,
             None => return Err( E_NOINTERFACE ),
         };
 
         unsafe {
+
+            // Invoke CoCreateInstance and return a result based on the return
+            // value.  
             let mut out = ::std::ptr::null_mut();
             match CoCreateInstance(
                     clsid,
@@ -43,8 +65,11 @@ impl<T: ComInterface + ?Sized> ComRc<T>
                     iid,
                     &mut out ) {
 
+                // On success construct the ComRc. We are using Automation type
+                // system as that's the IID we used earlier.
                 ::S_OK => Ok( ComRc::attach( ComItf::wrap(
-                                out, TypeSystem::Automation ) ) ),
+                                raw::InterfacePtr::new( out ),
+                                TypeSystem::Automation ) ) ),
                 e => Err( e ),
             }
         }

--- a/intercom/src/error.rs
+++ b/intercom/src/error.rs
@@ -106,7 +106,7 @@ mod error_store {
     extern "system" {
         pub(super) fn SetErrorInfo(
             dw_reserved: u32,
-            errorinfo: ::RawComPtr,
+            errorinfo: raw::InterfacePtr<IErrorInfo>,
         ) -> ::HRESULT;
 
         #[allow(private_in_public)]
@@ -123,12 +123,12 @@ mod error_store {
 
     pub unsafe fn SetErrorInfo(
         _dw_reserved: u32,
-        _errorinfo: ::RawComPtr,
+        _errorinfo: raw::InterfacePtr<IErrorInfo>,
     ) -> ::HRESULT { ::S_OK }
 
     pub unsafe fn GetErrorInfo(
         _dw_reserved: u32,
-        _errorinfo: &mut ::RawComPtr,
+        _errorinfo: *mut raw::InterfacePtr<IErrorInfo>,
     ) -> ::HRESULT { ::S_OK }
 }
 
@@ -226,12 +226,12 @@ pub fn return_hresult< E >( error : E ) -> HRESULT
                         info.as_mut(),
                         &IID_IErrorInfo,
                         &mut error_ptr );
-                error_store::SetErrorInfo( 0, error_ptr );
+                error_store::SetErrorInfo( 0, raw::InterfacePtr::new( error_ptr ) );
             }
         },
         None => {
             // No error info in the ComError.
-            unsafe { error_store::SetErrorInfo( 0, std::ptr::null_mut() ); }
+            unsafe { error_store::SetErrorInfo( 0, raw::InterfacePtr::null() ); }
         }
     }
 

--- a/intercom/src/error.rs
+++ b/intercom/src/error.rs
@@ -121,12 +121,14 @@ mod error_store {
 #[allow(non_snake_case)]
 mod error_store {
 
-    pub unsafe fn SetErrorInfo(
+    use super::*;
+
+    pub(super) unsafe fn SetErrorInfo(
         _dw_reserved: u32,
         _errorinfo: raw::InterfacePtr<IErrorInfo>,
     ) -> ::HRESULT { ::S_OK }
 
-    pub unsafe fn GetErrorInfo(
+    pub(super) unsafe fn GetErrorInfo(
         _dw_reserved: u32,
         _errorinfo: *mut raw::InterfacePtr<IErrorInfo>,
     ) -> ::HRESULT { ::S_OK }

--- a/intercom/src/lib.rs
+++ b/intercom/src/lib.rs
@@ -127,10 +127,20 @@ pub mod raw {
     pub type OutCStr = *mut ::std::os::raw::c_char;
     
     #[repr(C)]
+    #[derive(PartialEq, Eq)]
     pub struct InterfacePtr<I: ?Sized> {
         pub ptr : super::RawComPtr,
         phantom : ::std::marker::PhantomData<I>,
     }
+
+    impl<I: ?Sized> Clone for InterfacePtr<I>
+    {
+        fn clone( &self ) -> Self {
+            InterfacePtr::new( self.ptr )
+        }
+    }
+
+    impl<I: ?Sized> Copy for InterfacePtr<I> {}
 
     impl<I: ?Sized> InterfacePtr<I> {
         pub fn new( ptr : super::RawComPtr ) -> InterfacePtr<I> {
@@ -141,7 +151,7 @@ pub mod raw {
             Self::new( std::ptr::null_mut() )
         }
 
-        pub fn is_null( &self ) -> bool {
+        pub fn is_null( self ) -> bool {
             self.ptr.is_null()
         }
     }

--- a/intercom/src/lib.rs
+++ b/intercom/src/lib.rs
@@ -136,6 +136,14 @@ pub mod raw {
         pub fn new( ptr : super::RawComPtr ) -> InterfacePtr<I> {
             InterfacePtr { ptr, phantom: ::std::marker::PhantomData }
         }
+
+        pub fn null() -> Self {
+            Self::new( std::ptr::null_mut() )
+        }
+
+        pub fn is_null( &self ) -> bool {
+            self.ptr.is_null()
+        }
     }
 }
 


### PR DESCRIPTION
Use InterfacePtr<T> everywhere where the C++ should use typed COM interfaces instead of something such as `void*` pointers.