### PR TITLE
Change ComResult error to Result<S, ComError>

### DIFF
--- a/intercom-attributes/tests/data/com_impl.target.rs
+++ b/intercom-attributes/tests/data/com_impl.target.rs
@@ -72,8 +72,8 @@ impl ::intercom::CoClass for Foo {
                       Foo_Raw: &__Foo_Foo_RawVtbl_INSTANCE,}
     }
     fn query_interface(vtables: &Self::VTableList, riid: ::intercom::REFIID)
-     -> ::intercom::ComResult<::intercom::RawComPtr> {
-        if riid.is_null() { return Err(::intercom::E_NOINTERFACE) }
+     -> ::intercom::RawComResult<::intercom::RawComPtr> {
+        if riid.is_null() { return Err(::intercom::raw::E_NOINTERFACE) }
         Ok(match *unsafe { &*riid } {
                ::intercom::IID_IUnknown =>
                (&vtables._ISupportErrorInfo) as
@@ -91,7 +91,7 @@ impl ::intercom::CoClass for Foo {
                self::IID_Foo_Raw =>
                &vtables.Foo_Raw as *const &__Foo_RawVtbl as
                    *mut &__Foo_RawVtbl as ::intercom::RawComPtr,
-               _ => return Err(::intercom::E_NOINTERFACE),
+               _ => return Err(::intercom::raw::E_NOINTERFACE),
            })
     }
     fn interface_supports_error_info(riid: ::intercom::REFIID) -> bool {
@@ -144,7 +144,7 @@ unsafe extern "C" fn __Foo_Foo_Automation_query_interface(self_vtable:
                                                                     ::intercom::REFIID,
                                                                 out:
                                                                     *mut ::intercom::RawComPtr)
- -> ::intercom::HRESULT {
+ -> ::intercom::raw::HRESULT {
     ::intercom::ComBox::<Foo>::query_interface(&mut *((self_vtable as usize -
                                                            __Foo_Foo_AutomationVtbl_offset())
                                                           as *mut _), riid,
@@ -191,7 +191,7 @@ unsafe extern "C" fn __Foo_Foo_Automation_simple_method_Automation(self_vtable:
     match result {
         Ok(v) => v,
         Err(err) =>
-        <() as ErrorValue>::from_error(::intercom::return_hresult(err)),
+        <() as ErrorValue>::from_error(::intercom::store_error(err)),
     }
 }
 #[allow(non_snake_case)]
@@ -216,7 +216,7 @@ unsafe extern "C" fn __Foo_Foo_Automation_arg_method_Automation(self_vtable:
     match result {
         Ok(v) => v,
         Err(err) =>
-        <() as ErrorValue>::from_error(::intercom::return_hresult(err)),
+        <() as ErrorValue>::from_error(::intercom::store_error(err)),
     }
 }
 #[allow(non_snake_case)]
@@ -240,7 +240,7 @@ unsafe extern "C" fn __Foo_Foo_Automation_simple_result_method_Automation(self_v
     match result {
         Ok(v) => v,
         Err(err) =>
-        <u16 as ErrorValue>::from_error(::intercom::return_hresult(err)),
+        <u16 as ErrorValue>::from_error(::intercom::store_error(err)),
     }
 }
 #[allow(non_snake_case)]
@@ -250,8 +250,8 @@ unsafe extern "C" fn __Foo_Foo_Automation_com_result_method_Automation(self_vtab
                                                                                  ::intercom::RawComPtr,
                                                                              __out:
                                                                                  *mut u16)
- -> ::intercom::HRESULT {
-    let result: Result<::intercom::HRESULT, ::intercom::ComError> =
+ -> ::intercom::raw::HRESULT {
+    let result: Result<::intercom::raw::HRESULT, ::intercom::ComError> =
         (||
              {
                  let self_combox =
@@ -262,10 +262,13 @@ unsafe extern "C" fn __Foo_Foo_Automation_com_result_method_Automation(self_vtab
                  let __result = self_struct.com_result_method();
                  Ok({
                         match __result {
-                            Ok(v1) => { *__out = v1.into(); ::intercom::S_OK }
+                            Ok(v1) => {
+                                *__out = v1.into();
+                                ::intercom::raw::S_OK
+                            }
                             Err(e) => {
                                 *__out = Default::default();
-                                ::intercom::return_hresult(e)
+                                ::intercom::store_error(e).hresult
                             }
                         }
                     })
@@ -274,8 +277,8 @@ unsafe extern "C" fn __Foo_Foo_Automation_com_result_method_Automation(self_vtab
     match result {
         Ok(v) => v,
         Err(err) =>
-        <::intercom::HRESULT as
-            ErrorValue>::from_error(::intercom::return_hresult(err)),
+        <::intercom::raw::HRESULT as
+            ErrorValue>::from_error(::intercom::store_error(err)),
     }
 }
 #[allow(non_snake_case)]
@@ -285,8 +288,8 @@ unsafe extern "C" fn __Foo_Foo_Automation_rust_result_method_Automation(self_vta
                                                                                   ::intercom::RawComPtr,
                                                                               __out:
                                                                                   *mut u16)
- -> ::intercom::HRESULT {
-    let result: Result<::intercom::HRESULT, ::intercom::ComError> =
+ -> ::intercom::raw::HRESULT {
+    let result: Result<::intercom::raw::HRESULT, ::intercom::ComError> =
         (||
              {
                  let self_combox =
@@ -297,10 +300,13 @@ unsafe extern "C" fn __Foo_Foo_Automation_rust_result_method_Automation(self_vta
                  let __result = self_struct.rust_result_method();
                  Ok({
                         match __result {
-                            Ok(v1) => { *__out = v1.into(); ::intercom::S_OK }
+                            Ok(v1) => {
+                                *__out = v1.into();
+                                ::intercom::raw::S_OK
+                            }
                             Err(e) => {
                                 *__out = Default::default();
-                                ::intercom::return_hresult(e)
+                                ::intercom::store_error(e).hresult
                             }
                         }
                     })
@@ -309,8 +315,8 @@ unsafe extern "C" fn __Foo_Foo_Automation_rust_result_method_Automation(self_vta
     match result {
         Ok(v) => v,
         Err(err) =>
-        <::intercom::HRESULT as
-            ErrorValue>::from_error(::intercom::return_hresult(err)),
+        <::intercom::raw::HRESULT as
+            ErrorValue>::from_error(::intercom::store_error(err)),
     }
 }
 #[allow(non_snake_case)]
@@ -324,8 +330,8 @@ unsafe extern "C" fn __Foo_Foo_Automation_tuple_result_method_Automation(self_vt
                                                                                    *mut u16,
                                                                                __out3:
                                                                                    *mut u32)
- -> ::intercom::HRESULT {
-    let result: Result<::intercom::HRESULT, ::intercom::ComError> =
+ -> ::intercom::raw::HRESULT {
+    let result: Result<::intercom::raw::HRESULT, ::intercom::ComError> =
         (||
              {
                  let self_combox =
@@ -340,13 +346,13 @@ unsafe extern "C" fn __Foo_Foo_Automation_tuple_result_method_Automation(self_vt
                                 *__out1 = v1.into();
                                 *__out2 = v2.into();
                                 *__out3 = v3.into();
-                                ::intercom::S_OK
+                                ::intercom::raw::S_OK
                             }
                             Err(e) => {
                                 *__out1 = Default::default();
                                 *__out2 = Default::default();
                                 *__out3 = Default::default();
-                                ::intercom::return_hresult(e)
+                                ::intercom::store_error(e).hresult
                             }
                         }
                     })
@@ -355,8 +361,8 @@ unsafe extern "C" fn __Foo_Foo_Automation_tuple_result_method_Automation(self_vt
     match result {
         Ok(v) => v,
         Err(err) =>
-        <::intercom::HRESULT as
-            ErrorValue>::from_error(::intercom::return_hresult(err)),
+        <::intercom::raw::HRESULT as
+            ErrorValue>::from_error(::intercom::store_error(err)),
     }
 }
 #[allow(non_snake_case)]
@@ -390,7 +396,7 @@ unsafe extern "C" fn __Foo_Foo_Automation_string_method_Automation(self_vtable:
         Ok(v) => v,
         Err(err) =>
         <::intercom::raw::OutBSTR as
-            ErrorValue>::from_error(::intercom::return_hresult(err)),
+            ErrorValue>::from_error(::intercom::store_error(err)),
     }
 }
 #[allow(non_snake_case)]
@@ -402,8 +408,8 @@ unsafe extern "C" fn __Foo_Foo_Automation_string_result_method_Automation(self_v
                                                                                     ::intercom::raw::InBSTR,
                                                                                 __out:
                                                                                     *mut ::intercom::raw::OutBSTR)
- -> ::intercom::HRESULT {
-    let result: Result<::intercom::HRESULT, ::intercom::ComError> =
+ -> ::intercom::raw::HRESULT {
+    let result: Result<::intercom::raw::HRESULT, ::intercom::ComError> =
         (||
              {
                  let self_combox =
@@ -422,11 +428,11 @@ unsafe extern "C" fn __Foo_Foo_Automation_string_result_method_Automation(self_v
                             Ok(v1) => {
                                 *__out =
                                     ::intercom::ComInto::<::intercom::BString>::com_into(v1)?.into_ptr();
-                                ::intercom::S_OK
+                                ::intercom::raw::S_OK
                             }
                             Err(e) => {
                                 *__out = ::std::ptr::null_mut();
-                                ::intercom::return_hresult(e)
+                                ::intercom::store_error(e).hresult
                             }
                         }
                     })
@@ -435,8 +441,8 @@ unsafe extern "C" fn __Foo_Foo_Automation_string_result_method_Automation(self_v
     match result {
         Ok(v) => v,
         Err(err) =>
-        <::intercom::HRESULT as
-            ErrorValue>::from_error(::intercom::return_hresult(err)),
+        <::intercom::raw::HRESULT as
+            ErrorValue>::from_error(::intercom::store_error(err)),
     }
 }
 #[allow(non_snake_case)]
@@ -450,8 +456,8 @@ unsafe extern "C" fn __Foo_Foo_Automation_complete_method_Automation(self_vtable
                                                                                i16,
                                                                            __out:
                                                                                *mut ::intercom::raw::VariantBool)
- -> ::intercom::HRESULT {
-    let result: Result<::intercom::HRESULT, ::intercom::ComError> =
+ -> ::intercom::raw::HRESULT {
+    let result: Result<::intercom::raw::HRESULT, ::intercom::ComError> =
         (||
              {
                  let self_combox =
@@ -463,10 +469,13 @@ unsafe extern "C" fn __Foo_Foo_Automation_complete_method_Automation(self_vtable
                      self_struct.complete_method(a.into(), b.into());
                  Ok({
                         match __result {
-                            Ok(v1) => { *__out = v1.into(); ::intercom::S_OK }
+                            Ok(v1) => {
+                                *__out = v1.into();
+                                ::intercom::raw::S_OK
+                            }
                             Err(e) => {
                                 *__out = false.into();
-                                ::intercom::return_hresult(e)
+                                ::intercom::store_error(e).hresult
                             }
                         }
                     })
@@ -475,8 +484,8 @@ unsafe extern "C" fn __Foo_Foo_Automation_complete_method_Automation(self_vtable
     match result {
         Ok(v) => v,
         Err(err) =>
-        <::intercom::HRESULT as
-            ErrorValue>::from_error(::intercom::return_hresult(err)),
+        <::intercom::raw::HRESULT as
+            ErrorValue>::from_error(::intercom::store_error(err)),
     }
 }
 #[allow(non_snake_case)]
@@ -488,8 +497,8 @@ unsafe extern "C" fn __Foo_Foo_Automation_bool_method_Automation(self_vtable:
                                                                            ::intercom::raw::VariantBool,
                                                                        __out:
                                                                            *mut ::intercom::raw::VariantBool)
- -> ::intercom::HRESULT {
-    let result: Result<::intercom::HRESULT, ::intercom::ComError> =
+ -> ::intercom::raw::HRESULT {
+    let result: Result<::intercom::raw::HRESULT, ::intercom::ComError> =
         (||
              {
                  let self_combox =
@@ -500,10 +509,13 @@ unsafe extern "C" fn __Foo_Foo_Automation_bool_method_Automation(self_vtable:
                  let __result = self_struct.bool_method(input.into());
                  Ok({
                         match __result {
-                            Ok(v1) => { *__out = v1.into(); ::intercom::S_OK }
+                            Ok(v1) => {
+                                *__out = v1.into();
+                                ::intercom::raw::S_OK
+                            }
                             Err(e) => {
                                 *__out = false.into();
-                                ::intercom::return_hresult(e)
+                                ::intercom::store_error(e).hresult
                             }
                         }
                     })
@@ -512,8 +524,8 @@ unsafe extern "C" fn __Foo_Foo_Automation_bool_method_Automation(self_vtable:
     match result {
         Ok(v) => v,
         Err(err) =>
-        <::intercom::HRESULT as
-            ErrorValue>::from_error(::intercom::return_hresult(err)),
+        <::intercom::raw::HRESULT as
+            ErrorValue>::from_error(::intercom::store_error(err)),
     }
 }
 #[allow(non_snake_case)]
@@ -525,8 +537,8 @@ unsafe extern "C" fn __Foo_Foo_Automation_variant_method_Automation(self_vtable:
                                                                               ::intercom::raw::Variant,
                                                                           __out:
                                                                               *mut ::intercom::raw::Variant)
- -> ::intercom::HRESULT {
-    let result: Result<::intercom::HRESULT, ::intercom::ComError> =
+ -> ::intercom::raw::HRESULT {
+    let result: Result<::intercom::raw::HRESULT, ::intercom::ComError> =
         (||
              {
                  let self_combox =
@@ -539,11 +551,11 @@ unsafe extern "C" fn __Foo_Foo_Automation_variant_method_Automation(self_vtable:
                         match __result {
                             Ok(v1) => {
                                 *__out = v1.com_into()?;
-                                ::intercom::S_OK
+                                ::intercom::raw::S_OK
                             }
                             Err(e) => {
                                 *__out = Default::default();
-                                ::intercom::return_hresult(e)
+                                ::intercom::store_error(e).hresult
                             }
                         }
                     })
@@ -552,8 +564,8 @@ unsafe extern "C" fn __Foo_Foo_Automation_variant_method_Automation(self_vtable:
     match result {
         Ok(v) => v,
         Err(err) =>
-        <::intercom::HRESULT as
-            ErrorValue>::from_error(::intercom::return_hresult(err)),
+        <::intercom::raw::HRESULT as
+            ErrorValue>::from_error(::intercom::store_error(err)),
     }
 }
 #[allow(non_upper_case_globals)]
@@ -595,7 +607,7 @@ unsafe extern "C" fn __Foo_Foo_Raw_query_interface(self_vtable:
                                                              ::intercom::REFIID,
                                                          out:
                                                              *mut ::intercom::RawComPtr)
- -> ::intercom::HRESULT {
+ -> ::intercom::raw::HRESULT {
     ::intercom::ComBox::<Foo>::query_interface(&mut *((self_vtable as usize -
                                                            __Foo_Foo_RawVtbl_offset())
                                                           as *mut _), riid,
@@ -641,7 +653,7 @@ unsafe extern "C" fn __Foo_Foo_Raw_simple_method_Raw(self_vtable:
     match result {
         Ok(v) => v,
         Err(err) =>
-        <() as ErrorValue>::from_error(::intercom::return_hresult(err)),
+        <() as ErrorValue>::from_error(::intercom::store_error(err)),
     }
 }
 #[allow(non_snake_case)]
@@ -664,7 +676,7 @@ unsafe extern "C" fn __Foo_Foo_Raw_arg_method_Raw(self_vtable:
     match result {
         Ok(v) => v,
         Err(err) =>
-        <() as ErrorValue>::from_error(::intercom::return_hresult(err)),
+        <() as ErrorValue>::from_error(::intercom::store_error(err)),
     }
 }
 #[allow(non_snake_case)]
@@ -687,7 +699,7 @@ unsafe extern "C" fn __Foo_Foo_Raw_simple_result_method_Raw(self_vtable:
     match result {
         Ok(v) => v,
         Err(err) =>
-        <u16 as ErrorValue>::from_error(::intercom::return_hresult(err)),
+        <u16 as ErrorValue>::from_error(::intercom::store_error(err)),
     }
 }
 #[allow(non_snake_case)]
@@ -697,8 +709,8 @@ unsafe extern "C" fn __Foo_Foo_Raw_com_result_method_Raw(self_vtable:
                                                                    ::intercom::RawComPtr,
                                                                __out:
                                                                    *mut u16)
- -> ::intercom::HRESULT {
-    let result: Result<::intercom::HRESULT, ::intercom::ComError> =
+ -> ::intercom::raw::HRESULT {
+    let result: Result<::intercom::raw::HRESULT, ::intercom::ComError> =
         (||
              {
                  let self_combox =
@@ -708,10 +720,13 @@ unsafe extern "C" fn __Foo_Foo_Raw_com_result_method_Raw(self_vtable:
                  let __result = self_struct.com_result_method();
                  Ok({
                         match __result {
-                            Ok(v1) => { *__out = v1.into(); ::intercom::S_OK }
+                            Ok(v1) => {
+                                *__out = v1.into();
+                                ::intercom::raw::S_OK
+                            }
                             Err(e) => {
                                 *__out = Default::default();
-                                ::intercom::return_hresult(e)
+                                ::intercom::store_error(e).hresult
                             }
                         }
                     })
@@ -720,8 +735,8 @@ unsafe extern "C" fn __Foo_Foo_Raw_com_result_method_Raw(self_vtable:
     match result {
         Ok(v) => v,
         Err(err) =>
-        <::intercom::HRESULT as
-            ErrorValue>::from_error(::intercom::return_hresult(err)),
+        <::intercom::raw::HRESULT as
+            ErrorValue>::from_error(::intercom::store_error(err)),
     }
 }
 #[allow(non_snake_case)]
@@ -731,8 +746,8 @@ unsafe extern "C" fn __Foo_Foo_Raw_rust_result_method_Raw(self_vtable:
                                                                     ::intercom::RawComPtr,
                                                                 __out:
                                                                     *mut u16)
- -> ::intercom::HRESULT {
-    let result: Result<::intercom::HRESULT, ::intercom::ComError> =
+ -> ::intercom::raw::HRESULT {
+    let result: Result<::intercom::raw::HRESULT, ::intercom::ComError> =
         (||
              {
                  let self_combox =
@@ -742,10 +757,13 @@ unsafe extern "C" fn __Foo_Foo_Raw_rust_result_method_Raw(self_vtable:
                  let __result = self_struct.rust_result_method();
                  Ok({
                         match __result {
-                            Ok(v1) => { *__out = v1.into(); ::intercom::S_OK }
+                            Ok(v1) => {
+                                *__out = v1.into();
+                                ::intercom::raw::S_OK
+                            }
                             Err(e) => {
                                 *__out = Default::default();
-                                ::intercom::return_hresult(e)
+                                ::intercom::store_error(e).hresult
                             }
                         }
                     })
@@ -754,8 +772,8 @@ unsafe extern "C" fn __Foo_Foo_Raw_rust_result_method_Raw(self_vtable:
     match result {
         Ok(v) => v,
         Err(err) =>
-        <::intercom::HRESULT as
-            ErrorValue>::from_error(::intercom::return_hresult(err)),
+        <::intercom::raw::HRESULT as
+            ErrorValue>::from_error(::intercom::store_error(err)),
     }
 }
 #[allow(non_snake_case)]
@@ -769,8 +787,8 @@ unsafe extern "C" fn __Foo_Foo_Raw_tuple_result_method_Raw(self_vtable:
                                                                      *mut u16,
                                                                  __out3:
                                                                      *mut u32)
- -> ::intercom::HRESULT {
-    let result: Result<::intercom::HRESULT, ::intercom::ComError> =
+ -> ::intercom::raw::HRESULT {
+    let result: Result<::intercom::raw::HRESULT, ::intercom::ComError> =
         (||
              {
                  let self_combox =
@@ -784,13 +802,13 @@ unsafe extern "C" fn __Foo_Foo_Raw_tuple_result_method_Raw(self_vtable:
                                 *__out1 = v1.into();
                                 *__out2 = v2.into();
                                 *__out3 = v3.into();
-                                ::intercom::S_OK
+                                ::intercom::raw::S_OK
                             }
                             Err(e) => {
                                 *__out1 = Default::default();
                                 *__out2 = Default::default();
                                 *__out3 = Default::default();
-                                ::intercom::return_hresult(e)
+                                ::intercom::store_error(e).hresult
                             }
                         }
                     })
@@ -799,8 +817,8 @@ unsafe extern "C" fn __Foo_Foo_Raw_tuple_result_method_Raw(self_vtable:
     match result {
         Ok(v) => v,
         Err(err) =>
-        <::intercom::HRESULT as
-            ErrorValue>::from_error(::intercom::return_hresult(err)),
+        <::intercom::raw::HRESULT as
+            ErrorValue>::from_error(::intercom::store_error(err)),
     }
 }
 #[allow(non_snake_case)]
@@ -833,7 +851,7 @@ unsafe extern "C" fn __Foo_Foo_Raw_string_method_Raw(self_vtable:
         Ok(v) => v,
         Err(err) =>
         <::intercom::raw::OutCStr as
-            ErrorValue>::from_error(::intercom::return_hresult(err)),
+            ErrorValue>::from_error(::intercom::store_error(err)),
     }
 }
 #[allow(non_snake_case)]
@@ -845,8 +863,8 @@ unsafe extern "C" fn __Foo_Foo_Raw_string_result_method_Raw(self_vtable:
                                                                       ::intercom::raw::InCStr,
                                                                   __out:
                                                                       *mut ::intercom::raw::OutCStr)
- -> ::intercom::HRESULT {
-    let result: Result<::intercom::HRESULT, ::intercom::ComError> =
+ -> ::intercom::raw::HRESULT {
+    let result: Result<::intercom::raw::HRESULT, ::intercom::ComError> =
         (||
              {
                  let self_combox =
@@ -864,11 +882,11 @@ unsafe extern "C" fn __Foo_Foo_Raw_string_result_method_Raw(self_vtable:
                             Ok(v1) => {
                                 *__out =
                                     ::intercom::ComInto::<::intercom::CString>::com_into(v1)?.into_raw();
-                                ::intercom::S_OK
+                                ::intercom::raw::S_OK
                             }
                             Err(e) => {
                                 *__out = ::std::ptr::null_mut();
-                                ::intercom::return_hresult(e)
+                                ::intercom::store_error(e).hresult
                             }
                         }
                     })
@@ -877,8 +895,8 @@ unsafe extern "C" fn __Foo_Foo_Raw_string_result_method_Raw(self_vtable:
     match result {
         Ok(v) => v,
         Err(err) =>
-        <::intercom::HRESULT as
-            ErrorValue>::from_error(::intercom::return_hresult(err)),
+        <::intercom::raw::HRESULT as
+            ErrorValue>::from_error(::intercom::store_error(err)),
     }
 }
 #[allow(non_snake_case)]
@@ -888,8 +906,8 @@ unsafe extern "C" fn __Foo_Foo_Raw_complete_method_Raw(self_vtable:
                                                                  ::intercom::RawComPtr,
                                                              a: u16, b: i16,
                                                              __out: *mut bool)
- -> ::intercom::HRESULT {
-    let result: Result<::intercom::HRESULT, ::intercom::ComError> =
+ -> ::intercom::raw::HRESULT {
+    let result: Result<::intercom::raw::HRESULT, ::intercom::ComError> =
         (||
              {
                  let self_combox =
@@ -900,10 +918,13 @@ unsafe extern "C" fn __Foo_Foo_Raw_complete_method_Raw(self_vtable:
                      self_struct.complete_method(a.into(), b.into());
                  Ok({
                         match __result {
-                            Ok(v1) => { *__out = v1.into(); ::intercom::S_OK }
+                            Ok(v1) => {
+                                *__out = v1.into();
+                                ::intercom::raw::S_OK
+                            }
                             Err(e) => {
                                 *__out = false;
-                                ::intercom::return_hresult(e)
+                                ::intercom::store_error(e).hresult
                             }
                         }
                     })
@@ -912,8 +933,8 @@ unsafe extern "C" fn __Foo_Foo_Raw_complete_method_Raw(self_vtable:
     match result {
         Ok(v) => v,
         Err(err) =>
-        <::intercom::HRESULT as
-            ErrorValue>::from_error(::intercom::return_hresult(err)),
+        <::intercom::raw::HRESULT as
+            ErrorValue>::from_error(::intercom::store_error(err)),
     }
 }
 #[allow(non_snake_case)]
@@ -923,8 +944,8 @@ unsafe extern "C" fn __Foo_Foo_Raw_bool_method_Raw(self_vtable:
                                                              ::intercom::RawComPtr,
                                                          input: bool,
                                                          __out: *mut bool)
- -> ::intercom::HRESULT {
-    let result: Result<::intercom::HRESULT, ::intercom::ComError> =
+ -> ::intercom::raw::HRESULT {
+    let result: Result<::intercom::raw::HRESULT, ::intercom::ComError> =
         (||
              {
                  let self_combox =
@@ -934,10 +955,13 @@ unsafe extern "C" fn __Foo_Foo_Raw_bool_method_Raw(self_vtable:
                  let __result = self_struct.bool_method(input.into());
                  Ok({
                         match __result {
-                            Ok(v1) => { *__out = v1.into(); ::intercom::S_OK }
+                            Ok(v1) => {
+                                *__out = v1.into();
+                                ::intercom::raw::S_OK
+                            }
                             Err(e) => {
                                 *__out = false;
-                                ::intercom::return_hresult(e)
+                                ::intercom::store_error(e).hresult
                             }
                         }
                     })
@@ -946,8 +970,8 @@ unsafe extern "C" fn __Foo_Foo_Raw_bool_method_Raw(self_vtable:
     match result {
         Ok(v) => v,
         Err(err) =>
-        <::intercom::HRESULT as
-            ErrorValue>::from_error(::intercom::return_hresult(err)),
+        <::intercom::raw::HRESULT as
+            ErrorValue>::from_error(::intercom::store_error(err)),
     }
 }
 #[allow(non_snake_case)]
@@ -959,8 +983,8 @@ unsafe extern "C" fn __Foo_Foo_Raw_variant_method_Raw(self_vtable:
                                                                 ::intercom::raw::Variant,
                                                             __out:
                                                                 *mut ::intercom::raw::Variant)
- -> ::intercom::HRESULT {
-    let result: Result<::intercom::HRESULT, ::intercom::ComError> =
+ -> ::intercom::raw::HRESULT {
+    let result: Result<::intercom::raw::HRESULT, ::intercom::ComError> =
         (||
              {
                  let self_combox =
@@ -972,11 +996,11 @@ unsafe extern "C" fn __Foo_Foo_Raw_variant_method_Raw(self_vtable:
                         match __result {
                             Ok(v1) => {
                                 *__out = v1.com_into()?;
-                                ::intercom::S_OK
+                                ::intercom::raw::S_OK
                             }
                             Err(e) => {
                                 *__out = Default::default();
-                                ::intercom::return_hresult(e)
+                                ::intercom::store_error(e).hresult
                             }
                         }
                     })
@@ -985,8 +1009,8 @@ unsafe extern "C" fn __Foo_Foo_Raw_variant_method_Raw(self_vtable:
     match result {
         Ok(v) => v,
         Err(err) =>
-        <::intercom::HRESULT as
-            ErrorValue>::from_error(::intercom::return_hresult(err)),
+        <::intercom::raw::HRESULT as
+            ErrorValue>::from_error(::intercom::store_error(err)),
     }
 }
 #[allow(non_upper_case_globals)]

--- a/intercom-attributes/tests/data/com_interface.target.rs
+++ b/intercom-attributes/tests/data/com_interface.target.rs
@@ -61,18 +61,18 @@ pub struct __Foo_AutomationVtbl {
                                                                      ::intercom::RawComPtr,
                                                                  __out:
                                                                      *mut u16)
-                                          -> ::intercom::HRESULT,
+                                          -> ::intercom::raw::HRESULT,
     pub rust_result_method_Automation: unsafe extern "C" fn(self_vtable:
                                                                       ::intercom::RawComPtr,
                                                                   __out:
                                                                       *mut u16)
-                                           -> ::intercom::HRESULT,
+                                           -> ::intercom::raw::HRESULT,
     pub complete_method_Automation: unsafe extern "C" fn(self_vtable:
                                                                    ::intercom::RawComPtr,
                                                                a: u16, b: i16,
                                                                __out:
                                                                    *mut ::intercom::raw::VariantBool)
-                                        -> ::intercom::HRESULT,
+                                        -> ::intercom::raw::HRESULT,
     pub string_method_Automation: unsafe extern "C" fn(self_vtable:
                                                                  ::intercom::RawComPtr,
                                                              msg:
@@ -84,21 +84,21 @@ pub struct __Foo_AutomationVtbl {
                                                                  ::intercom::raw::InterfacePtr<Foo>,
                                                              __out:
                                                                  *mut ::intercom::raw::InterfacePtr<IUnknown>)
-                                      -> ::intercom::HRESULT,
+                                      -> ::intercom::raw::HRESULT,
     pub bool_method_Automation: unsafe extern "C" fn(self_vtable:
                                                                ::intercom::RawComPtr,
                                                            input:
                                                                ::intercom::raw::VariantBool,
                                                            __out:
                                                                *mut ::intercom::raw::VariantBool)
-                                    -> ::intercom::HRESULT,
+                                    -> ::intercom::raw::HRESULT,
     pub variant_method_Automation: unsafe extern "C" fn(self_vtable:
                                                                   ::intercom::RawComPtr,
                                                               input:
                                                                   ::intercom::raw::Variant,
                                                               __out:
                                                                   *mut ::intercom::raw::Variant)
-                                       -> ::intercom::HRESULT,
+                                       -> ::intercom::raw::HRESULT,
 }
 #[doc = "`Foo` interface ID."]
 #[allow(non_upper_case_globals)]
@@ -124,16 +124,16 @@ pub struct __Foo_RawVtbl {
     pub com_result_method_Raw: unsafe extern "C" fn(self_vtable:
                                                               ::intercom::RawComPtr,
                                                           __out: *mut u16)
-                                   -> ::intercom::HRESULT,
+                                   -> ::intercom::raw::HRESULT,
     pub rust_result_method_Raw: unsafe extern "C" fn(self_vtable:
                                                                ::intercom::RawComPtr,
                                                            __out: *mut u16)
-                                    -> ::intercom::HRESULT,
+                                    -> ::intercom::raw::HRESULT,
     pub complete_method_Raw: unsafe extern "C" fn(self_vtable:
                                                             ::intercom::RawComPtr,
                                                         a: u16, b: i16,
                                                         __out: *mut bool)
-                                 -> ::intercom::HRESULT,
+                                 -> ::intercom::raw::HRESULT,
     pub string_method_Raw: unsafe extern "C" fn(self_vtable:
                                                           ::intercom::RawComPtr,
                                                       msg:
@@ -145,19 +145,19 @@ pub struct __Foo_RawVtbl {
                                                           ::intercom::raw::InterfacePtr<Foo>,
                                                       __out:
                                                           *mut ::intercom::raw::InterfacePtr<IUnknown>)
-                               -> ::intercom::HRESULT,
+                               -> ::intercom::raw::HRESULT,
     pub bool_method_Raw: unsafe extern "C" fn(self_vtable:
                                                         ::intercom::RawComPtr,
                                                     input: bool,
                                                     __out: *mut bool)
-                             -> ::intercom::HRESULT,
+                             -> ::intercom::raw::HRESULT,
     pub variant_method_Raw: unsafe extern "C" fn(self_vtable:
                                                            ::intercom::RawComPtr,
                                                        input:
                                                            ::intercom::raw::Variant,
                                                        __out:
                                                            *mut ::intercom::raw::Variant)
-                                -> ::intercom::HRESULT,
+                                -> ::intercom::raw::HRESULT,
 }
 impl Foo for ::intercom::ComItf<Foo> {
     fn arg_method(&self, a: u16) -> () {
@@ -181,7 +181,7 @@ impl Foo for ::intercom::ComItf<Foo> {
                        Ok(v) => v,
                        Err(err) =>
                        <() as
-                           ErrorValue>::from_error(::intercom::return_hresult(err)),
+                           ErrorValue>::from_error(::intercom::store_error(err)),
                    };
         }
         if let Some(comptr) =
@@ -199,10 +199,11 @@ impl Foo for ::intercom::ComItf<Foo> {
                        Ok(v) => v,
                        Err(err) =>
                        <() as
-                           ErrorValue>::from_error(::intercom::return_hresult(err)),
+                           ErrorValue>::from_error(::intercom::store_error(err)),
                    };
         }
-        <() as ErrorValue>::from_error(::intercom::E_POINTER)
+        <() as
+            ErrorValue>::from_error(::intercom::store_error(::intercom::ComError::E_POINTER))
     }
     fn bool_method(&self, input: bool) -> ComResult<bool> {
         #[allow(unused_imports)]
@@ -223,7 +224,7 @@ impl Foo for ::intercom::ComItf<Foo> {
                                                                input.into(),
                                                                &mut __out);
                          Ok({
-                                if __result == ::intercom::S_OK {
+                                if __result == ::intercom::raw::S_OK {
                                     Ok(__out.into())
                                 } else {
                                     Err(::intercom::get_last_error(__result))
@@ -234,7 +235,7 @@ impl Foo for ::intercom::ComItf<Foo> {
                        Ok(v) => v,
                        Err(err) =>
                        <ComResult<bool> as
-                           ErrorValue>::from_error(::intercom::return_hresult(err)),
+                           ErrorValue>::from_error(::intercom::store_error(err)),
                    };
         }
         if let Some(comptr) =
@@ -250,7 +251,7 @@ impl Foo for ::intercom::ComItf<Foo> {
                                                         input.into(),
                                                         &mut __out);
                          Ok({
-                                if __result == ::intercom::S_OK {
+                                if __result == ::intercom::raw::S_OK {
                                     Ok(__out.into())
                                 } else {
                                     Err(::intercom::get_last_error(__result))
@@ -261,10 +262,11 @@ impl Foo for ::intercom::ComItf<Foo> {
                        Ok(v) => v,
                        Err(err) =>
                        <ComResult<bool> as
-                           ErrorValue>::from_error(::intercom::return_hresult(err)),
+                           ErrorValue>::from_error(::intercom::store_error(err)),
                    };
         }
-        <ComResult<bool> as ErrorValue>::from_error(::intercom::E_POINTER)
+        <ComResult<bool> as
+            ErrorValue>::from_error(::intercom::store_error(::intercom::ComError::E_POINTER))
     }
     fn com_result_method(&self) -> ComResult<u16> {
         #[allow(unused_imports)]
@@ -283,7 +285,7 @@ impl Foo for ::intercom::ComItf<Foo> {
                              ((**vtbl).com_result_method_Automation)(comptr.ptr,
                                                                      &mut __out);
                          Ok({
-                                if __result == ::intercom::S_OK {
+                                if __result == ::intercom::raw::S_OK {
                                     Ok(__out.into())
                                 } else {
                                     Err(::intercom::get_last_error(__result))
@@ -294,7 +296,7 @@ impl Foo for ::intercom::ComItf<Foo> {
                        Ok(v) => v,
                        Err(err) =>
                        <ComResult<u16> as
-                           ErrorValue>::from_error(::intercom::return_hresult(err)),
+                           ErrorValue>::from_error(::intercom::store_error(err)),
                    };
         }
         if let Some(comptr) =
@@ -309,7 +311,7 @@ impl Foo for ::intercom::ComItf<Foo> {
                              ((**vtbl).com_result_method_Raw)(comptr.ptr,
                                                               &mut __out);
                          Ok({
-                                if __result == ::intercom::S_OK {
+                                if __result == ::intercom::raw::S_OK {
                                     Ok(__out.into())
                                 } else {
                                     Err(::intercom::get_last_error(__result))
@@ -320,10 +322,11 @@ impl Foo for ::intercom::ComItf<Foo> {
                        Ok(v) => v,
                        Err(err) =>
                        <ComResult<u16> as
-                           ErrorValue>::from_error(::intercom::return_hresult(err)),
+                           ErrorValue>::from_error(::intercom::store_error(err)),
                    };
         }
-        <ComResult<u16> as ErrorValue>::from_error(::intercom::E_POINTER)
+        <ComResult<u16> as
+            ErrorValue>::from_error(::intercom::store_error(::intercom::ComError::E_POINTER))
     }
     fn comitf_method(&self, itf: ComItf<Foo>) -> ComResult<ComItf<IUnknown>> {
         #[allow(unused_imports)]
@@ -348,7 +351,7 @@ impl Foo for ::intercom::ComItf<Foo> {
                                                                                          ::intercom::TypeSystem::Automation),
                                                                  &mut __out);
                          Ok({
-                                if __result == ::intercom::S_OK {
+                                if __result == ::intercom::raw::S_OK {
                                     Ok(::intercom::ComItf::wrap(__out,
                                                                 ::intercom::TypeSystem::Automation))
                                 } else {
@@ -360,7 +363,7 @@ impl Foo for ::intercom::ComItf<Foo> {
                        Ok(v) => v,
                        Err(err) =>
                        <ComResult<ComItf<IUnknown>> as
-                           ErrorValue>::from_error(::intercom::return_hresult(err)),
+                           ErrorValue>::from_error(::intercom::store_error(err)),
                    };
         }
         if let Some(comptr) =
@@ -381,7 +384,7 @@ impl Foo for ::intercom::ComItf<Foo> {
                                                                                   ::intercom::TypeSystem::Raw),
                                                           &mut __out);
                          Ok({
-                                if __result == ::intercom::S_OK {
+                                if __result == ::intercom::raw::S_OK {
                                     Ok(::intercom::ComItf::wrap(__out,
                                                                 ::intercom::TypeSystem::Raw))
                                 } else {
@@ -393,11 +396,11 @@ impl Foo for ::intercom::ComItf<Foo> {
                        Ok(v) => v,
                        Err(err) =>
                        <ComResult<ComItf<IUnknown>> as
-                           ErrorValue>::from_error(::intercom::return_hresult(err)),
+                           ErrorValue>::from_error(::intercom::store_error(err)),
                    };
         }
         <ComResult<ComItf<IUnknown>> as
-            ErrorValue>::from_error(::intercom::E_POINTER)
+            ErrorValue>::from_error(::intercom::store_error(::intercom::ComError::E_POINTER))
     }
     fn complete_method(&mut self, a: u16, b: i16) -> ComResult<bool> {
         #[allow(unused_imports)]
@@ -419,7 +422,7 @@ impl Foo for ::intercom::ComItf<Foo> {
                                                                    b.into(),
                                                                    &mut __out);
                          Ok({
-                                if __result == ::intercom::S_OK {
+                                if __result == ::intercom::raw::S_OK {
                                     Ok(__out.into())
                                 } else {
                                     Err(::intercom::get_last_error(__result))
@@ -430,7 +433,7 @@ impl Foo for ::intercom::ComItf<Foo> {
                        Ok(v) => v,
                        Err(err) =>
                        <ComResult<bool> as
-                           ErrorValue>::from_error(::intercom::return_hresult(err)),
+                           ErrorValue>::from_error(::intercom::store_error(err)),
                    };
         }
         if let Some(comptr) =
@@ -447,7 +450,7 @@ impl Foo for ::intercom::ComItf<Foo> {
                                                             b.into(),
                                                             &mut __out);
                          Ok({
-                                if __result == ::intercom::S_OK {
+                                if __result == ::intercom::raw::S_OK {
                                     Ok(__out.into())
                                 } else {
                                     Err(::intercom::get_last_error(__result))
@@ -458,10 +461,11 @@ impl Foo for ::intercom::ComItf<Foo> {
                        Ok(v) => v,
                        Err(err) =>
                        <ComResult<bool> as
-                           ErrorValue>::from_error(::intercom::return_hresult(err)),
+                           ErrorValue>::from_error(::intercom::store_error(err)),
                    };
         }
-        <ComResult<bool> as ErrorValue>::from_error(::intercom::E_POINTER)
+        <ComResult<bool> as
+            ErrorValue>::from_error(::intercom::store_error(::intercom::ComError::E_POINTER))
     }
     fn rust_result_method(&self) -> Result<u16, i32> {
         #[allow(unused_imports)]
@@ -480,7 +484,7 @@ impl Foo for ::intercom::ComItf<Foo> {
                              ((**vtbl).rust_result_method_Automation)(comptr.ptr,
                                                                       &mut __out);
                          Ok({
-                                if __result == ::intercom::S_OK {
+                                if __result == ::intercom::raw::S_OK {
                                     Ok(__out.into())
                                 } else {
                                     Err(::intercom::get_last_error(__result))
@@ -491,7 +495,7 @@ impl Foo for ::intercom::ComItf<Foo> {
                        Ok(v) => v,
                        Err(err) =>
                        <Result<u16, i32> as
-                           ErrorValue>::from_error(::intercom::return_hresult(err)),
+                           ErrorValue>::from_error(::intercom::store_error(err)),
                    };
         }
         if let Some(comptr) =
@@ -506,7 +510,7 @@ impl Foo for ::intercom::ComItf<Foo> {
                              ((**vtbl).rust_result_method_Raw)(comptr.ptr,
                                                                &mut __out);
                          Ok({
-                                if __result == ::intercom::S_OK {
+                                if __result == ::intercom::raw::S_OK {
                                     Ok(__out.into())
                                 } else {
                                     Err(::intercom::get_last_error(__result))
@@ -517,10 +521,11 @@ impl Foo for ::intercom::ComItf<Foo> {
                        Ok(v) => v,
                        Err(err) =>
                        <Result<u16, i32> as
-                           ErrorValue>::from_error(::intercom::return_hresult(err)),
+                           ErrorValue>::from_error(::intercom::store_error(err)),
                    };
         }
-        <Result<u16, i32> as ErrorValue>::from_error(::intercom::E_POINTER)
+        <Result<u16, i32> as
+            ErrorValue>::from_error(::intercom::store_error(::intercom::ComError::E_POINTER))
     }
     fn simple_method(&self) -> () {
         #[allow(unused_imports)]
@@ -542,7 +547,7 @@ impl Foo for ::intercom::ComItf<Foo> {
                        Ok(v) => v,
                        Err(err) =>
                        <() as
-                           ErrorValue>::from_error(::intercom::return_hresult(err)),
+                           ErrorValue>::from_error(::intercom::store_error(err)),
                    };
         }
         if let Some(comptr) =
@@ -560,10 +565,11 @@ impl Foo for ::intercom::ComItf<Foo> {
                        Ok(v) => v,
                        Err(err) =>
                        <() as
-                           ErrorValue>::from_error(::intercom::return_hresult(err)),
+                           ErrorValue>::from_error(::intercom::store_error(err)),
                    };
         }
-        <() as ErrorValue>::from_error(::intercom::E_POINTER)
+        <() as
+            ErrorValue>::from_error(::intercom::store_error(::intercom::ComError::E_POINTER))
     }
     fn simple_result_method(&self) -> u16 {
         #[allow(unused_imports)]
@@ -585,7 +591,7 @@ impl Foo for ::intercom::ComItf<Foo> {
                        Ok(v) => v,
                        Err(err) =>
                        <u16 as
-                           ErrorValue>::from_error(::intercom::return_hresult(err)),
+                           ErrorValue>::from_error(::intercom::store_error(err)),
                    };
         }
         if let Some(comptr) =
@@ -603,10 +609,11 @@ impl Foo for ::intercom::ComItf<Foo> {
                        Ok(v) => v,
                        Err(err) =>
                        <u16 as
-                           ErrorValue>::from_error(::intercom::return_hresult(err)),
+                           ErrorValue>::from_error(::intercom::store_error(err)),
                    };
         }
-        <u16 as ErrorValue>::from_error(::intercom::E_POINTER)
+        <u16 as
+            ErrorValue>::from_error(::intercom::store_error(::intercom::ComError::E_POINTER))
     }
     fn string_method(&self, msg: String) -> String {
         #[allow(unused_imports)]
@@ -636,7 +643,7 @@ impl Foo for ::intercom::ComItf<Foo> {
                        Ok(v) => v,
                        Err(err) =>
                        <String as
-                           ErrorValue>::from_error(::intercom::return_hresult(err)),
+                           ErrorValue>::from_error(::intercom::store_error(err)),
                    };
         }
         if let Some(comptr) =
@@ -662,10 +669,11 @@ impl Foo for ::intercom::ComItf<Foo> {
                        Ok(v) => v,
                        Err(err) =>
                        <String as
-                           ErrorValue>::from_error(::intercom::return_hresult(err)),
+                           ErrorValue>::from_error(::intercom::store_error(err)),
                    };
         }
-        <String as ErrorValue>::from_error(::intercom::E_POINTER)
+        <String as
+            ErrorValue>::from_error(::intercom::store_error(::intercom::ComError::E_POINTER))
     }
     fn variant_method(&self, input: Variant) -> ComResult<Variant> {
         #[allow(unused_imports)]
@@ -686,7 +694,7 @@ impl Foo for ::intercom::ComItf<Foo> {
                                                                   input.com_into()?,
                                                                   &mut __out);
                          Ok({
-                                if __result == ::intercom::S_OK {
+                                if __result == ::intercom::raw::S_OK {
                                     Ok(__out.into())
                                 } else {
                                     Err(::intercom::get_last_error(__result))
@@ -697,7 +705,7 @@ impl Foo for ::intercom::ComItf<Foo> {
                        Ok(v) => v,
                        Err(err) =>
                        <ComResult<Variant> as
-                           ErrorValue>::from_error(::intercom::return_hresult(err)),
+                           ErrorValue>::from_error(::intercom::store_error(err)),
                    };
         }
         if let Some(comptr) =
@@ -714,7 +722,7 @@ impl Foo for ::intercom::ComItf<Foo> {
                                                            input.com_into()?,
                                                            &mut __out);
                          Ok({
-                                if __result == ::intercom::S_OK {
+                                if __result == ::intercom::raw::S_OK {
                                     Ok(__out.into())
                                 } else {
                                     Err(::intercom::get_last_error(__result))
@@ -725,10 +733,11 @@ impl Foo for ::intercom::ComItf<Foo> {
                        Ok(v) => v,
                        Err(err) =>
                        <ComResult<Variant> as
-                           ErrorValue>::from_error(::intercom::return_hresult(err)),
+                           ErrorValue>::from_error(::intercom::store_error(err)),
                    };
         }
-        <ComResult<Variant> as ErrorValue>::from_error(::intercom::E_POINTER)
+        <ComResult<Variant> as
+            ErrorValue>::from_error(::intercom::store_error(::intercom::ComError::E_POINTER))
     }
 }
 impl ::intercom::ComInterface for Foo {

--- a/intercom-attributes/tests/data/com_interface.target.rs
+++ b/intercom-attributes/tests/data/com_interface.target.rs
@@ -175,13 +175,19 @@ impl Foo for ::intercom::ComItf<Foo> {
                          let __result =
                              ((**vtbl).arg_method_Automation)(comptr.ptr,
                                                               a.into());
+                         let INTERCOM_iid =
+                             ::intercom::GUID{data1: 0u32,
+                                              data2: 0u16,
+                                              data3: 0u16,
+                                              data4:
+                                                  [0u8, 0u8, 0u8, 0u8, 0u8,
+                                                   0u8, 0u8, 0u8],};
                          Ok({ })
                      })();
             return match result {
                        Ok(v) => v,
                        Err(err) =>
-                       <() as
-                           ErrorValue>::from_error(::intercom::store_error(err)),
+                       <() as ::intercom::ErrorValue>::from_com_error(err),
                    };
         }
         if let Some(comptr) =
@@ -193,17 +199,23 @@ impl Foo for ::intercom::ComItf<Foo> {
                      unsafe {
                          let __result =
                              ((**vtbl).arg_method_Raw)(comptr.ptr, a.into());
+                         let INTERCOM_iid =
+                             ::intercom::GUID{data1: 0u32,
+                                              data2: 0u16,
+                                              data3: 0u16,
+                                              data4:
+                                                  [0u8, 0u8, 0u8, 0u8, 0u8,
+                                                   0u8, 0u8, 1u8],};
                          Ok({ })
                      })();
             return match result {
                        Ok(v) => v,
                        Err(err) =>
-                       <() as
-                           ErrorValue>::from_error(::intercom::store_error(err)),
+                       <() as ::intercom::ErrorValue>::from_com_error(err),
                    };
         }
         <() as
-            ErrorValue>::from_error(::intercom::store_error(::intercom::ComError::E_POINTER))
+            ::intercom::ErrorValue>::from_com_error(::intercom::ComError::E_POINTER.into())
     }
     fn bool_method(&self, input: bool) -> ComResult<bool> {
         #[allow(unused_imports)]
@@ -223,11 +235,22 @@ impl Foo for ::intercom::ComItf<Foo> {
                              ((**vtbl).bool_method_Automation)(comptr.ptr,
                                                                input.into(),
                                                                &mut __out);
+                         let INTERCOM_iid =
+                             ::intercom::GUID{data1: 0u32,
+                                              data2: 0u16,
+                                              data3: 0u16,
+                                              data4:
+                                                  [0u8, 0u8, 0u8, 0u8, 0u8,
+                                                   0u8, 0u8, 0u8],};
                          Ok({
-                                if __result == ::intercom::raw::S_OK {
+                                if __result == ::intercom::raw::S_OK ||
+                                       __result == ::intercom::raw::S_FALSE {
                                     Ok(__out.into())
                                 } else {
-                                    Err(::intercom::get_last_error(__result))
+                                    return Err(::intercom::load_error(&ComItf::wrap(comptr.as_unknown(),
+                                                                                    ::intercom::TypeSystem::Automation),
+                                                                      &INTERCOM_iid,
+                                                                      __result));
                                 }
                             })
                      })();
@@ -235,7 +258,7 @@ impl Foo for ::intercom::ComItf<Foo> {
                        Ok(v) => v,
                        Err(err) =>
                        <ComResult<bool> as
-                           ErrorValue>::from_error(::intercom::store_error(err)),
+                           ::intercom::ErrorValue>::from_com_error(err),
                    };
         }
         if let Some(comptr) =
@@ -250,11 +273,22 @@ impl Foo for ::intercom::ComItf<Foo> {
                              ((**vtbl).bool_method_Raw)(comptr.ptr,
                                                         input.into(),
                                                         &mut __out);
+                         let INTERCOM_iid =
+                             ::intercom::GUID{data1: 0u32,
+                                              data2: 0u16,
+                                              data3: 0u16,
+                                              data4:
+                                                  [0u8, 0u8, 0u8, 0u8, 0u8,
+                                                   0u8, 0u8, 1u8],};
                          Ok({
-                                if __result == ::intercom::raw::S_OK {
+                                if __result == ::intercom::raw::S_OK ||
+                                       __result == ::intercom::raw::S_FALSE {
                                     Ok(__out.into())
                                 } else {
-                                    Err(::intercom::get_last_error(__result))
+                                    return Err(::intercom::load_error(&ComItf::wrap(comptr.as_unknown(),
+                                                                                    ::intercom::TypeSystem::Automation),
+                                                                      &INTERCOM_iid,
+                                                                      __result));
                                 }
                             })
                      })();
@@ -262,11 +296,11 @@ impl Foo for ::intercom::ComItf<Foo> {
                        Ok(v) => v,
                        Err(err) =>
                        <ComResult<bool> as
-                           ErrorValue>::from_error(::intercom::store_error(err)),
+                           ::intercom::ErrorValue>::from_com_error(err),
                    };
         }
         <ComResult<bool> as
-            ErrorValue>::from_error(::intercom::store_error(::intercom::ComError::E_POINTER))
+            ::intercom::ErrorValue>::from_com_error(::intercom::ComError::E_POINTER.into())
     }
     fn com_result_method(&self) -> ComResult<u16> {
         #[allow(unused_imports)]
@@ -284,11 +318,22 @@ impl Foo for ::intercom::ComItf<Foo> {
                          let __result =
                              ((**vtbl).com_result_method_Automation)(comptr.ptr,
                                                                      &mut __out);
+                         let INTERCOM_iid =
+                             ::intercom::GUID{data1: 0u32,
+                                              data2: 0u16,
+                                              data3: 0u16,
+                                              data4:
+                                                  [0u8, 0u8, 0u8, 0u8, 0u8,
+                                                   0u8, 0u8, 0u8],};
                          Ok({
-                                if __result == ::intercom::raw::S_OK {
+                                if __result == ::intercom::raw::S_OK ||
+                                       __result == ::intercom::raw::S_FALSE {
                                     Ok(__out.into())
                                 } else {
-                                    Err(::intercom::get_last_error(__result))
+                                    return Err(::intercom::load_error(&ComItf::wrap(comptr.as_unknown(),
+                                                                                    ::intercom::TypeSystem::Automation),
+                                                                      &INTERCOM_iid,
+                                                                      __result));
                                 }
                             })
                      })();
@@ -296,7 +341,7 @@ impl Foo for ::intercom::ComItf<Foo> {
                        Ok(v) => v,
                        Err(err) =>
                        <ComResult<u16> as
-                           ErrorValue>::from_error(::intercom::store_error(err)),
+                           ::intercom::ErrorValue>::from_com_error(err),
                    };
         }
         if let Some(comptr) =
@@ -310,11 +355,22 @@ impl Foo for ::intercom::ComItf<Foo> {
                          let __result =
                              ((**vtbl).com_result_method_Raw)(comptr.ptr,
                                                               &mut __out);
+                         let INTERCOM_iid =
+                             ::intercom::GUID{data1: 0u32,
+                                              data2: 0u16,
+                                              data3: 0u16,
+                                              data4:
+                                                  [0u8, 0u8, 0u8, 0u8, 0u8,
+                                                   0u8, 0u8, 1u8],};
                          Ok({
-                                if __result == ::intercom::raw::S_OK {
+                                if __result == ::intercom::raw::S_OK ||
+                                       __result == ::intercom::raw::S_FALSE {
                                     Ok(__out.into())
                                 } else {
-                                    Err(::intercom::get_last_error(__result))
+                                    return Err(::intercom::load_error(&ComItf::wrap(comptr.as_unknown(),
+                                                                                    ::intercom::TypeSystem::Automation),
+                                                                      &INTERCOM_iid,
+                                                                      __result));
                                 }
                             })
                      })();
@@ -322,11 +378,11 @@ impl Foo for ::intercom::ComItf<Foo> {
                        Ok(v) => v,
                        Err(err) =>
                        <ComResult<u16> as
-                           ErrorValue>::from_error(::intercom::store_error(err)),
+                           ::intercom::ErrorValue>::from_com_error(err),
                    };
         }
         <ComResult<u16> as
-            ErrorValue>::from_error(::intercom::store_error(::intercom::ComError::E_POINTER))
+            ::intercom::ErrorValue>::from_com_error(::intercom::ComError::E_POINTER.into())
     }
     fn comitf_method(&self, itf: ComItf<Foo>) -> ComResult<ComItf<IUnknown>> {
         #[allow(unused_imports)]
@@ -350,12 +406,23 @@ impl Foo for ::intercom::ComItf<Foo> {
                                                                  ::intercom::ComItf::ptr(&itf.into(),
                                                                                          ::intercom::TypeSystem::Automation),
                                                                  &mut __out);
+                         let INTERCOM_iid =
+                             ::intercom::GUID{data1: 0u32,
+                                              data2: 0u16,
+                                              data3: 0u16,
+                                              data4:
+                                                  [0u8, 0u8, 0u8, 0u8, 0u8,
+                                                   0u8, 0u8, 0u8],};
                          Ok({
-                                if __result == ::intercom::raw::S_OK {
+                                if __result == ::intercom::raw::S_OK ||
+                                       __result == ::intercom::raw::S_FALSE {
                                     Ok(::intercom::ComItf::wrap(__out,
                                                                 ::intercom::TypeSystem::Automation))
                                 } else {
-                                    Err(::intercom::get_last_error(__result))
+                                    return Err(::intercom::load_error(&ComItf::wrap(comptr.as_unknown(),
+                                                                                    ::intercom::TypeSystem::Automation),
+                                                                      &INTERCOM_iid,
+                                                                      __result));
                                 }
                             })
                      })();
@@ -363,7 +430,7 @@ impl Foo for ::intercom::ComItf<Foo> {
                        Ok(v) => v,
                        Err(err) =>
                        <ComResult<ComItf<IUnknown>> as
-                           ErrorValue>::from_error(::intercom::store_error(err)),
+                           ::intercom::ErrorValue>::from_com_error(err),
                    };
         }
         if let Some(comptr) =
@@ -383,12 +450,23 @@ impl Foo for ::intercom::ComItf<Foo> {
                                                           ::intercom::ComItf::ptr(&itf.into(),
                                                                                   ::intercom::TypeSystem::Raw),
                                                           &mut __out);
+                         let INTERCOM_iid =
+                             ::intercom::GUID{data1: 0u32,
+                                              data2: 0u16,
+                                              data3: 0u16,
+                                              data4:
+                                                  [0u8, 0u8, 0u8, 0u8, 0u8,
+                                                   0u8, 0u8, 1u8],};
                          Ok({
-                                if __result == ::intercom::raw::S_OK {
+                                if __result == ::intercom::raw::S_OK ||
+                                       __result == ::intercom::raw::S_FALSE {
                                     Ok(::intercom::ComItf::wrap(__out,
                                                                 ::intercom::TypeSystem::Raw))
                                 } else {
-                                    Err(::intercom::get_last_error(__result))
+                                    return Err(::intercom::load_error(&ComItf::wrap(comptr.as_unknown(),
+                                                                                    ::intercom::TypeSystem::Automation),
+                                                                      &INTERCOM_iid,
+                                                                      __result));
                                 }
                             })
                      })();
@@ -396,11 +474,11 @@ impl Foo for ::intercom::ComItf<Foo> {
                        Ok(v) => v,
                        Err(err) =>
                        <ComResult<ComItf<IUnknown>> as
-                           ErrorValue>::from_error(::intercom::store_error(err)),
+                           ::intercom::ErrorValue>::from_com_error(err),
                    };
         }
         <ComResult<ComItf<IUnknown>> as
-            ErrorValue>::from_error(::intercom::store_error(::intercom::ComError::E_POINTER))
+            ::intercom::ErrorValue>::from_com_error(::intercom::ComError::E_POINTER.into())
     }
     fn complete_method(&mut self, a: u16, b: i16) -> ComResult<bool> {
         #[allow(unused_imports)]
@@ -421,11 +499,22 @@ impl Foo for ::intercom::ComItf<Foo> {
                                                                    a.into(),
                                                                    b.into(),
                                                                    &mut __out);
+                         let INTERCOM_iid =
+                             ::intercom::GUID{data1: 0u32,
+                                              data2: 0u16,
+                                              data3: 0u16,
+                                              data4:
+                                                  [0u8, 0u8, 0u8, 0u8, 0u8,
+                                                   0u8, 0u8, 0u8],};
                          Ok({
-                                if __result == ::intercom::raw::S_OK {
+                                if __result == ::intercom::raw::S_OK ||
+                                       __result == ::intercom::raw::S_FALSE {
                                     Ok(__out.into())
                                 } else {
-                                    Err(::intercom::get_last_error(__result))
+                                    return Err(::intercom::load_error(&ComItf::wrap(comptr.as_unknown(),
+                                                                                    ::intercom::TypeSystem::Automation),
+                                                                      &INTERCOM_iid,
+                                                                      __result));
                                 }
                             })
                      })();
@@ -433,7 +522,7 @@ impl Foo for ::intercom::ComItf<Foo> {
                        Ok(v) => v,
                        Err(err) =>
                        <ComResult<bool> as
-                           ErrorValue>::from_error(::intercom::store_error(err)),
+                           ::intercom::ErrorValue>::from_com_error(err),
                    };
         }
         if let Some(comptr) =
@@ -449,11 +538,22 @@ impl Foo for ::intercom::ComItf<Foo> {
                                                             a.into(),
                                                             b.into(),
                                                             &mut __out);
+                         let INTERCOM_iid =
+                             ::intercom::GUID{data1: 0u32,
+                                              data2: 0u16,
+                                              data3: 0u16,
+                                              data4:
+                                                  [0u8, 0u8, 0u8, 0u8, 0u8,
+                                                   0u8, 0u8, 1u8],};
                          Ok({
-                                if __result == ::intercom::raw::S_OK {
+                                if __result == ::intercom::raw::S_OK ||
+                                       __result == ::intercom::raw::S_FALSE {
                                     Ok(__out.into())
                                 } else {
-                                    Err(::intercom::get_last_error(__result))
+                                    return Err(::intercom::load_error(&ComItf::wrap(comptr.as_unknown(),
+                                                                                    ::intercom::TypeSystem::Automation),
+                                                                      &INTERCOM_iid,
+                                                                      __result));
                                 }
                             })
                      })();
@@ -461,11 +561,11 @@ impl Foo for ::intercom::ComItf<Foo> {
                        Ok(v) => v,
                        Err(err) =>
                        <ComResult<bool> as
-                           ErrorValue>::from_error(::intercom::store_error(err)),
+                           ::intercom::ErrorValue>::from_com_error(err),
                    };
         }
         <ComResult<bool> as
-            ErrorValue>::from_error(::intercom::store_error(::intercom::ComError::E_POINTER))
+            ::intercom::ErrorValue>::from_com_error(::intercom::ComError::E_POINTER.into())
     }
     fn rust_result_method(&self) -> Result<u16, i32> {
         #[allow(unused_imports)]
@@ -483,11 +583,22 @@ impl Foo for ::intercom::ComItf<Foo> {
                          let __result =
                              ((**vtbl).rust_result_method_Automation)(comptr.ptr,
                                                                       &mut __out);
+                         let INTERCOM_iid =
+                             ::intercom::GUID{data1: 0u32,
+                                              data2: 0u16,
+                                              data3: 0u16,
+                                              data4:
+                                                  [0u8, 0u8, 0u8, 0u8, 0u8,
+                                                   0u8, 0u8, 0u8],};
                          Ok({
-                                if __result == ::intercom::raw::S_OK {
+                                if __result == ::intercom::raw::S_OK ||
+                                       __result == ::intercom::raw::S_FALSE {
                                     Ok(__out.into())
                                 } else {
-                                    Err(::intercom::get_last_error(__result))
+                                    return Err(::intercom::load_error(&ComItf::wrap(comptr.as_unknown(),
+                                                                                    ::intercom::TypeSystem::Automation),
+                                                                      &INTERCOM_iid,
+                                                                      __result));
                                 }
                             })
                      })();
@@ -495,7 +606,7 @@ impl Foo for ::intercom::ComItf<Foo> {
                        Ok(v) => v,
                        Err(err) =>
                        <Result<u16, i32> as
-                           ErrorValue>::from_error(::intercom::store_error(err)),
+                           ::intercom::ErrorValue>::from_com_error(err),
                    };
         }
         if let Some(comptr) =
@@ -509,11 +620,22 @@ impl Foo for ::intercom::ComItf<Foo> {
                          let __result =
                              ((**vtbl).rust_result_method_Raw)(comptr.ptr,
                                                                &mut __out);
+                         let INTERCOM_iid =
+                             ::intercom::GUID{data1: 0u32,
+                                              data2: 0u16,
+                                              data3: 0u16,
+                                              data4:
+                                                  [0u8, 0u8, 0u8, 0u8, 0u8,
+                                                   0u8, 0u8, 1u8],};
                          Ok({
-                                if __result == ::intercom::raw::S_OK {
+                                if __result == ::intercom::raw::S_OK ||
+                                       __result == ::intercom::raw::S_FALSE {
                                     Ok(__out.into())
                                 } else {
-                                    Err(::intercom::get_last_error(__result))
+                                    return Err(::intercom::load_error(&ComItf::wrap(comptr.as_unknown(),
+                                                                                    ::intercom::TypeSystem::Automation),
+                                                                      &INTERCOM_iid,
+                                                                      __result));
                                 }
                             })
                      })();
@@ -521,11 +643,11 @@ impl Foo for ::intercom::ComItf<Foo> {
                        Ok(v) => v,
                        Err(err) =>
                        <Result<u16, i32> as
-                           ErrorValue>::from_error(::intercom::store_error(err)),
+                           ::intercom::ErrorValue>::from_com_error(err),
                    };
         }
         <Result<u16, i32> as
-            ErrorValue>::from_error(::intercom::store_error(::intercom::ComError::E_POINTER))
+            ::intercom::ErrorValue>::from_com_error(::intercom::ComError::E_POINTER.into())
     }
     fn simple_method(&self) -> () {
         #[allow(unused_imports)]
@@ -541,13 +663,19 @@ impl Foo for ::intercom::ComItf<Foo> {
                      unsafe {
                          let __result =
                              ((**vtbl).simple_method_Automation)(comptr.ptr);
+                         let INTERCOM_iid =
+                             ::intercom::GUID{data1: 0u32,
+                                              data2: 0u16,
+                                              data3: 0u16,
+                                              data4:
+                                                  [0u8, 0u8, 0u8, 0u8, 0u8,
+                                                   0u8, 0u8, 0u8],};
                          Ok({ })
                      })();
             return match result {
                        Ok(v) => v,
                        Err(err) =>
-                       <() as
-                           ErrorValue>::from_error(::intercom::store_error(err)),
+                       <() as ::intercom::ErrorValue>::from_com_error(err),
                    };
         }
         if let Some(comptr) =
@@ -559,17 +687,23 @@ impl Foo for ::intercom::ComItf<Foo> {
                      unsafe {
                          let __result =
                              ((**vtbl).simple_method_Raw)(comptr.ptr);
+                         let INTERCOM_iid =
+                             ::intercom::GUID{data1: 0u32,
+                                              data2: 0u16,
+                                              data3: 0u16,
+                                              data4:
+                                                  [0u8, 0u8, 0u8, 0u8, 0u8,
+                                                   0u8, 0u8, 1u8],};
                          Ok({ })
                      })();
             return match result {
                        Ok(v) => v,
                        Err(err) =>
-                       <() as
-                           ErrorValue>::from_error(::intercom::store_error(err)),
+                       <() as ::intercom::ErrorValue>::from_com_error(err),
                    };
         }
         <() as
-            ErrorValue>::from_error(::intercom::store_error(::intercom::ComError::E_POINTER))
+            ::intercom::ErrorValue>::from_com_error(::intercom::ComError::E_POINTER.into())
     }
     fn simple_result_method(&self) -> u16 {
         #[allow(unused_imports)]
@@ -585,13 +719,19 @@ impl Foo for ::intercom::ComItf<Foo> {
                      unsafe {
                          let __result =
                              ((**vtbl).simple_result_method_Automation)(comptr.ptr);
+                         let INTERCOM_iid =
+                             ::intercom::GUID{data1: 0u32,
+                                              data2: 0u16,
+                                              data3: 0u16,
+                                              data4:
+                                                  [0u8, 0u8, 0u8, 0u8, 0u8,
+                                                   0u8, 0u8, 0u8],};
                          Ok({ __result.into() })
                      })();
             return match result {
                        Ok(v) => v,
                        Err(err) =>
-                       <u16 as
-                           ErrorValue>::from_error(::intercom::store_error(err)),
+                       <u16 as ::intercom::ErrorValue>::from_com_error(err),
                    };
         }
         if let Some(comptr) =
@@ -603,17 +743,23 @@ impl Foo for ::intercom::ComItf<Foo> {
                      unsafe {
                          let __result =
                              ((**vtbl).simple_result_method_Raw)(comptr.ptr);
+                         let INTERCOM_iid =
+                             ::intercom::GUID{data1: 0u32,
+                                              data2: 0u16,
+                                              data3: 0u16,
+                                              data4:
+                                                  [0u8, 0u8, 0u8, 0u8, 0u8,
+                                                   0u8, 0u8, 1u8],};
                          Ok({ __result.into() })
                      })();
             return match result {
                        Ok(v) => v,
                        Err(err) =>
-                       <u16 as
-                           ErrorValue>::from_error(::intercom::store_error(err)),
+                       <u16 as ::intercom::ErrorValue>::from_com_error(err),
                    };
         }
         <u16 as
-            ErrorValue>::from_error(::intercom::store_error(::intercom::ComError::E_POINTER))
+            ::intercom::ErrorValue>::from_com_error(::intercom::ComError::E_POINTER.into())
     }
     fn string_method(&self, msg: String) -> String {
         #[allow(unused_imports)]
@@ -635,6 +781,13 @@ impl Foo for ::intercom::ComItf<Foo> {
                                                                  <&::intercom::BStr
                                                                      as
                                                                      ::intercom::FromWithTemporary<String>>::from_temporary(&mut __msg_temporary)?.as_ptr());
+                         let INTERCOM_iid =
+                             ::intercom::GUID{data1: 0u32,
+                                              data2: 0u16,
+                                              data3: 0u16,
+                                              data4:
+                                                  [0u8, 0u8, 0u8, 0u8, 0u8,
+                                                   0u8, 0u8, 0u8],};
                          Ok({
                                 ::intercom::BString::from_ptr(__result).com_into()?
                             })
@@ -643,7 +796,7 @@ impl Foo for ::intercom::ComItf<Foo> {
                        Ok(v) => v,
                        Err(err) =>
                        <String as
-                           ErrorValue>::from_error(::intercom::store_error(err)),
+                           ::intercom::ErrorValue>::from_com_error(err),
                    };
         }
         if let Some(comptr) =
@@ -661,6 +814,13 @@ impl Foo for ::intercom::ComItf<Foo> {
                                                           <&::intercom::CStr
                                                               as
                                                               ::intercom::FromWithTemporary<String>>::from_temporary(&mut __msg_temporary)?.as_ptr());
+                         let INTERCOM_iid =
+                             ::intercom::GUID{data1: 0u32,
+                                              data2: 0u16,
+                                              data3: 0u16,
+                                              data4:
+                                                  [0u8, 0u8, 0u8, 0u8, 0u8,
+                                                   0u8, 0u8, 1u8],};
                          Ok({
                                 ::intercom::CString::from_raw(__result).com_into()?
                             })
@@ -669,11 +829,11 @@ impl Foo for ::intercom::ComItf<Foo> {
                        Ok(v) => v,
                        Err(err) =>
                        <String as
-                           ErrorValue>::from_error(::intercom::store_error(err)),
+                           ::intercom::ErrorValue>::from_com_error(err),
                    };
         }
         <String as
-            ErrorValue>::from_error(::intercom::store_error(::intercom::ComError::E_POINTER))
+            ::intercom::ErrorValue>::from_com_error(::intercom::ComError::E_POINTER.into())
     }
     fn variant_method(&self, input: Variant) -> ComResult<Variant> {
         #[allow(unused_imports)]
@@ -693,11 +853,22 @@ impl Foo for ::intercom::ComItf<Foo> {
                              ((**vtbl).variant_method_Automation)(comptr.ptr,
                                                                   input.com_into()?,
                                                                   &mut __out);
+                         let INTERCOM_iid =
+                             ::intercom::GUID{data1: 0u32,
+                                              data2: 0u16,
+                                              data3: 0u16,
+                                              data4:
+                                                  [0u8, 0u8, 0u8, 0u8, 0u8,
+                                                   0u8, 0u8, 0u8],};
                          Ok({
-                                if __result == ::intercom::raw::S_OK {
+                                if __result == ::intercom::raw::S_OK ||
+                                       __result == ::intercom::raw::S_FALSE {
                                     Ok(__out.into())
                                 } else {
-                                    Err(::intercom::get_last_error(__result))
+                                    return Err(::intercom::load_error(&ComItf::wrap(comptr.as_unknown(),
+                                                                                    ::intercom::TypeSystem::Automation),
+                                                                      &INTERCOM_iid,
+                                                                      __result));
                                 }
                             })
                      })();
@@ -705,7 +876,7 @@ impl Foo for ::intercom::ComItf<Foo> {
                        Ok(v) => v,
                        Err(err) =>
                        <ComResult<Variant> as
-                           ErrorValue>::from_error(::intercom::store_error(err)),
+                           ::intercom::ErrorValue>::from_com_error(err),
                    };
         }
         if let Some(comptr) =
@@ -721,11 +892,22 @@ impl Foo for ::intercom::ComItf<Foo> {
                              ((**vtbl).variant_method_Raw)(comptr.ptr,
                                                            input.com_into()?,
                                                            &mut __out);
+                         let INTERCOM_iid =
+                             ::intercom::GUID{data1: 0u32,
+                                              data2: 0u16,
+                                              data3: 0u16,
+                                              data4:
+                                                  [0u8, 0u8, 0u8, 0u8, 0u8,
+                                                   0u8, 0u8, 1u8],};
                          Ok({
-                                if __result == ::intercom::raw::S_OK {
+                                if __result == ::intercom::raw::S_OK ||
+                                       __result == ::intercom::raw::S_FALSE {
                                     Ok(__out.into())
                                 } else {
-                                    Err(::intercom::get_last_error(__result))
+                                    return Err(::intercom::load_error(&ComItf::wrap(comptr.as_unknown(),
+                                                                                    ::intercom::TypeSystem::Automation),
+                                                                      &INTERCOM_iid,
+                                                                      __result));
                                 }
                             })
                      })();
@@ -733,11 +915,11 @@ impl Foo for ::intercom::ComItf<Foo> {
                        Ok(v) => v,
                        Err(err) =>
                        <ComResult<Variant> as
-                           ErrorValue>::from_error(::intercom::store_error(err)),
+                           ::intercom::ErrorValue>::from_com_error(err),
                    };
         }
         <ComResult<Variant> as
-            ErrorValue>::from_error(::intercom::store_error(::intercom::ComError::E_POINTER))
+            ::intercom::ErrorValue>::from_com_error(::intercom::ComError::E_POINTER.into())
     }
 }
 impl ::intercom::ComInterface for Foo {

--- a/intercom-attributes/tests/data/private_item.target.rs
+++ b/intercom-attributes/tests/data/private_item.target.rs
@@ -57,13 +57,19 @@ impl IFoo for ::intercom::ComItf<IFoo> {
                      unsafe {
                          let __result =
                              ((**vtbl).trait_method_Automation)(comptr.ptr);
+                         let INTERCOM_iid =
+                             ::intercom::GUID{data1: 0u32,
+                                              data2: 0u16,
+                                              data3: 0u16,
+                                              data4:
+                                                  [0u8, 0u8, 0u8, 0u8, 0u8,
+                                                   0u8, 0u8, 0u8],};
                          Ok({ })
                      })();
             return match result {
                        Ok(v) => v,
                        Err(err) =>
-                       <() as
-                           ErrorValue>::from_error(::intercom::store_error(err)),
+                       <() as ::intercom::ErrorValue>::from_com_error(err),
                    };
         }
         if let Some(comptr) =
@@ -75,17 +81,23 @@ impl IFoo for ::intercom::ComItf<IFoo> {
                      unsafe {
                          let __result =
                              ((**vtbl).trait_method_Raw)(comptr.ptr);
+                         let INTERCOM_iid =
+                             ::intercom::GUID{data1: 0u32,
+                                              data2: 0u16,
+                                              data3: 0u16,
+                                              data4:
+                                                  [0u8, 0u8, 0u8, 0u8, 0u8,
+                                                   0u8, 0u8, 1u8],};
                          Ok({ })
                      })();
             return match result {
                        Ok(v) => v,
                        Err(err) =>
-                       <() as
-                           ErrorValue>::from_error(::intercom::store_error(err)),
+                       <() as ::intercom::ErrorValue>::from_com_error(err),
                    };
         }
         <() as
-            ErrorValue>::from_error(::intercom::store_error(::intercom::ComError::E_POINTER))
+            ::intercom::ErrorValue>::from_com_error(::intercom::ComError::E_POINTER.into())
     }
 }
 impl ::intercom::ComInterface for IFoo {

--- a/intercom-attributes/tests/data/private_item.target.rs
+++ b/intercom-attributes/tests/data/private_item.target.rs
@@ -63,7 +63,7 @@ impl IFoo for ::intercom::ComItf<IFoo> {
                        Ok(v) => v,
                        Err(err) =>
                        <() as
-                           ErrorValue>::from_error(::intercom::return_hresult(err)),
+                           ErrorValue>::from_error(::intercom::store_error(err)),
                    };
         }
         if let Some(comptr) =
@@ -81,10 +81,11 @@ impl IFoo for ::intercom::ComItf<IFoo> {
                        Ok(v) => v,
                        Err(err) =>
                        <() as
-                           ErrorValue>::from_error(::intercom::return_hresult(err)),
+                           ErrorValue>::from_error(::intercom::store_error(err)),
                    };
         }
-        <() as ErrorValue>::from_error(::intercom::E_POINTER)
+        <() as
+            ErrorValue>::from_error(::intercom::store_error(::intercom::ComError::E_POINTER))
     }
 }
 impl ::intercom::ComInterface for IFoo {
@@ -168,8 +169,8 @@ impl ::intercom::CoClass for Foo {
                       IFoo_Raw: &__Foo_IFoo_RawVtbl_INSTANCE,}
     }
     fn query_interface(vtables: &Self::VTableList, riid: ::intercom::REFIID)
-     -> ::intercom::ComResult<::intercom::RawComPtr> {
-        if riid.is_null() { return Err(::intercom::E_NOINTERFACE) }
+     -> ::intercom::RawComResult<::intercom::RawComPtr> {
+        if riid.is_null() { return Err(::intercom::raw::E_NOINTERFACE) }
         Ok(match *unsafe { &*riid } {
                ::intercom::IID_IUnknown =>
                (&vtables._ISupportErrorInfo) as
@@ -193,7 +194,7 @@ impl ::intercom::CoClass for Foo {
                self::IID_IFoo_Raw =>
                &vtables.IFoo_Raw as *const &__IFoo_RawVtbl as
                    *mut &__IFoo_RawVtbl as ::intercom::RawComPtr,
-               _ => return Err(::intercom::E_NOINTERFACE),
+               _ => return Err(::intercom::raw::E_NOINTERFACE),
            })
     }
     fn interface_supports_error_info(riid: ::intercom::REFIID) -> bool {
@@ -225,7 +226,7 @@ unsafe extern "C" fn __Foo_Foo_Automation_query_interface(self_vtable:
                                                                     ::intercom::REFIID,
                                                                 out:
                                                                     *mut ::intercom::RawComPtr)
- -> ::intercom::HRESULT {
+ -> ::intercom::raw::HRESULT {
     ::intercom::ComBox::<Foo>::query_interface(&mut *((self_vtable as usize -
                                                            __Foo_Foo_AutomationVtbl_offset())
                                                           as *mut _), riid,
@@ -272,7 +273,7 @@ unsafe extern "C" fn __Foo_Foo_Automation_struct_method_Automation(self_vtable:
     match result {
         Ok(v) => v,
         Err(err) =>
-        <() as ErrorValue>::from_error(::intercom::return_hresult(err)),
+        <() as ErrorValue>::from_error(::intercom::store_error(err)),
     }
 }
 #[allow(non_upper_case_globals)]
@@ -294,7 +295,7 @@ unsafe extern "C" fn __Foo_Foo_Raw_query_interface(self_vtable:
                                                              ::intercom::REFIID,
                                                          out:
                                                              *mut ::intercom::RawComPtr)
- -> ::intercom::HRESULT {
+ -> ::intercom::raw::HRESULT {
     ::intercom::ComBox::<Foo>::query_interface(&mut *((self_vtable as usize -
                                                            __Foo_Foo_RawVtbl_offset())
                                                           as *mut _), riid,
@@ -340,7 +341,7 @@ unsafe extern "C" fn __Foo_Foo_Raw_struct_method_Raw(self_vtable:
     match result {
         Ok(v) => v,
         Err(err) =>
-        <() as ErrorValue>::from_error(::intercom::return_hresult(err)),
+        <() as ErrorValue>::from_error(::intercom::store_error(err)),
     }
 }
 #[allow(non_upper_case_globals)]
@@ -422,7 +423,7 @@ unsafe extern "C" fn __Foo_IFoo_Automation_query_interface(self_vtable:
                                                                      ::intercom::REFIID,
                                                                  out:
                                                                      *mut ::intercom::RawComPtr)
- -> ::intercom::HRESULT {
+ -> ::intercom::raw::HRESULT {
     ::intercom::ComBox::<Foo>::query_interface(&mut *((self_vtable as usize -
                                                            __Foo_IFoo_AutomationVtbl_offset())
                                                           as *mut _), riid,
@@ -469,7 +470,7 @@ unsafe extern "C" fn __Foo_IFoo_Automation_trait_method_Automation(self_vtable:
     match result {
         Ok(v) => v,
         Err(err) =>
-        <() as ErrorValue>::from_error(::intercom::return_hresult(err)),
+        <() as ErrorValue>::from_error(::intercom::store_error(err)),
     }
 }
 #[allow(non_upper_case_globals)]
@@ -491,7 +492,7 @@ unsafe extern "C" fn __Foo_IFoo_Raw_query_interface(self_vtable:
                                                               ::intercom::REFIID,
                                                           out:
                                                               *mut ::intercom::RawComPtr)
- -> ::intercom::HRESULT {
+ -> ::intercom::raw::HRESULT {
     ::intercom::ComBox::<Foo>::query_interface(&mut *((self_vtable as usize -
                                                            __Foo_IFoo_RawVtbl_offset())
                                                           as *mut _), riid,
@@ -537,7 +538,7 @@ unsafe extern "C" fn __Foo_IFoo_Raw_trait_method_Raw(self_vtable:
     match result {
         Ok(v) => v,
         Err(err) =>
-        <() as ErrorValue>::from_error(::intercom::return_hresult(err)),
+        <() as ErrorValue>::from_error(::intercom::store_error(err)),
     }
 }
 #[allow(non_upper_case_globals)]

--- a/intercom-common/src/attributes/com_class.rs
+++ b/intercom-common/src/attributes/com_class.rs
@@ -177,11 +177,11 @@ pub fn expand_com_class(
                 fn query_interface(
                     vtables : &Self::VTableList,
                     riid : ::intercom::REFIID,
-                ) -> ::intercom::ComResult< ::intercom::RawComPtr > {
-                    if riid.is_null() { return Err( ::intercom::E_NOINTERFACE ) }
+                ) -> ::intercom::RawComResult< ::intercom::RawComPtr > {
+                    if riid.is_null() { return Err( ::intercom::raw::E_NOINTERFACE ) }
                     Ok( match *unsafe { &*riid } {
                         #( #query_interface_match_arms ),*,
-                        _ => return Err( ::intercom::E_NOINTERFACE )
+                        _ => return Err( ::intercom::raw::E_NOINTERFACE )
                     } )
                 }
 

--- a/intercom-common/src/attributes/com_impl.rs
+++ b/intercom-common/src/attributes/com_impl.rs
@@ -59,7 +59,7 @@ pub fn expand_com_impl(
                     self_vtable : ::intercom::RawComPtr,
                     riid : ::intercom::REFIID,
                     out : *mut ::intercom::RawComPtr
-                ) -> ::intercom::HRESULT
+                ) -> ::intercom::raw::HRESULT
                 {
                     // Get the primary iunk interface by offsetting the current
                     // self_vtable with the vtable offset. Once we have the primary
@@ -195,7 +195,7 @@ pub fn expand_com_impl(
                     match result {
                         Ok( v ) => v,
                         Err( err ) => < #ret_ty as ErrorValue >::from_error(
-                                ::intercom::return_hresult( err ) ),
+                                ::intercom::store_error( err ) ),
                     }
                 }
             ) );

--- a/intercom-common/src/attributes/com_interface.rs
+++ b/intercom-common/src/attributes/com_interface.rs
@@ -112,8 +112,8 @@ pub fn expand_com_interface(
 
                     // None of the type system pointers were available,
                     // which means this is a null reference.
-                    < #return_ty as ErrorValue >::from_error(
-                            ::intercom::store_error( ::intercom::ComError::E_POINTER ) )
+                    < #return_ty as ::intercom::ErrorValue >::from_com_error(
+                            ::intercom::ComError::E_POINTER.into() )
                 }
             ) );
         }
@@ -275,7 +275,7 @@ fn process_itf_variant(
                 .expect( "We just ensured this exists three lines up... ;_;" );
         method_impl.impls.insert(
                 itf_variant.type_system(),
-                rust_to_com_delegate( method_info, &vtable_ident ) );
+                rust_to_com_delegate( itf_variant, method_info, &vtable_ident ) );
     }
 
     // Create the vtable. We've already gathered all the vtable method
@@ -293,9 +293,11 @@ fn process_itf_variant(
 ///
 /// # Arguments
 ///
+/// * `itf_variant` - Interface variant details.
 /// * `method_info` - Method to delegate.
 /// * `vtable_ident` - Vtable to use for the delegation.
 fn rust_to_com_delegate(
+    itf_variant : &model::ComInterfaceVariant,
     method_info : &ComMethodInfo,
     vtable_ident : &Ident,
 ) -> TokenStream {
@@ -342,6 +344,7 @@ fn rust_to_com_delegate(
     // Resolve some of the fields needed for quote.
     let method_ident = &method_info.unique_name;
     let return_ty = &method_info.rust_return_ty;
+    let iid_tokens = utils::get_guid_tokens( itf_variant.iid() );
 
     // Construct the final method.
     quote!(
@@ -357,13 +360,13 @@ fn rust_to_com_delegate(
             #( #out_arg_declarations )*;
             let #return_ident = ((**vtbl).#method_ident)( #( #params ),* );
 
+            let INTERCOM_iid = #iid_tokens;
             Ok( { #return_statement } )
         } )();
 
         return match result {
             Ok( v ) => v,
-            Err( err ) => < #return_ty as ErrorValue >::from_error(
-                    ::intercom::store_error( err ) ),
+            Err( err ) => < #return_ty as ::intercom::ErrorValue >::from_com_error( err ),
         };
     )
 }

--- a/intercom-common/src/attributes/com_library.rs
+++ b/intercom-common/src/attributes/com_library.rs
@@ -98,7 +98,7 @@ fn get_dll_get_class_object_function(
                 rclsid : ::intercom::REFCLSID,
                 riid : ::intercom::REFIID,
                 pout : *mut ::intercom::RawComPtr
-            ) -> ::intercom::HRESULT
+            ) -> ::intercom::raw::HRESULT
             {
                 // Create new class factory.
                 // Specify a create function that is able to create all the
@@ -107,7 +107,7 @@ fn get_dll_get_class_object_function(
                     ::intercom::ClassFactory::new( rclsid, | clsid | {
                         match *clsid {
                             #( #match_arms, )*
-                            _ => Err( ::intercom::E_NOINTERFACE ),
+                            _ => Err( ::intercom::raw::E_NOINTERFACE ),
                         }
                     } ) );
                 ::intercom::ComBox::query_interface(
@@ -119,7 +119,7 @@ fn get_dll_get_class_object_function(
                 // This is okay, as the query_interface incremented it, leaving
                 // it at two at this point.
 
-                ::intercom::S_OK
+                ::intercom::raw::S_OK
             }
         )
 }
@@ -138,11 +138,11 @@ fn get_intercom_list_class_objects_function(
             pub unsafe extern #calling_convetion fn IntercomListClassObjects(
                 pcount: *mut usize,
                 pclsids: *mut *const ::intercom::CLSID,
-            ) -> ::intercom::HRESULT
+            ) -> ::intercom::raw::HRESULT
             {
                 // Do not crash due to invalid parameters.
-                if pcount.is_null() { return ::intercom::E_POINTER; }
-                if pclsids.is_null() { return ::intercom::E_POINTER; }
+                if pcount.is_null() { return ::intercom::raw::E_POINTER; }
+                if pclsids.is_null() { return ::intercom::raw::E_POINTER; }
 
                 // Store the available CLSID in a static variable so that we can
                 // pass them as-is to the caller.
@@ -156,7 +156,7 @@ fn get_intercom_list_class_objects_function(
                 *pcount = #token_count;
                 *pclsids = AVAILABLE_CLASSES.as_ptr();
 
-                ::intercom::S_OK
+                ::intercom::raw::S_OK
             }
         )
 }

--- a/intercom-common/src/builtin_model.rs
+++ b/intercom-common/src/builtin_model.rs
@@ -20,6 +20,12 @@ pub fn builtin_intercom_types( lib_name: &str ) -> Vec<BuiltinTypeInfo> {
             implementation: allocator_impl(),
             ctor: quote!( ::intercom::alloc::Allocator::default() ),
         },
+        BuiltinTypeInfo {
+            interface: errorstore_interface( lib_name ),
+            class: errorstore_class( lib_name ),
+            implementation: errorstore_impl(),
+            ctor: quote!( ::intercom::error::ErrorStore::default() ),
+        },
     ]
 }
 
@@ -47,21 +53,42 @@ fn allocator_class( lib_name: &str ) -> ComStruct {
 fn allocator_impl_code() -> &'static str {
     r#"
     impl Allocator {
-        unsafe fn alloc_bstr( &self, text : *const u16, len : u32 ) -> BString {
-            os::alloc_bstr( text, len )
-        }
+        unsafe fn alloc_bstr( &self, text : *const u16, len : u32 ) -> BString {}
+        unsafe fn free_bstr( &self, bstr : &BStr ) { }
+        unsafe fn alloc( &self, len : usize ) -> *mut raw::c_void { }
+        unsafe fn free( &self, ptr : *mut raw::c_void ) { }
+    }
+    "#
+}
 
-        unsafe fn free_bstr( &self, bstr : &BStr ) {
-            os::free_bstr( bstr )
-        }
+fn errorstore_interface( lib_name: &str ) -> ComInterface {
+    ComInterface::parse(
+            lib_name,
+            quote!( (
+                com_iid = "d7f996c5-0b51-4053-82f8-19a7261793a9",
+                raw_iid = "7586c49a-abbd-4a06-b588-e3d02b431f01",
+            ) ),
+            errorstore_impl_code() ).unwrap()
+}
 
-        unsafe fn alloc( &self, len : usize ) -> *mut raw::c_void {
-            os::alloc( len )
-        }
+fn errorstore_impl() -> ComImpl {
+    ComImpl::parse( errorstore_impl_code() ).unwrap()
+}
 
-        unsafe fn free( &self, ptr : *mut raw::c_void ) {
-            os::free( ptr )
-        }
+fn errorstore_class( lib_name: &str ) -> ComStruct {
+    ComStruct::parse(
+            lib_name,
+            quote!( ErrorStore ),
+            "pub struct ErrorStore;" ).unwrap()
+}
+
+fn errorstore_impl_code() -> &'static str {
+    r#"
+    impl ErrorStore
+    {
+        fn get_error_info( &self ) -> ComResult<ComItf<IErrorInfo>> { }
+        fn set_error_info( &self, info : ComItf<IErrorInfo> ) -> ComResult<()> { }
+        fn set_error_message( &self, msg : &str ) -> ComResult<()> { }
     }
     "#
 }

--- a/intercom-common/src/generators/cpp.rs
+++ b/intercom-common/src/generators/cpp.rs
@@ -159,6 +159,7 @@ impl<'s> CppTypeInfo<'s> for TypeInfo<'s> {
             "f64" => "double".to_owned(),
             "f32" => "float".to_owned(),
             "c_void" => "void".to_owned(),
+            "c_char" => "char".to_owned(),
             t => CppTypeInfo::get_cpp_name_for_custom_type( krate, t, ts_config ),
         }
     }

--- a/intercom-common/src/generators/cpp.rs
+++ b/intercom-common/src/generators/cpp.rs
@@ -508,8 +508,45 @@ mod test {
                         },
                     ]
                 },
+                CppInterface {
+                    name : "IErrorStore".to_owned(),
+                    base : Some( "IUnknown".to_owned() ),
+                    iid_struct : "{0x7586c49a,0xabbd,0x4a06,{0xb5,0x88,0xe3,0xd0,0x2b,0x43,0x1f,0x01}}".to_owned(),
+                    methods : vec![
+                        CppMethod {
+                            name : "GetErrorInfo".to_owned(),
+                            ret_type : "intercom::HRESULT".to_owned(),
+                            args : vec![
+                                CppArg {
+                                    name : "__out".to_owned(),
+                                    arg_type : "IErrorInfo**".to_owned(),
+                                },
+                            ]
+                        },
+                        CppMethod {
+                            name : "SetErrorInfo".to_owned(),
+                            ret_type : "intercom::HRESULT".to_owned(),
+                            args : vec![
+                                CppArg {
+                                    name : "info".to_owned(),
+                                    arg_type : "IErrorInfo*".to_owned(),
+                                },
+                            ]
+                        },
+                        CppMethod {
+                            name : "SetErrorMessage".to_owned(),
+                            ret_type : "intercom::HRESULT".to_owned(),
+                            args : vec![
+                                CppArg {
+                                    name : "msg".to_owned(),
+                                    arg_type : "char*".to_owned(),
+                                },
+                            ]
+                        },
+                    ]
+                },
             ],
-            coclass_count: 2,
+            coclass_count: 3,
             coclasses : vec![
                 CppCoClass {
                     name : "CoClass".to_owned(),
@@ -527,6 +564,14 @@ mod test {
                     interfaces : vec![
                         "IAllocator".to_owned(),
                     ],
+                },
+                CppCoClass {
+                    name : "ErrorStore".to_owned(),
+                    clsid_struct : "{0x1467b819,0x62df,0x3720,{0x4e,0xe6,0x6e,0x76,0xfd,0x4e,0x11,0x20}}".to_owned(),
+                    interface_count: 1,
+                    interfaces : vec![
+                        "IErrorStore".to_owned(),
+                    ]
                 },
             ],
         };

--- a/intercom-common/src/generators/idl.rs
+++ b/intercom-common/src/generators/idl.rs
@@ -480,6 +480,49 @@ mod test {
                         },
                     ]
                 },
+                IdlInterface {
+                    name : "IErrorStore".to_owned(),
+                    base : Some( "IUnknown".to_owned() ),
+                    iid : "D7F996C5-0B51-4053-82F8-19A7261793A9".to_owned(),
+                    methods : vec![
+                        IdlMethod {
+                            name : "GetErrorInfo".to_owned(),
+                            idx : 0,
+                            ret_type : "HRESULT".to_owned(),
+                            args : vec![
+                                IdlArg {
+                                    name : "__out".to_owned(),
+                                    arg_type : "IErrorInfo**".to_owned(),
+                                    attributes : "out, retval".to_owned(),
+                                },
+                            ]
+                        },
+                        IdlMethod {
+                            name : "SetErrorInfo".to_owned(),
+                            idx : 1,
+                            ret_type : "HRESULT".to_owned(),
+                            args : vec![
+                                IdlArg {
+                                    name : "info".to_owned(),
+                                    arg_type : "IErrorInfo*".to_owned(),
+                                    attributes : "in".to_owned(),
+                                },
+                            ]
+                        },
+                        IdlMethod {
+                            name : "SetErrorMessage".to_owned(),
+                            idx : 2,
+                            ret_type : "HRESULT".to_owned(),
+                            args : vec![
+                                IdlArg {
+                                    name : "msg".to_owned(),
+                                    arg_type : "BSTR".to_owned(),
+                                    attributes : "in".to_owned(),
+                                },
+                            ]
+                        },
+                    ]
+                },
             ],
             coclasses : vec![
                 IdlCoClass {
@@ -495,6 +538,13 @@ mod test {
                     clsid : "EC444090-9CDC-31A4-4023-D0458C5CD45C".to_owned(),
                     interfaces : vec![
                         "IAllocator".to_owned(),
+                    ]
+                },
+                IdlCoClass {
+                    name : "ErrorStore".to_owned(),
+                    clsid : "1467B819-62DF-3720-4EE6-6E76FD4E1120".to_owned(),
+                    interfaces : vec![
+                        "IErrorStore".to_owned(),
                     ]
                 },
             ],

--- a/intercom-common/src/generators/idl.rs
+++ b/intercom-common/src/generators/idl.rs
@@ -319,6 +319,7 @@ impl<'s> IdlTypeInfo<'s> for TypeInfo<'s> {
             "VariantBool" => "VARIANT_BOOL".to_owned(),
             "Variant" => "VARIANT".to_owned(),
             "c_void" => "void".to_owned(),
+            "c_char" => "char".to_owned(),
             t => IdlTypeInfo::get_idl_name_for_custom_type( krate, t, ts_config ),
         }
     }

--- a/intercom-common/src/generators/manifest.rs
+++ b/intercom-common/src/generators/manifest.rs
@@ -133,7 +133,11 @@ mod test {
                 ManifestCoClass {
                     name : "Allocator".to_owned(),
                     clsid : "{EC444090-9CDC-31A4-4023-D0458C5CD45C}".to_owned(),
-                }
+                },
+                ManifestCoClass {
+                    name : "ErrorStore".to_owned(),
+                    clsid : "{1467B819-62DF-3720-4EE6-6E76FD4E1120}".to_owned(),
+                },
             ],
         };
 

--- a/intercom-common/src/methodinfo.rs
+++ b/intercom-common/src/methodinfo.rs
@@ -304,7 +304,7 @@ fn try_parse_result( ty : &Type ) -> Option<( Type, Type )>
 }
 
 fn hresult_ty() -> Type {
-    parse_quote!( ::intercom::HRESULT )
+    parse_quote!( ::intercom::raw::HRESULT )
 }
 
 #[cfg(test)]
@@ -372,7 +372,7 @@ mod tests {
                 Some( parse_quote!( String ) ) );
         assert_eq!(
                 info.return_type,
-                Some( parse_quote!( ::intercom::HRESULT ) ) );
+                Some( parse_quote!( ::intercom::raw::HRESULT ) ) );
     }
 
     #[test]

--- a/intercom-common/src/model/comcrate.rs
+++ b/intercom-common/src/model/comcrate.rs
@@ -362,7 +362,7 @@ mod test
             &GUID::parse( "12345678-1234-1234-1234-567890000000" ).unwrap() );
 
         // The interfaces should contain the built-in interface.
-        assert_eq!( krate.interfaces().len(), 2 );
+        assert_eq!( krate.interfaces().len(), 3 );
 
         assert_eq!( krate.interfaces()[ "IFoo" ].variants()[ &Automation ].iid(),
             &GUID::parse( "12345678-1234-1234-1234-567890000001" ).unwrap() );
@@ -374,17 +374,26 @@ mod test
         assert_eq!( krate.interfaces()[ "Allocator" ].variants()[ &Raw ].iid(),
             &GUID::parse( "7A6F6564-04B5-4455-A223-EA0512B8CC63" ).unwrap() );
 
-        assert_eq!( krate.structs().len(), 2 );
+        assert_eq!( krate.interfaces()[ "ErrorStore" ].variants()[ &Automation ].iid(),
+            &GUID::parse( "D7F996C5-0B51-4053-82F8-19A7261793A9" ).unwrap() );
+        assert_eq!( krate.interfaces()[ "ErrorStore" ].variants()[ &Raw ].iid(),
+            &GUID::parse( "7586C49A-ABBD-4A06-B588-E3D02B431F01" ).unwrap() );
+
+        assert_eq!( krate.structs().len(), 3 );
         assert_eq!( krate.structs()[ "S" ].clsid().as_ref().unwrap(),
             &GUID::parse( "12345678-1234-1234-1234-567890000003" ).unwrap() );
         assert_eq!( krate.structs()[ "Allocator" ].clsid().as_ref().unwrap(),
             &GUID::parse( "1582F0E9-9CAB-3E18-7F37-0CF2CD9DA33A" ).unwrap() );
+        assert_eq!( krate.structs()[ "ErrorStore" ].clsid().as_ref().unwrap(),
+            &GUID::parse( "1CC4A0E8-C882-37B4-53FA-BC9E6030DF56" ).unwrap() );
 
-        assert_eq!( krate.impls().len(), 2 );
+        assert_eq!( krate.impls().len(), 3 );
         assert_eq!( krate.impls()[0].struct_name(), "S" );
         assert_eq!( krate.impls()[0].interface_name(), "IFoo" );
         assert_eq!( krate.impls()[1].struct_name(), "Allocator" );
         assert_eq!( krate.impls()[1].interface_name(), "Allocator" );
+        assert_eq!( krate.impls()[2].struct_name(), "ErrorStore" );
+        assert_eq!( krate.impls()[2].interface_name(), "ErrorStore" );
     }
 
     #[test]

--- a/intercom-common/src/returnhandlers.rs
+++ b/intercom-common/src/returnhandlers.rs
@@ -96,7 +96,7 @@ impl ReturnHandler for ErrorResultHandler {
 
     fn type_system( &self ) -> ModelTypeSystem { self.type_system }
     fn rust_ty( &self ) -> Type { self.return_ty.clone() }
-    fn com_ty( &self ) -> Type { parse_quote!( ::intercom::HRESULT ) }
+    fn com_ty( &self ) -> Type { parse_quote!( ::intercom::raw::HRESULT ) }
 
     fn com_to_rust_return( &self, result : &Ident ) -> TokenStream {
 
@@ -113,7 +113,7 @@ impl ReturnHandler for ErrorResultHandler {
         // Return statement checks for S_OK (should be is_success) HRESULT and
         // yields either Ok or Err Result based on that.
         quote!(
-            if #result == ::intercom::S_OK {
+            if #result == ::intercom::raw::S_OK {
                 Ok( #ok_tokens )
             } else {
                 Err( ::intercom::get_last_error( #result ) )
@@ -151,10 +151,10 @@ impl ReturnHandler for ErrorResultHandler {
             self.com_out_args() );
         quote!(
             match #result {
-                Ok( #ok_pattern ) => { #( #ok_writes );*; ::intercom::S_OK },
+                Ok( #ok_pattern ) => { #( #ok_writes );*; ::intercom::raw::S_OK },
                 Err( e ) => {
                     #( #err_writes );*;
-                    ::intercom::return_hresult( e )
+                    ::intercom::store_error( e ).hresult
                 },
             }
         )

--- a/intercom-common/src/returnhandlers.rs
+++ b/intercom-common/src/returnhandlers.rs
@@ -113,10 +113,16 @@ impl ReturnHandler for ErrorResultHandler {
         // Return statement checks for S_OK (should be is_success) HRESULT and
         // yields either Ok or Err Result based on that.
         quote!(
-            if #result == ::intercom::raw::S_OK {
+            // TODO: HRESULT::succeeded
+            if #result == ::intercom::raw::S_OK || #result == ::intercom::raw::S_FALSE {
                 Ok( #ok_tokens )
             } else {
-                Err( ::intercom::get_last_error( #result ) )
+                return Err( ::intercom::load_error(
+                        &ComItf::wrap(
+                            comptr.as_unknown(),
+                            ::intercom::TypeSystem::Automation ),
+                        &INTERCOM_iid,
+                        #result ) );
             }
         )
     }

--- a/intercom-common/src/tyhandlers.rs
+++ b/intercom-common/src/tyhandlers.rs
@@ -111,12 +111,11 @@ pub trait TypeHandler {
                 let ident = p.path.get_ident().unwrap();
                 let name = ident.to_string();
                 match name.as_ref() {
-                    "c_void"
-                        | "RawComPtr"
-                        => quote!( ::std::ptr::null_mut() ),
+                    "RawComPtr" => quote!( ::std::ptr::null_mut() ),
                     _ => quote!( Default::default() )
                 }
             },
+            Type::Ptr( .. ) => quote!( ::std::ptr::null_mut() ),
             _ => quote!( Default::default() )
         }
     }

--- a/intercom-cpp/src/comdef.hpp
+++ b/intercom-cpp/src/comdef.hpp
@@ -8,6 +8,7 @@
 #else
 
 #include "posix/iunknown.hpp"
+#include "posix/isupporterrorinfo.hpp"
 #include "posix/idispatch.hpp"
 
 #endif

--- a/intercom-cpp/src/detail/hresult_errors.hpp
+++ b/intercom-cpp/src/detail/hresult_errors.hpp
@@ -15,6 +15,7 @@ namespace detail
 namespace hresult
 {
     static const HRESULT SC_OK = 0;
+    static const HRESULT SC_FALSE = 1;
     static const HRESULT EC_NOTIMPL = null_error( 0x4001 );
     static const HRESULT EC_NOINTERFACE = null_error( 0x4002 );
     static const HRESULT EC_POINTER = null_error( 0x4003 );

--- a/intercom-cpp/src/error_codes.hpp
+++ b/intercom-cpp/src/error_codes.hpp
@@ -12,6 +12,7 @@
 namespace intercom
 {
     static const intercom::HRESULT SC_OK = intercom::detail::hresult::SC_OK;
+    static const intercom::HRESULT SC_FALSE = intercom::detail::hresult::SC_FALSE;
     static const intercom::HRESULT EC_FAIL = intercom::detail::hresult::EC_FAIL;
     static const intercom::HRESULT EC_NOTIMPL = intercom::detail::hresult::EC_NOTIMPL;
     static const intercom::HRESULT EC_NOINTERFACE = intercom::detail::hresult::EC_NOINTERFACE;

--- a/intercom-cpp/src/posix/isupporterrorinfo.hpp
+++ b/intercom-cpp/src/posix/isupporterrorinfo.hpp
@@ -1,15 +1,41 @@
 
-#ifndef INTERCOM_CPP_POSIX_IUNKNOWN_H
-#define INTERCOM_CPP_POSIX_IUNKNOWN_H
+#ifndef INTERCOM_CPP_POSIX_ISUPPORTERRORINFO_H
+#define INTERCOM_CPP_POSIX_ISUPPORTERRORINFO_H
 
 #include "../callingconvention.hpp"
 #include "../datatypes.hpp"
 #include "../error_codes.hpp"
 #include "../guiddef.hpp"
 
+#include "datatypes.hpp"
 
-// MIDL_INTERFACE("00000000-0000-0000-C000-000000000046")
-struct ISupportErrorInfo
+// MIDL_INTERFACE("1CF2B120-547D-101B-8E65-08002B2BD119")
+struct IErrorInfo : public IUnknown
+{
+public:
+
+	virtual intercom::HRESULT INTERCOM_CC GetGUID( 
+		intercom::GUID *pGUID) = 0;
+	
+	virtual intercom::HRESULT INTERCOM_CC GetSource( 
+		intercom::BSTR *pBstrSource) = 0;
+	
+	virtual intercom::HRESULT INTERCOM_CC GetDescription( 
+		intercom::BSTR *pBstrDescription) = 0;
+	
+	virtual intercom::HRESULT INTERCOM_CC GetHelpFile( 
+		intercom::BSTR *pBstrHelpFile) = 0;
+	
+	virtual intercom::HRESULT INTERCOM_CC GetHelpContext( 
+		intercom::DWORD *pdwHelpContext) = 0;
+};
+
+static const intercom::IID IID_IErrorInfo = {
+		0x1CF2B120, 0x547D, 0x101B,
+		{ 0x8E, 0x65, 0x08, 0x00, 0x2B, 0x2B, 0xD1, 0x19 } };
+
+// MIDL_INTERFACE("DF0B3D60-548F-101B-8E65-08002B2BD119" )
+struct ISupportErrorInfo : public IUnknown
 {
 public:
 

--- a/intercom-cpp/src/posix/isupporterrorinfo.hpp
+++ b/intercom-cpp/src/posix/isupporterrorinfo.hpp
@@ -1,0 +1,23 @@
+
+#ifndef INTERCOM_CPP_POSIX_IUNKNOWN_H
+#define INTERCOM_CPP_POSIX_IUNKNOWN_H
+
+#include "../callingconvention.hpp"
+#include "../datatypes.hpp"
+#include "../error_codes.hpp"
+#include "../guiddef.hpp"
+
+
+// MIDL_INTERFACE("00000000-0000-0000-C000-000000000046")
+struct ISupportErrorInfo
+{
+public:
+
+    virtual intercom::HRESULT INTERCOM_CC InterfaceSupportsErrorInfo(
+        intercom::REFIID riid
+    ) = 0;
+};
+
+static const intercom::IID IID_ISupportErrorInfo = { 0xDF0B3D60, 0x548F, 0x101B, { 0x8E, 0x65, 0x08, 0x00, 0x2B, 0x2B, 0xD1, 0x19 } };
+
+#endif

--- a/intercom/src/alloc.rs
+++ b/intercom/src/alloc.rs
@@ -5,6 +5,7 @@ use std::os::raw;
 /// A memory allocator to be used for allocating/deallocating memory shared
 /// with intercom libraries.
 #[com_class( IAllocator )]
+#[derive(Default)]
 pub struct Allocator;
 
 #[com_interface(
@@ -36,10 +37,9 @@ impl IAllocator for Allocator {
     }
 }
 
-impl Default for Allocator {
-    fn default() -> Allocator { Allocator }
-}
+pub fn allocate( len : usize ) -> *mut raw::c_void { unsafe { os::alloc( len ) } }
 
+pub unsafe fn free( ptr : *mut raw::c_void ) { os::free( ptr ) }
 
 #[cfg(windows)]
 pub mod os {

--- a/intercom/src/combox.rs
+++ b/intercom/src/combox.rs
@@ -11,7 +11,7 @@ pub trait CoClass {
     fn query_interface(
         vtables : &Self::VTableList,
         riid : REFIID,
-    ) -> ComResult< RawComPtr >;
+    ) -> RawComResult< RawComPtr >;
     fn interface_supports_error_info(
         riid : REFIID
     ) -> bool;
@@ -176,10 +176,10 @@ impl<T: CoClass> ComBox<T> {
         this : &mut Self,
         riid : REFIID,
         out : *mut RawComPtr,
-    ) -> HRESULT {
+    ) -> raw::HRESULT {
 
         match T::query_interface( &this.vtable_list, riid ) {
-            Ok( ptr ) => { *out = ptr; Self::add_ref( this ); S_OK },
+            Ok( ptr ) => { *out = ptr; Self::add_ref( this ); raw::S_OK },
             Err( e ) => { *out = std::ptr::null_mut(); e },
         }
     }
@@ -241,9 +241,12 @@ impl<T: CoClass> ComBox<T> {
     pub unsafe fn interface_supports_error_info(
         _this : &mut Self,
         riid : REFIID,
-    ) -> HRESULT {
+    ) -> raw::HRESULT {
 
-        if T::interface_supports_error_info( riid ) { S_OK } else { S_FALSE }
+        match T::interface_supports_error_info( riid ) {
+            true => raw::S_OK,
+            false => raw::S_FALSE,
+        }
     }
 
     /// Converts a RawComPtr to a ComBox reference.
@@ -271,7 +274,7 @@ impl<T: CoClass> ComBox<T> {
         self_iunk : RawComPtr,
         riid : REFIID,
         out : *mut RawComPtr,
-    ) -> HRESULT
+    ) -> raw::HRESULT
     {
         ComBox::query_interface( ComBox::<T>::from_ptr( self_iunk ), riid, out )
     }
@@ -282,7 +285,7 @@ impl<T: CoClass> ComBox<T> {
         self_iunk : RawComPtr,
         riid : REFIID,
         out : *mut RawComPtr,
-    ) -> HRESULT
+    ) -> raw::HRESULT
     {
         ComBox::query_interface( ComBox::<T>::from_ptr( self_iunk ), riid, out )
     }
@@ -328,7 +331,7 @@ impl<T: CoClass> ComBox<T> {
     pub unsafe extern "stdcall" fn interface_supports_error_info_ptr(
         self_iunk : RawComPtr,
         riid : REFIID,
-    ) -> HRESULT
+    ) -> raw::HRESULT
     {
         ComBox::interface_supports_error_info(
                 ComBox::<T>::from_ptr( self_iunk ),
@@ -340,7 +343,7 @@ impl<T: CoClass> ComBox<T> {
     pub unsafe extern "C" fn interface_supports_error_info_ptr(
         self_iunk : RawComPtr,
         riid : REFIID,
-    ) -> HRESULT
+    ) -> raw::HRESULT
     {
         ComBox::interface_supports_error_info(
                 ComBox::<T>::from_ptr( self_iunk ),

--- a/intercom/src/comitf.rs
+++ b/intercom/src/comitf.rs
@@ -141,8 +141,8 @@ impl<T: ComInterface + ?Sized> ComItf<T> {
     #[allow(clippy::wrong_self_convention)]
     pub fn as_unknown( this : &Self ) -> ComItf<IUnknown> {
         ComItf {
-            raw_ptr: this.raw_ptr.into_unknown(),
-            automation_ptr: this.automation_ptr.into_unknown(),
+            raw_ptr: this.raw_ptr.as_unknown(),
+            automation_ptr: this.automation_ptr.as_unknown(),
             phantom: PhantomData,
         }
     }

--- a/intercom/src/comitf.rs
+++ b/intercom/src/comitf.rs
@@ -44,6 +44,8 @@ impl<T: ?Sized> Clone for ComItf<T> {
     }
 }
 
+impl<T: ?Sized> Copy for ComItf<T> { }
+
 impl<T: ?Sized> ComItf<T> {
 
     /// Creates a `ComItf<T>` from a raw type system COM interface pointer..

--- a/intercom/src/comrc.rs
+++ b/intercom/src/comrc.rs
@@ -77,7 +77,7 @@ impl<T: ComInterface + ?Sized> ComRc<T>
         // This is the one that plays well with Windows' CoCreateInstance, etc.
         let iid = match T::iid( TypeSystem::Automation ) {
             Some( iid ) => iid,
-            None => return Err( E_NOINTERFACE ),
+            None => return Err( ComError::E_NOINTERFACE ),
         };
 
         unsafe {
@@ -94,10 +94,10 @@ impl<T: ComInterface + ?Sized> ComRc<T>
 
                 // On success construct the ComRc. We are using Automation type
                 // system as that's the IID we used earlier.
-                ::S_OK => Ok( ComRc::attach( ComItf::wrap(
+                ::raw::S_OK => Ok( ComRc::attach( ComItf::wrap(
                                 raw::InterfacePtr::new( out ),
                                 TypeSystem::Automation ) ) ),
-                e => Err( e ),
+                e => Err( e.into() ),
             }
         }
     }

--- a/intercom/src/comrc.rs
+++ b/intercom/src/comrc.rs
@@ -32,6 +32,14 @@ impl<T : ComInterface + ?Sized> ComRc<T> {
         ComRc { itf }
     }
 
+    /// Attaches a floating ComItf reference and brings it under managed
+    /// reference counting.
+    ///
+    /// Does not increment the reference count.
+    pub fn detach( mut rc : ComRc<T> ) -> ComItf<T> {
+        unsafe { std::mem::replace( &mut rc.itf, ComItf::null_itf() ) }
+    }
+
     /// Creates a `ComItf<T>` from a raw type system COM interface pointer..
     ///
     /// Does not increment the reference count.
@@ -41,6 +49,25 @@ impl<T : ComInterface + ?Sized> ComRc<T> {
     /// The `ptr` __must__ be a valid COM interface pointer for an interface
     /// of type `T`.
     pub unsafe fn wrap(
+        ptr : raw::InterfacePtr<T>,
+        ts : TypeSystem
+    ) -> Option<ComRc<T>> {
+        if ptr.is_null() {
+            None
+        } else {
+            Some( ComRc::attach( ComItf::wrap( ptr, ts ) ) )
+        }
+    }
+
+    /// Creates a `ComItf<T>` from a raw type system COM interface pointer..
+    ///
+    /// Does not increment the reference count.
+    ///
+    /// # Safety
+    ///
+    /// The `ptr` __must__ be a valid COM interface pointer for an interface
+    /// of type `T`.
+    pub unsafe fn wrap_unchecked(
         ptr : raw::InterfacePtr<T>,
         ts : TypeSystem
     ) -> ComRc<T> {

--- a/intercom/src/comrc.rs
+++ b/intercom/src/comrc.rs
@@ -16,7 +16,7 @@ impl<T: ComInterface + ?Sized> std::fmt::Debug for ComRc<T> {
 
 impl<T: ComInterface + ?Sized> Clone for ComRc<T> {
     fn clone( &self ) -> Self {
-        let rc = ComRc { itf : self.itf.clone() };
+        let rc = ComRc { itf : self.itf };
         rc.itf.as_ref().release();
         rc
     }
@@ -78,7 +78,7 @@ impl<T : ComInterface + ?Sized> ComRc<T> {
 
         let iunk : &ComItf<IUnknown> = itf.as_ref();
         iunk.add_ref();
-        ComRc::attach( itf.clone() )
+        ComRc::attach( *itf )
     }
 
     // ComRc is a smart pointer and shouldn't introduce methods on 'self'.

--- a/intercom/src/error.rs
+++ b/intercom/src/error.rs
@@ -208,7 +208,7 @@ mod error_store {
             reset_error_store( Some( ComItf::wrap( errorinfo, TypeSystem::Automation ) ) );
         }
 
-        return raw::S_OK;
+        raw::S_OK
     }
 
     pub(super) unsafe fn GetErrorInfo(

--- a/intercom/src/error.rs
+++ b/intercom/src/error.rs
@@ -9,7 +9,7 @@ use super::*;
 pub struct ComError {
 
     /// `HRESULT` that triggered the error.
-    pub hresult : HRESULT,
+    pub hresult : raw::HRESULT,
 
     /// Possible detailed error info.
     pub error_info : Option<ErrorInfo>,
@@ -18,14 +18,14 @@ pub struct ComError {
 impl ComError {
 
     /// Constructs a new `ComError` from a `HRESULT` code.
-    pub fn new_hr( hresult : HRESULT ) -> ComError
+    pub fn new_hr( hresult : raw::HRESULT ) -> ComError
     {
         ComError { hresult, error_info: None }
     }
 
     /// Construts a new `ComError` with a given message.
     pub fn new_message(
-        hresult: HRESULT,
+        hresult: raw::HRESULT,
         description: String
     ) -> ComError
     {
@@ -35,11 +35,41 @@ impl ComError {
         }
     }
 
+    pub fn with_message<S: Into<String>>( mut self, msg : S ) -> Self {
+        self.error_info = Some( ErrorInfo::new( msg.into() ) );
+        self
+    }
+
     /// Gets the description if it's available.
     pub fn description( &self ) -> Option< &str >
     {
         self.error_info.as_ref().map( |e| e.description.as_str() )
     }
+
+    pub const E_NOTIMPL : ComError = ComError {
+            hresult : raw::E_NOTIMPL, error_info : None };
+    pub const E_NOINTERFACE : ComError = ComError {
+            hresult : raw::E_NOINTERFACE, error_info : None };
+    pub const E_POINTER : ComError = ComError {
+            hresult : raw::E_POINTER, error_info : None };
+    pub const E_ABORT : ComError = ComError {
+            hresult : raw::E_ABORT, error_info : None };
+    pub const E_FAIL : ComError = ComError {
+            hresult : raw::E_FAIL, error_info : None };
+    pub const E_INVALIDARG : ComError = ComError {
+            hresult : raw::E_INVALIDARG, error_info : None };
+    pub const E_ACCESSDENIED : ComError = ComError {
+            hresult : raw::E_ACCESSDENIED, error_info : None };
+    pub const STG_E_FILENOTFOUND : ComError = ComError {
+            hresult : raw::STG_E_FILENOTFOUND, error_info : None };
+    pub const RPC_E_DISCONNECTED : ComError = ComError {
+            hresult : raw::RPC_E_DISCONNECTED, error_info : None };
+    pub const RPC_E_CALL_REJECTED : ComError = ComError {
+            hresult : raw::RPC_E_CALL_REJECTED, error_info : None };
+    pub const RPC_E_CALL_CANCELED : ComError = ComError {
+            hresult : raw::RPC_E_CALL_CANCELED, error_info : None };
+    pub const RPC_E_TIMEOUT : ComError = ComError {
+            hresult : raw::RPC_E_TIMEOUT, error_info : None };
 }
 
 impl From<ComError> for std::io::Error {
@@ -48,13 +78,13 @@ impl From<ComError> for std::io::Error {
 
         let error_kind = match com_error.hresult {
 
-            ::STG_E_FILENOTFOUND => std::io::ErrorKind::NotFound,
-            ::E_ACCESSDENIED => std::io::ErrorKind::PermissionDenied,
-            ::RPC_E_CALL_REJECTED => std::io::ErrorKind::ConnectionRefused,
-            ::RPC_E_DISCONNECTED => std::io::ErrorKind::ConnectionReset,
-            ::RPC_E_CALL_CANCELED => std::io::ErrorKind::ConnectionAborted,
-            ::RPC_E_TIMEOUT => std::io::ErrorKind::TimedOut,
-            ::E_INVALIDARG => std::io::ErrorKind::InvalidInput,
+            raw::STG_E_FILENOTFOUND => std::io::ErrorKind::NotFound,
+            raw::E_ACCESSDENIED => std::io::ErrorKind::PermissionDenied,
+            raw::RPC_E_CALL_REJECTED => std::io::ErrorKind::ConnectionRefused,
+            raw::RPC_E_DISCONNECTED => std::io::ErrorKind::ConnectionReset,
+            raw::RPC_E_CALL_CANCELED => std::io::ErrorKind::ConnectionAborted,
+            raw::RPC_E_TIMEOUT => std::io::ErrorKind::TimedOut,
+            raw::E_INVALIDARG => std::io::ErrorKind::InvalidInput,
             _ => std::io::ErrorKind::Other,
         };
 
@@ -68,30 +98,28 @@ impl From<std::io::Error> for ComError {
 
     fn from( io_error : std::io::Error ) -> ComError {
 
-        let hresult = match io_error.kind() {
+        match io_error.kind() {
 
-            std::io::ErrorKind::NotFound => ::STG_E_FILENOTFOUND,
-            std::io::ErrorKind::PermissionDenied => ::E_ACCESSDENIED,
-            std::io::ErrorKind::ConnectionRefused => ::RPC_E_CALL_REJECTED,
-            std::io::ErrorKind::ConnectionReset => ::RPC_E_DISCONNECTED,
-            std::io::ErrorKind::ConnectionAborted => ::RPC_E_CALL_CANCELED,
-            std::io::ErrorKind::TimedOut => ::RPC_E_TIMEOUT,
-            std::io::ErrorKind::InvalidInput => ::E_INVALIDARG,
-            _ => ::E_FAIL,
-        };
-
-        ComError::new_message( hresult, io_error.description().to_owned() )
+            std::io::ErrorKind::NotFound => ComError::STG_E_FILENOTFOUND,
+            std::io::ErrorKind::PermissionDenied => ComError::E_ACCESSDENIED,
+            std::io::ErrorKind::ConnectionRefused => ComError::RPC_E_CALL_REJECTED,
+            std::io::ErrorKind::ConnectionReset => ComError::RPC_E_DISCONNECTED,
+            std::io::ErrorKind::ConnectionAborted => ComError::RPC_E_CALL_CANCELED,
+            std::io::ErrorKind::TimedOut => ComError::RPC_E_TIMEOUT,
+            std::io::ErrorKind::InvalidInput => ComError::E_INVALIDARG,
+            _ => ComError::E_FAIL,
+        }.with_message( io_error.description().to_owned() )
     }
 }
 
-impl From<::HRESULT> for ComError {
-    fn from( hresult : ::HRESULT ) -> ComError {
+impl From<raw::HRESULT> for ComError {
+    fn from( hresult : raw::HRESULT ) -> ComError {
         ComError::new_hr( hresult )
     }
 }
 
-impl From<ComError> for ::HRESULT {
-    fn from( error : ComError ) -> ::HRESULT {
+impl From<ComError> for raw::HRESULT {
+    fn from( error : ComError ) -> raw::HRESULT {
         error.hresult
     }
 }
@@ -106,7 +134,7 @@ impl<'a> From<&'a str> for ::ComError
 impl From<String> for ::ComError
 {
     fn from( s : String ) -> Self {
-        Self::new_message( ::E_FAIL, s )
+        Self::new_message( raw::E_FAIL, s )
     }
 }
 
@@ -121,14 +149,14 @@ mod error_store {
     extern "system" {
         pub(super) fn SetErrorInfo(
             dw_reserved: u32,
-            errorinfo: raw::InterfacePtr<IErrorInfo>,
-        ) -> ::HRESULT;
+            errorinfo: ::raw::InterfacePtr<IErrorInfo>,
+        ) -> raw::HRESULT;
 
         #[allow(private_in_public)]
         pub(super) fn GetErrorInfo(
             dw_reserved: u32,
-            errorinfo: *mut raw::InterfacePtr<IErrorInfo>,
-        ) -> ::HRESULT;
+            errorinfo: *mut ::raw::InterfacePtr<IErrorInfo>,
+        ) -> raw::HRESULT;
     }
 }
 
@@ -141,17 +169,17 @@ mod error_store {
     pub(super) unsafe fn SetErrorInfo(
         _dw_reserved: u32,
         _errorinfo: raw::InterfacePtr<IErrorInfo>,
-    ) -> ::HRESULT { ::S_OK }
+    ) -> raw::HRESULT { ::S_OK }
 
     pub(super) unsafe fn GetErrorInfo(
         _dw_reserved: u32,
         _errorinfo: *mut raw::InterfacePtr<IErrorInfo>,
-    ) -> ::HRESULT { ::S_OK }
+    ) -> raw::HRESULT { ::S_OK }
 }
 
 /// Error info COM object data.
 #[com_class( clsid = None, IErrorInfo )]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ErrorInfo {
     guid : GUID,
     source : String,
@@ -180,7 +208,7 @@ impl ErrorInfo {
 
 impl<'a> TryFrom<&'a IErrorInfo> for ErrorInfo {
 
-    type Error = ::HRESULT;
+    type Error = raw::HRESULT;
 
     fn try_from( source : &'a IErrorInfo ) -> Result<Self, Self::Error> {
 
@@ -216,7 +244,7 @@ impl IErrorInfo for ErrorInfo
 
 /// Extracts the HRESULT from the error result and stores the extended error
 /// information in thread memory so it can be fetched by the COM client.
-pub fn return_hresult< E >( error : E ) -> HRESULT
+pub fn store_error< E >( error : E ) -> ComError
     where E : Into< ComError >
 {
     // Convet the error.
@@ -224,14 +252,14 @@ pub fn return_hresult< E >( error : E ) -> HRESULT
 
     match com_error.error_info {
 
-        Some( error_info ) => {
+        Some( ref error_info ) => {
 
             // ComError contains ErrorInfo. We need to set this in the OS error
             // store.
 
             // Construct the COM class used for IErrorInfo. The class contains the
             // description in memory.
-            let mut info = ComStruct::< ErrorInfo >::new( error_info );
+            let mut info = ComStruct::< ErrorInfo >::new( error_info.clone() );
 
             // Get the IErrorInfo interface and set it in thread memory.
             let mut error_ptr : RawComPtr = std::ptr::null_mut();
@@ -243,21 +271,21 @@ pub fn return_hresult< E >( error : E ) -> HRESULT
                         info.as_mut(),
                         &IID_IErrorInfo,
                         &mut error_ptr );
-                error_store::SetErrorInfo( 0, raw::InterfacePtr::new( error_ptr ) );
+                error_store::SetErrorInfo( 0, ::raw::InterfacePtr::new( error_ptr ) );
             }
         },
         None => {
             // No error info in the ComError.
-            unsafe { error_store::SetErrorInfo( 0, raw::InterfacePtr::null() ); }
+            unsafe { error_store::SetErrorInfo( 0, ::raw::InterfacePtr::null() ); }
         }
     }
 
     // Return the HRESULT of the original error.
-    com_error.hresult
+    com_error
 }
 
 /// Gets the last COM error that occurred on the current thread.
-pub fn get_last_error< E >( last_hr : HRESULT ) -> E
+pub fn get_last_error< E >( last_hr : raw::HRESULT ) -> E
     where E : From< ComError >
 {
     let com_error = ComError {
@@ -265,11 +293,11 @@ pub fn get_last_error< E >( last_hr : HRESULT ) -> E
         error_info: unsafe {
 
             // Get the last error COM interface.
-            let mut error_ptr : raw::InterfacePtr<IErrorInfo>
-                    = raw::InterfacePtr::null();
+            let mut error_ptr : ::raw::InterfacePtr<IErrorInfo>
+                    = ::raw::InterfacePtr::null();
             let hr = error_store::GetErrorInfo( 0, &mut error_ptr );
 
-            if hr == S_OK && ! error_ptr.is_null(){
+            if hr == raw::S_OK && ! error_ptr.is_null(){
 
                 let ierrorinfo = ComItf::< IErrorInfo >::wrap(
                         error_ptr,
@@ -307,15 +335,86 @@ pub fn get_last_error< E >( last_hr : HRESULT ) -> E
 pub trait ErrorValue {
 
     /// Attempts to convert a COM error into a custom status code.
-    fn from_error( HRESULT ) -> Self;
+    fn from_error( ComError ) -> Self;
 }
 
 impl<T> ErrorValue for T {
-    default fn from_error( _ : HRESULT ) -> Self {
+    default fn from_error( _ : ComError ) -> Self {
         panic!( "Function does not support error values" )
     }
 }
 
-impl ErrorValue for HRESULT {
-    fn from_error( hr : HRESULT ) -> Self { hr }
+impl ErrorValue for raw::HRESULT {
+    fn from_error( err : ComError ) -> Self { err.hresult }
+}
+
+pub mod raw {
+
+    /// COM method status code.
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Copy)]
+    #[repr(C)]
+    pub struct HRESULT {
+
+        /// The numerical HRESULT code.
+        pub hr : i32
+    }
+
+    impl HRESULT {
+
+        /// Constructs a new `HRESULT` with the given numerical code.
+        pub fn new( hr : u32 ) -> HRESULT {
+            #[allow(overflowing_literals)]
+            HRESULT { hr : hr as i32 }
+        }
+    }
+
+    macro_rules! make_hr {
+        ( $(#[$attr:meta] )* $hr_name: ident = $hr_value: expr ) => {
+            $(#[$attr])*
+            #[allow(overflowing_literals)]
+            pub const $hr_name : HRESULT = HRESULT { hr: $hr_value as i32 };
+        }
+    }
+
+    make_hr!(
+        /// `HRESULT` indicating the operation completed successfully.
+        S_OK = 0 );
+
+    make_hr!(
+        /// `HRESULT` indicating the operation completed successfully and returned
+        /// `false`.
+        S_FALSE = 1 );
+
+    make_hr!(
+        /// `HRESULT` for unimplemented functionality.
+        E_NOTIMPL = 0x8000_4001 );
+
+    make_hr!(
+        /// `HRESULT` indicating the type does not support the requested interface.
+        E_NOINTERFACE = 0x8000_4002 );
+
+    make_hr!(
+        /// `HRESULT` indicating a pointer parameter was invalid.
+        E_POINTER = 0x8000_4003 );
+
+    make_hr!(
+        /// `HRESULT` for aborted operation.
+        E_ABORT = 0x8000_4004 );
+
+    make_hr!(
+        /// `HRESULT` for unspecified failure.
+        E_FAIL = 0x8000_4005 );
+
+    make_hr!(
+        /// `HRESULT` for invalid argument.
+        E_INVALIDARG = 0x8007_0057 );
+
+    // These might be deprecated. They are a bit too specific for cross-platform
+    // support. We'll just need to ensure the winapi HRESULTs are compatible.
+    make_hr!( E_ACCESSDENIED = 0x8007_0005 );
+    make_hr!( STG_E_FILENOTFOUND = 0x8003_0002 );
+    make_hr!( RPC_E_DISCONNECTED = 0x8001_0108 );
+    make_hr!( RPC_E_CALL_REJECTED = 0x8001_0001 );
+    make_hr!( RPC_E_CALL_CANCELED = 0x8001_0002 );
+    make_hr!( RPC_E_TIMEOUT = 0x8001_011F );
 }

--- a/intercom/src/error.rs
+++ b/intercom/src/error.rs
@@ -168,13 +168,13 @@ mod error_store {
 
     pub(super) unsafe fn SetErrorInfo(
         _dw_reserved: u32,
-        _errorinfo: raw::InterfacePtr<IErrorInfo>,
-    ) -> raw::HRESULT { ::S_OK }
+        _errorinfo: ::raw::InterfacePtr<IErrorInfo>,
+    ) -> raw::HRESULT { raw::S_OK }
 
     pub(super) unsafe fn GetErrorInfo(
         _dw_reserved: u32,
-        _errorinfo: *mut raw::InterfacePtr<IErrorInfo>,
-    ) -> raw::HRESULT { ::S_OK }
+        _errorinfo: *mut ::raw::InterfacePtr<IErrorInfo>,
+    ) -> raw::HRESULT { raw::S_OK }
 }
 
 /// Error info COM object data.

--- a/intercom/src/interfaces.rs
+++ b/intercom/src/interfaces.rs
@@ -20,7 +20,7 @@ pub trait IUnknown {
     ///
     /// Returns `Ok( interface_ptr )` if the object supports the specified
     /// interface or `Err( E_NOINTERFACE )` if it doesn't.
-    fn query_interface( &self, riid : ::REFIID ) -> ::ComResult< ::RawComPtr >;
+    fn query_interface( &self, riid : ::REFIID ) -> ::RawComResult< ::RawComPtr >;
 
     /// Increments the reference count of the object.
     ///
@@ -79,5 +79,5 @@ pub trait ISupportErrorInfo {
     /// for all custom interfaces the user defines. This includes returning
     /// `S_OK` from this method.
     ///
-    fn interface_supports_error_info( &self, riid : ::REFIID ) -> ::HRESULT;
+    fn interface_supports_error_info( &self, riid : ::REFIID ) -> ::raw::HRESULT;
 }

--- a/intercom/src/lib.rs
+++ b/intercom/src/lib.rs
@@ -77,7 +77,7 @@ mod comrc; pub use comrc::*;
 mod comitf; pub use comitf::*;
 mod strings; pub use strings::*;
 mod guid; pub use guid::GUID;
-mod error; pub use error::{store_error, get_last_error, ComError, ErrorInfo, ErrorValue};
+pub mod error; pub use error::{ComError, store_error, load_error, ErrorValue};
 mod interfaces;
 pub mod runtime;
 pub mod alloc;
@@ -168,7 +168,7 @@ pub mod raw {
     }
 
     impl<I: ::ComInterface + ?Sized> InterfacePtr<I> {
-        pub fn into_unknown( self ) -> InterfacePtr<::IUnknown> {
+        pub fn as_unknown( &self ) -> InterfacePtr<::IUnknown> {
             InterfacePtr { ptr : self.ptr, phantom: ::std::marker::PhantomData }
         }
     }

--- a/intercom/src/lib.rs
+++ b/intercom/src/lib.rs
@@ -47,6 +47,7 @@
 
 #![crate_type="dylib"]
 #![feature(try_from, specialization, non_exhaustive, integer_atomics)]
+#![allow(clippy::match_bool)]
 
 #[cfg(not(windows))]
 extern crate libc;

--- a/intercom/src/lib.rs
+++ b/intercom/src/lib.rs
@@ -76,7 +76,7 @@ mod comrc; pub use comrc::*;
 mod comitf; pub use comitf::*;
 mod strings; pub use strings::*;
 mod guid; pub use guid::GUID;
-mod error; pub use error::{return_hresult, get_last_error, ComError, ErrorInfo, ErrorValue};
+mod error; pub use error::{store_error, get_last_error, ComError, ErrorInfo, ErrorValue};
 mod interfaces;
 pub mod runtime;
 pub mod alloc;
@@ -127,8 +127,8 @@ pub mod raw {
     pub type InCStr = *const ::std::os::raw::c_char;
     pub type OutCStr = *mut ::std::os::raw::c_char;
 
-    // ... for some reason the 'Variant' needs to be exported explicitly here.
     pub use variant::raw::*;
+    pub use error::raw::*;
     
     #[repr(C)]
     #[derive(PartialEq, Eq)]
@@ -172,74 +172,6 @@ pub mod raw {
         }
     }
 }
-
-/// COM method status code.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Copy)]
-#[repr(C)]
-pub struct HRESULT {
-
-    /// The numerical HRESULT code.
-    pub hr : i32
-}
-
-impl HRESULT {
-
-    /// Constructs a new `HRESULT` with the given numerical code.
-    pub fn new( hr : u32 ) -> HRESULT {
-        #[allow(overflowing_literals)]
-        HRESULT { hr : hr as i32 }
-    }
-}
-
-macro_rules! make_hr {
-    ( $(#[$attr:meta] )* $hr_name: ident = $hr_value: expr ) => {
-        $(#[$attr])*
-        #[allow(overflowing_literals)]
-        pub const $hr_name : HRESULT = HRESULT { hr: $hr_value as i32 };
-    }
-}
-
-make_hr!(
-    /// `HRESULT` indicating the operation completed successfully.
-    S_OK = 0 );
-
-make_hr!(
-    /// `HRESULT` indicating the operation completed successfully and returned
-    /// `false`.
-    S_FALSE = 1 );
-
-make_hr!(
-    /// `HRESULT` for unimplemented functionality.
-    E_NOTIMPL = 0x8000_4001 );
-
-make_hr!(
-    /// `HRESULT` indicating the type does not support the requested interface.
-    E_NOINTERFACE = 0x8000_4002 );
-
-make_hr!(
-    /// `HRESULT` indicating a pointer parameter was invalid.
-    E_POINTER = 0x8000_4003 );
-
-make_hr!(
-    /// `HRESULT` for aborted operation.
-    E_ABORT = 0x8000_4004 );
-
-make_hr!(
-    /// `HRESULT` for unspecified failure.
-    E_FAIL = 0x8000_4005 );
-
-make_hr!(
-    /// `HRESULT` for invalid argument.
-    E_INVALIDARG = 0x8007_0057 );
-
-// These might be deprecated. They are a bit too specific for cross-platform
-// support. We'll just need to ensure the winapi HRESULTs are compatible.
-make_hr!( E_ACCESSDENIED = 0x8007_0005 );
-make_hr!( STG_E_FILENOTFOUND = 0x8003_0002 );
-make_hr!( RPC_E_DISCONNECTED = 0x8001_0108 );
-make_hr!( RPC_E_CALL_REJECTED = 0x8001_0001 );
-make_hr!( RPC_E_CALL_CANCELED = 0x8001_0002 );
-make_hr!( RPC_E_TIMEOUT = 0x8001_011F );
 
 
 /// `IClassFactory` interface ID.
@@ -285,5 +217,11 @@ pub extern "stdcall" fn DllMain(
 ///
 /// The `ComResult` maps the Rust concept of `Ok` and `Err` values to COM
 /// `[out, retval]` parameter and `HRESULT` return value.
-pub type ComResult<A> = Result<A, HRESULT>;
+pub type ComResult<A> = Result<A, ComError>;
+
+/// Basic COM result type.
+///
+/// The `ComResult` maps the Rust concept of `Ok` and `Err` values to COM
+/// `[out, retval]` parameter and `HRESULT` return value.
+pub type RawComResult<A> = Result<A, raw::HRESULT>;
 

--- a/intercom/src/lib.rs
+++ b/intercom/src/lib.rs
@@ -168,7 +168,7 @@ pub mod raw {
     }
 
     impl<I: ::ComInterface + ?Sized> InterfacePtr<I> {
-        pub fn as_unknown( &self ) -> InterfacePtr<::IUnknown> {
+        pub fn as_unknown( self ) -> InterfacePtr<::IUnknown> {
             InterfacePtr { ptr : self.ptr, phantom: ::std::marker::PhantomData }
         }
     }

--- a/intercom/src/runtime.rs
+++ b/intercom/src/runtime.rs
@@ -9,17 +9,17 @@ mod os {
         pub fn CoInitializeEx(
             reserved : *const ::std::os::raw::c_void,
             init : u32,
-        ) -> ::HRESULT;
+        ) -> ::raw::HRESULT;
 
         #[doc(hidden)]
         pub fn CoUninitialize();
     }
 
-    pub fn initialize() -> ::HRESULT {
+    pub fn initialize() -> ::raw::HRESULT {
         unsafe {
             let hr = CoInitializeEx( ::std::ptr::null(), 2 /* APARTMENTTHREADED */ );
             match hr {
-                ::S_FALSE => ::S_OK,
+                ::raw::S_FALSE => ::raw::S_OK,
                 other => other
             }
         }
@@ -34,14 +34,14 @@ mod os {
 
 #[cfg(not(windows))]
 mod os {
-    pub fn initialize() -> ::HRESULT { ::S_OK }
+    pub fn initialize() -> ::raw::HRESULT { ::raw::S_OK }
 
     pub fn uninitialize() {}
 }
 
-pub fn initialize() -> ::ComResult<()> {
+pub fn initialize() -> ::RawComResult<()> {
     match os::initialize() {
-        ::S_OK => Ok( () ),
+        ::raw::S_OK => Ok( () ),
         e => Err( e )
     }
 }

--- a/intercom/src/strings.rs
+++ b/intercom/src/strings.rs
@@ -9,10 +9,7 @@ use std::{
     str::{ FromStr, Utf8Error }
 };
 
-use intercom::{
-    self,
-    ComError,
-};
+use intercom::ComError;
 
 #[derive(Debug)]
 pub struct FormatError;
@@ -318,7 +315,7 @@ impl<'a> FromWithTemporary<'a, &'a BStr>
     type Temporary = String;
 
     fn to_temporary( bstr : &'a BStr ) -> Result<Self::Temporary, ComError> {
-        bstr.to_string().map_err( |_| ComError::new_hr( intercom::E_INVALIDARG ) )
+        bstr.to_string().map_err( |_| ComError::E_INVALIDARG )
     }
 
     fn from_temporary( temp : &'a mut Self::Temporary ) -> Result<Self, ComError> {
@@ -336,7 +333,7 @@ impl<'a> FromWithTemporary<'a, &'a BStr>
     }
 
     fn from_temporary( temp : &'a mut Self::Temporary ) -> Result<Self, ComError> {
-        temp.to_string().map_err( |_| ComError::new_hr( intercom::E_INVALIDARG ) )
+        temp.to_string().map_err( |_| ComError::E_INVALIDARG )
     }
 }
 
@@ -374,7 +371,7 @@ impl<'a> FromWithTemporary<'a, &'a str>
     type Temporary = BString;
 
     fn to_temporary( source : &'a str ) -> Result<Self::Temporary, ComError> {
-        BString::from_str( source ).map_err( |_| ComError::new_hr( intercom::E_INVALIDARG ) )
+        BString::from_str( source ).map_err( |_| ComError::E_INVALIDARG )
     }
 
     fn from_temporary( temp : &'a mut Self::Temporary ) -> Result<Self, ComError> {
@@ -388,7 +385,7 @@ impl<'a> FromWithTemporary<'a, String>
     type Temporary = BString;
 
     fn to_temporary( source : String ) -> Result<Self::Temporary, ComError> {
-        BString::from_str( &source ).map_err( |_| ComError::new_hr( intercom::E_INVALIDARG ) )
+        BString::from_str( &source ).map_err( |_| ComError::E_INVALIDARG )
     }
 
     fn from_temporary( temp : &'a mut Self::Temporary ) -> Result<Self, ComError> {
@@ -404,7 +401,7 @@ impl<'a> FromWithTemporary<'a, &'a CStr>
     fn to_temporary( source : &'a CStr ) -> Result<Self::Temporary, ComError> {
         source.to_str()
             .map( |s| s.into() )
-            .map_err( |_| ComError::new_hr( intercom::E_INVALIDARG ) )
+            .map_err( |_| ComError::E_INVALIDARG )
     }
 
     fn from_temporary( temp : &'a mut Self::Temporary ) -> Result<Self, ComError> {
@@ -419,10 +416,10 @@ impl<'a> FromWithTemporary<'a, &'a BStr>
 
     fn to_temporary( source : &'a BStr ) -> Result<Self::Temporary, ComError> {
         let string = source.to_string()
-                .map_err( |_| ComError::new_hr( intercom::E_INVALIDARG ) )?;
+                .map_err( |_| ComError::E_INVALIDARG )?;
 
         CString::new( string )
-                .map_err( |_| ComError::new_hr( intercom::E_INVALIDARG ) )
+                .map_err( |_| ComError::E_INVALIDARG )
     }
 
     fn from_temporary( temp : &'a mut Self::Temporary ) -> Result<Self, ComError> {
@@ -441,10 +438,10 @@ impl<'a> FromWithTemporary<'a, &'a BStr>
 
     fn from_temporary( temp : &'a mut Self::Temporary ) -> Result<Self, ComError> {
         let string = temp.to_string()
-                .map_err( |_| ComError::new_hr( intercom::E_INVALIDARG ) )?;
+                .map_err( |_| ComError::E_INVALIDARG )?;
 
         CString::new( string )
-                .map_err( |_| ComError::new_hr( intercom::E_INVALIDARG ) )
+                .map_err( |_| ComError::E_INVALIDARG )
     }
 }
 
@@ -486,14 +483,14 @@ impl ComFrom<String> for BString {
 impl ComFrom<CString> for String {
     fn com_from( source : CString ) -> Result<Self, ComError> {
         source.into_string()
-                .map_err( |_| ComError::new_hr( intercom::E_INVALIDARG ) )
+                .map_err( |_| ComError::E_INVALIDARG )
     }
 }
 
 impl ComFrom<String> for CString {
     fn com_from( source: String ) -> Result<Self, ComError> {
         CString::new( source )
-                .map_err( |_| ComError::new_hr( intercom::E_INVALIDARG ) )
+                .map_err( |_| ComError::E_INVALIDARG )
     }
 }
 
@@ -501,17 +498,17 @@ impl ComFrom<CString> for BString {
     fn com_from( source : CString ) -> Result<Self, ComError> {
         source.to_str()
                 .map( BString::from )
-                .map_err( |_| ComError::new_hr( intercom::E_INVALIDARG ) )
+                .map_err( |_| ComError::E_INVALIDARG )
     }
 }
 
 impl ComFrom<BString> for CString {
     fn com_from( source : BString ) -> Result<Self, ComError> {
         let string = source.to_string()
-                .map_err( |_| ComError::new_hr( intercom::E_INVALIDARG ) )?;
+                .map_err( |_| ComError::E_INVALIDARG )?;
 
         CString::new( string )
-                .map_err( |_| ComError::new_hr( intercom::E_INVALIDARG ) )
+                .map_err( |_| ComError::E_INVALIDARG )
     }
 }
 
@@ -537,7 +534,7 @@ impl<'a> FromWithTemporary<'a, &'a CStr>
     fn to_temporary( cstr : &'a CStr ) -> Result<Self::Temporary, ComError> {
         cstr.to_str()
             .map( |s| s.to_string() )
-            .map_err( |_| ComError::new_hr( intercom::E_INVALIDARG ) )
+            .map_err( |_| ComError::E_INVALIDARG )
     }
 
     fn from_temporary( temp : &'a mut Self::Temporary ) -> Result<Self, ComError> {
@@ -557,7 +554,7 @@ impl<'a> FromWithTemporary<'a, &'a CStr>
     fn from_temporary( temp : &'a mut Self::Temporary ) -> Result<Self, ComError> {
         temp.to_str()
             .map( |s| s.to_string() )
-            .map_err( |_| ComError::new_hr( intercom::E_INVALIDARG ) )
+            .map_err( |_| ComError::E_INVALIDARG )
     }
 }
 
@@ -595,7 +592,7 @@ impl<'a> FromWithTemporary<'a, &'a str>
     type Temporary = CString;
 
     fn to_temporary( source : &'a str ) -> Result<Self::Temporary, ComError> {
-        CString::new( source ).map_err( |_| ComError::new_hr( intercom::E_INVALIDARG ) )
+        CString::new( source ).map_err( |_| ComError::E_INVALIDARG )
     }
 
     fn from_temporary( temp : &'a mut Self::Temporary ) -> Result<Self, ComError> {
@@ -609,7 +606,7 @@ impl<'a> FromWithTemporary<'a, String>
     type Temporary = CString;
 
     fn to_temporary( source : String ) -> Result<Self::Temporary, ComError> {
-        CString::new( source ).map_err( |_| ComError::new_hr( intercom::E_INVALIDARG ) )
+        CString::new( source ).map_err( |_| ComError::E_INVALIDARG )
     }
 
     fn from_temporary( temp : &'a mut Self::Temporary ) -> Result<Self, ComError> {
@@ -629,7 +626,7 @@ impl<'a> FromWithTemporary<'a, &'a CStr>
     fn from_temporary( temp : &'a mut Self::Temporary ) -> Result<Self, ComError> {
         temp.to_str()
             .map( |s| s.into() )
-            .map_err( |_| ComError::new_hr( intercom::E_INVALIDARG ) )
+            .map_err( |_| ComError::E_INVALIDARG )
     }
 }
 

--- a/intercom/src/variant.rs
+++ b/intercom/src/variant.rs
@@ -185,13 +185,7 @@ impl<'a> From<&'a Variant> for VariantError {
 
 impl From<VariantError> for ComError
 {
-    fn from( _ : VariantError ) -> Self { ::E_INVALIDARG.into() }
-}
-
-impl From<VariantError> for HRESULT {
-    fn from( _ : VariantError ) -> HRESULT {
-        E_INVALIDARG
-    }
+    fn from( _ : VariantError ) -> Self { ComError::E_INVALIDARG }
 }
 
 impl TryFrom< Variant > for () {
@@ -621,7 +615,7 @@ pub mod raw {
         pub fltVal : f32,
         pub dblVal : f64,
         pub boolVal : VariantBool,
-        pub scode : ::HRESULT,
+        pub scode : ::raw::HRESULT,
         //cyVal : CY,
         pub date : VariantDate,
         pub bstrVal : *mut u16,
@@ -762,7 +756,7 @@ pub mod raw {
 
     impl From<VariantError> for ::ComError
     {
-        fn from( _ : VariantError ) -> Self { ::E_INVALIDARG.into() }
+        fn from( _ : VariantError ) -> Self { ::ComError::E_INVALIDARG }
     }
 
     impl std::fmt::Debug for Variant {

--- a/intercom/src/variant.rs
+++ b/intercom/src/variant.rs
@@ -78,8 +78,10 @@ impl From<raw::Variant> for Variant {
                     raw::var_type::DATE =>
                         Variant::SystemTime( src.data.date.into() ),
                     raw::var_type::UNKNOWN =>
-                        Variant::IUnknown( ComRc::wrap(
-                                src.data.punkVal, TypeSystem::Automation ) ),
+                        match ComRc::wrap( src.data.punkVal, TypeSystem::Automation ) {
+                            Some( rc ) => Variant::IUnknown( rc ),
+                            None => Variant::None,
+                        }
                     _ => Variant::Raw( src ),
                 }
             } else {
@@ -102,8 +104,10 @@ impl From<raw::Variant> for Variant {
                     raw::var_type::DATE =>
                         Variant::SystemTime( (*src.data.pdate).into() ),
                     raw::var_type::UNKNOWN =>
-                        Variant::IUnknown( ComRc::wrap(
-                                *src.data.ppunkVal, TypeSystem::Automation ) ),
+                        match ComRc::wrap( *src.data.ppunkVal, TypeSystem::Automation ) {
+                            Some( rc ) => Variant::IUnknown( rc ),
+                            None => Variant::None,
+                        }
                     _ => Variant::Raw( src ),
                 }
             }

--- a/test/cpp-raw/error_info.cpp
+++ b/test/cpp-raw/error_info.cpp
@@ -1,8 +1,229 @@
+
+#include <cstdint>
+#include <string>
+using std::char_traits;
+
 #include "../cpp-utility/os.hpp"
 #include "../cpp-utility/catch.hpp"
 #include "testlib.hpp"
+#include <iostream>
+using namespace std;
 
 #ifdef _MSC_VER
+
+namespace
+{
+	class ErrorSource :
+            public IErrorSource_Automation,
+            public ISupportErrorInfo
+	{
+	public:
+
+		virtual intercom::HRESULT INTERCOM_CC ReturnComerror(
+            intercom::HRESULT hr,
+            intercom::BSTR bstr
+		) 
+		{
+            // Get the error store for storing the message.
+            IErrorStore_Automation* pErrorStore = nullptr;
+            intercom::HRESULT hr2 = CreateInstance(
+                CLSID_ErrorStore,
+                IID_IErrorStore_Automation,
+                &pErrorStore );
+            if( hr2 != intercom::SC_OK )
+                return hr2;
+
+            // Set the error message.
+            hr2 = pErrorStore->SetErrorMessage( bstr );
+            if( hr2 != intercom::SC_OK )
+                return hr2;
+
+            // Return the hresult.
+            return hr;
+		}
+
+		virtual intercom::HRESULT INTERCOM_CC ReturnTesterror(
+            intercom::HRESULT hr,
+            intercom::BSTR bstr
+		) 
+		{
+            // Get the error store for storing the message.
+            IErrorStore_Automation* pErrorStore = nullptr;
+            intercom::HRESULT hr2 = CreateInstance(
+                CLSID_ErrorStore,
+                IID_IErrorStore_Automation,
+                &pErrorStore );
+            if( hr2 != intercom::SC_OK )
+                return hr2;
+
+            // Set the error message.
+            hr2 = pErrorStore->SetErrorMessage( bstr );
+            if( hr2 != intercom::SC_OK )
+                return hr2;
+
+            // Return the hresult.
+            return hr;
+		}
+
+		virtual intercom::HRESULT INTERCOM_CC ReturnIoerror(
+            intercom::HRESULT hr,
+            intercom::BSTR bstr
+		) 
+		{
+            // Get the error store for storing the message.
+            IErrorStore_Automation* pErrorStore = nullptr;
+            intercom::HRESULT hr2 = CreateInstance(
+                CLSID_ErrorStore,
+                IID_IErrorStore_Automation,
+                &pErrorStore );
+            if( hr2 != intercom::SC_OK )
+                return hr2;
+
+            // Set the error message.
+            hr2 = pErrorStore->SetErrorMessage( bstr );
+            if( hr2 != intercom::SC_OK )
+                return hr2;
+
+            // Return the hresult.
+            return hr;
+		}
+
+		virtual intercom::HRESULT INTERCOM_CC QueryInterface(
+			const intercom::IID& riid,
+			void** out
+		)
+		{
+            if( riid == IID_ISupportErrorInfo ) {
+                *out = static_cast< ISupportErrorInfo* >( this );
+            } else if( riid == IID_IUnknown || riid == IID_IErrorSource_Automation ) {
+                *out = this;
+            } else {
+                return intercom::EC_NOINTERFACE;
+            }
+
+            // Only increment 'qi on successful queries.
+            // Intercom might query for the raw interface which we do not implement.
+            qi += 1;
+			return intercom::SC_OK;
+		}
+
+        virtual intercom::HRESULT INTERCOM_CC InterfaceSupportsErrorInfo(
+            const intercom::IID& riid
+        )
+        {
+            return intercom::SC_OK;
+        }
+
+		virtual intercom::REF_COUNT_32 INTERCOM_CC AddRef() {
+            addRef += 1;
+            return addRef - release;
+        }
+
+		virtual intercom::REF_COUNT_32 INTERCOM_CC Release() {
+            release += 1;
+            return addRef - release;
+        }
+
+		int qi = 0;
+		int addRef = 0;
+		int release = 0;
+	};
+
+    intercom::BSTR AllocBstr(
+        IAllocator_Automation* pAllocator,
+        const char16_t* str
+    )
+    {
+        return pAllocator->AllocBstr(
+                const_cast< uint16_t* >(
+                    reinterpret_cast< const uint16_t* >( str ) ),
+                static_cast< uint32_t >(
+                    char_traits<char16_t>::length( str ) ) );
+    }
+
+    void check_equal( const char16_t* text, intercom::BSTR right )
+    {
+        IUnicodeConversion_Automation* pConverter = nullptr;
+        REQUIRE( intercom::SC_OK == CreateInstance(
+            CLSID_UnicodeConversion,
+            IID_IUnicodeConversion_Automation,
+            &pConverter ) );
+
+        IAllocator_Automation* pAllocator = nullptr;
+        REQUIRE( intercom::SC_OK == CreateInstance(
+            CLSID_Allocator,
+            IID_IAllocator_Automation,
+            &pAllocator ) );
+
+        const size_t len_size_t = text == nullptr ? 0 : char_traits<char16_t>::length( text );
+        const uint32_t len = static_cast< uint32_t >( len_size_t );
+
+        if( len == 0 ) {
+            REQUIRE( right == nullptr );
+            return;
+        }
+
+        if( len != 0 )
+            REQUIRE( right != nullptr );
+
+        uint32_t right_len = 0;
+        std::memcpy(
+                reinterpret_cast< char* >( &right_len ),
+                reinterpret_cast< char* >( right ) - 4,
+                4 );
+
+        if( len * 2 != right_len ) {
+            char* utf8_expected = nullptr;
+            REQUIRE( intercom::SC_OK == pConverter->Utf16ToUtf8(
+                    const_cast< uint16_t* >(
+                        reinterpret_cast< const uint16_t* >( text ) ),
+                    OUT &utf8_expected ) );
+            char* utf8_actual = nullptr;
+            REQUIRE( intercom::SC_OK == pConverter->Utf16ToUtf8(
+                    reinterpret_cast< uint16_t* >( right ), OUT &utf8_actual ) );
+
+            std::string expected = utf8_expected;
+            std::string actual = utf8_actual;
+
+            pAllocator->Free( utf8_expected );
+            pAllocator->Free( utf8_actual );
+
+            REQUIRE( expected == actual );  // This should fail.
+            REQUIRE( len * 2 == right_len );  // This failed above.
+        }
+
+        uint16_t right_termination = 0xffff;
+        std::memcpy(
+                reinterpret_cast< char* >( &right_termination ),
+                reinterpret_cast< char* >( right ) + right_len,
+                2 );
+
+        REQUIRE( right_termination == 0 );
+
+        for( uint32_t i = 0; i < len; i++ ) {
+            if( text[ i ] != right[ i ] ) {
+                char* utf8_expected = nullptr;
+                REQUIRE( intercom::SC_OK == pConverter->Utf16ToUtf8(
+                        const_cast< uint16_t* >(
+                            reinterpret_cast< const uint16_t* >( text ) ),
+                        OUT &utf8_expected ) );
+                char* utf8_actual = nullptr;
+                REQUIRE( intercom::SC_OK == pConverter->Utf16ToUtf8(
+                        reinterpret_cast< uint16_t* >( right ), OUT &utf8_actual ) );
+                cerr << utf8_actual << " != " << utf8_expected << endl;
+
+                std::string expected = utf8_expected;
+                std::string actual = utf8_actual;
+
+                pAllocator->Free( utf8_expected );
+                pAllocator->Free( utf8_actual );
+
+                REQUIRE( expected == actual );  // This should fail.
+                REQUIRE( text[ i ] == right[ i ] );  // This failed above.
+            }
+        }
+    }
+}
 
 TEST_CASE( "Interfaces support error info" )
 {
@@ -10,45 +231,52 @@ TEST_CASE( "Interfaces support error info" )
     InitializeRuntime();
 
     // Get the error source interface.
+    IErrorTests_Automation* pErrorTests = nullptr;
+    intercom::HRESULT hr = CreateInstance(
+        CLSID_ErrorTests,
+        IID_IErrorTests_Automation,
+        &pErrorTests );
+    REQUIRE( hr == S_OK );
+    REQUIRE( pErrorTests != nullptr );
+
+    // Get the error source interface.
     IErrorSource_Automation* pErrorSource = nullptr;
-    HRESULT hr = CreateInstance(
-        CLSID_ErrorSource,
-        IID_IErrorSource_Automation,
-        &pErrorSource );
+    hr = pErrorTests->QueryInterface(
+            IID_IErrorSource_Automation,
+            OUT reinterpret_cast< void** >( &pErrorSource ) );
     REQUIRE( hr == S_OK );
     REQUIRE( pErrorSource != nullptr );
+
+    // Get the error store.
+    IErrorStore_Automation* pErrorStore = nullptr;
+    hr = CreateInstance(
+        CLSID_ErrorStore,
+        IID_IErrorStore_Automation,
+        &pErrorStore );
+    REQUIRE( hr == S_OK );
+    REQUIRE( pErrorTests != nullptr );
+
+    // Construct allocator.
+    IAllocator_Automation* pAllocator = nullptr;
+    hr = CreateInstance(
+        CLSID_Allocator,
+        IID_IAllocator_Automation,
+        &pAllocator );
+    REQUIRE( hr == intercom::SC_OK );
 
     SECTION( "Error source supports error info interface" )
     {
         ISupportErrorInfo* pSupportErrorInfo = nullptr;
-        hr = pErrorSource->QueryInterface(
+        hr = pErrorTests->QueryInterface(
                 IID_ISupportErrorInfo,
                 reinterpret_cast< void** >( &pSupportErrorInfo ) );
         REQUIRE( hr == S_OK );
         REQUIRE( pSupportErrorInfo != nullptr );
 
-        SECTION( "IErrorSource supports error info" )
+        SECTION( "IErrorTests supports error info" )
         {
-            hr = pSupportErrorInfo->InterfaceSupportsErrorInfo( IID_IErrorSource_Automation );
+            hr = pSupportErrorInfo->InterfaceSupportsErrorInfo( IID_IErrorTests_Automation );
             REQUIRE( hr == S_OK );
-
-            SECTION( "Errors set error info" )
-            {
-                BSTR bstrError = SysAllocString( L"Error message" );
-                hr = pErrorSource->StoreError( E_FAIL, bstrError );
-
-                REQUIRE( hr == E_FAIL );
-
-                IErrorInfo* pErrorInfo = nullptr;
-                hr = GetErrorInfo( 0, &pErrorInfo );
-                REQUIRE( hr == S_OK );
-
-                BSTR bstrOut = nullptr;
-                hr = pErrorInfo->GetDescription( &bstrOut );
-                REQUIRE( hr == 0 );
-                REQUIRE( wcscmp( bstrOut, L"Error message" ) == 0 );
-                SysFreeString( bstrOut );
-            }
         }
 
         SECTION( "IUnknown does not support error info" )
@@ -66,7 +294,92 @@ TEST_CASE( "Interfaces support error info" )
         pSupportErrorInfo->Release();
     }
 
-    pErrorSource->Release();
+    SECTION( "Errors set error info" )
+    {
+        SECTION( "Returning ComError" )
+        {
+            BSTR bstrError = AllocBstr( pAllocator, u"Error message" );
+            hr = pErrorSource->ReturnComerror( 0x81234567, bstrError );
+
+            REQUIRE( hr == 0x81234567 );
+
+            IErrorInfo* pErrorInfo = nullptr;
+            hr = pErrorStore->GetErrorInfo( &pErrorInfo );
+            REQUIRE( hr == S_OK );
+
+            BSTR bstrOut = nullptr;
+            hr = pErrorInfo->GetDescription( &bstrOut );
+            check_equal( u"Error message", bstrOut );
+            pAllocator->FreeBstr( bstrOut );
+            pAllocator->FreeBstr( bstrError );
+        }
+
+        SECTION( "Returning custom error" )
+        {
+            BSTR bstrError = AllocBstr( pAllocator, u"Error message" );
+            hr = pErrorSource->ReturnTesterror( 0x81234567, bstrError );
+
+            REQUIRE( hr == 0x81234567 );
+
+            IErrorInfo* pErrorInfo = nullptr;
+            hr = pErrorStore->GetErrorInfo( &pErrorInfo );
+            REQUIRE( hr == S_OK );
+
+            BSTR bstrOut = nullptr;
+            hr = pErrorInfo->GetDescription( &bstrOut );
+            check_equal( u"Error message", bstrOut );
+            pAllocator->FreeBstr( bstrOut );
+            pAllocator->FreeBstr( bstrError );
+        }
+
+        SECTION( "Returning std::io::Error" )
+        {
+            hr = pErrorSource->ReturnIoerror( 5, nullptr );
+
+            REQUIRE( hr == 0x80070005 );
+
+            IErrorInfo* pErrorInfo = nullptr;
+            hr = pErrorStore->GetErrorInfo( &pErrorInfo );
+            REQUIRE( hr == S_OK );
+
+            BSTR bstrOut = nullptr;
+            hr = pErrorInfo->GetDescription( &bstrOut );
+            check_equal( u"permission denied", bstrOut );
+            pAllocator->FreeBstr( bstrOut );
+        }
+
+        SECTION( "Returning ComError from COM callback" )
+        {
+            ErrorSource source;
+            REQUIRE( intercom::SC_OK == pErrorTests->TestComerror( &source ) );
+            REQUIRE( source.addRef == 0 );
+            REQUIRE( source.qi == 1 );
+            REQUIRE( source.release == 1 );
+        }
+
+        SECTION( "Returning custom error from COM callback" )
+        {
+            ErrorSource source;
+            REQUIRE( intercom::SC_OK == pErrorTests->TestTesterror( &source ) );
+            REQUIRE( source.addRef == 0 );
+            REQUIRE( source.qi == 1 );
+            REQUIRE( source.release == 1 );
+        }
+
+        SECTION( "Returning std::io::Error from COM callback" )
+        {
+            ErrorSource source;
+            REQUIRE( intercom::SC_OK == pErrorTests->TestIoerror( &source ) );
+            REQUIRE( source.addRef == 0 );
+            REQUIRE( source.qi == 1 );
+            REQUIRE( source.release == 1 );
+        }
+    }
+
+    REQUIRE( pErrorTests->Release() == 1 );
+    REQUIRE( pErrorSource->Release() == 0 );
+    REQUIRE( pErrorStore->Release() == 0 );
+    REQUIRE( pAllocator->Release() == 0 );
 
     UninitializeRuntime();
 }

--- a/test/cpp-raw/error_info.cpp
+++ b/test/cpp-raw/error_info.cpp
@@ -9,8 +9,6 @@ using std::char_traits;
 #include <iostream>
 using namespace std;
 
-#ifdef _MSC_VER
-
 namespace
 {
 	class ErrorSource :
@@ -236,7 +234,7 @@ TEST_CASE( "Interfaces support error info" )
         CLSID_ErrorTests,
         IID_IErrorTests_Automation,
         &pErrorTests );
-    REQUIRE( hr == S_OK );
+    REQUIRE( hr == intercom::SC_OK );
     REQUIRE( pErrorTests != nullptr );
 
     // Get the error source interface.
@@ -244,7 +242,7 @@ TEST_CASE( "Interfaces support error info" )
     hr = pErrorTests->QueryInterface(
             IID_IErrorSource_Automation,
             OUT reinterpret_cast< void** >( &pErrorSource ) );
-    REQUIRE( hr == S_OK );
+    REQUIRE( hr == intercom::SC_OK );
     REQUIRE( pErrorSource != nullptr );
 
     // Get the error store.
@@ -253,7 +251,7 @@ TEST_CASE( "Interfaces support error info" )
         CLSID_ErrorStore,
         IID_IErrorStore_Automation,
         &pErrorStore );
-    REQUIRE( hr == S_OK );
+    REQUIRE( hr == intercom::SC_OK );
     REQUIRE( pErrorTests != nullptr );
 
     // Construct allocator.
@@ -270,25 +268,25 @@ TEST_CASE( "Interfaces support error info" )
         hr = pErrorTests->QueryInterface(
                 IID_ISupportErrorInfo,
                 reinterpret_cast< void** >( &pSupportErrorInfo ) );
-        REQUIRE( hr == S_OK );
+        REQUIRE( hr == intercom::SC_OK );
         REQUIRE( pSupportErrorInfo != nullptr );
 
         SECTION( "IErrorTests supports error info" )
         {
             hr = pSupportErrorInfo->InterfaceSupportsErrorInfo( IID_IErrorTests_Automation );
-            REQUIRE( hr == S_OK );
+            REQUIRE( hr == intercom::SC_OK );
         }
 
         SECTION( "IUnknown does not support error info" )
         {
             hr = pSupportErrorInfo->InterfaceSupportsErrorInfo( IID_IUnknown );
-            REQUIRE( hr == S_FALSE );
+            REQUIRE( hr == intercom::SC_FALSE );
         }
 
         SECTION( "ISupportErrorInfo does not support error info" )
         {
             hr = pSupportErrorInfo->InterfaceSupportsErrorInfo( IID_ISupportErrorInfo );
-            REQUIRE( hr == S_FALSE );
+            REQUIRE( hr == intercom::SC_FALSE );
         }
 
         pSupportErrorInfo->Release();
@@ -298,16 +296,16 @@ TEST_CASE( "Interfaces support error info" )
     {
         SECTION( "Returning ComError" )
         {
-            BSTR bstrError = AllocBstr( pAllocator, u"Error message" );
+            intercom::BSTR bstrError = AllocBstr( pAllocator, u"Error message" );
             hr = pErrorSource->ReturnComerror( 0x81234567, bstrError );
 
             REQUIRE( hr == 0x81234567 );
 
             IErrorInfo* pErrorInfo = nullptr;
             hr = pErrorStore->GetErrorInfo( &pErrorInfo );
-            REQUIRE( hr == S_OK );
+            REQUIRE( hr == intercom::SC_OK );
 
-            BSTR bstrOut = nullptr;
+            intercom::BSTR bstrOut = nullptr;
             hr = pErrorInfo->GetDescription( &bstrOut );
             check_equal( u"Error message", bstrOut );
             pAllocator->FreeBstr( bstrOut );
@@ -316,16 +314,16 @@ TEST_CASE( "Interfaces support error info" )
 
         SECTION( "Returning custom error" )
         {
-            BSTR bstrError = AllocBstr( pAllocator, u"Error message" );
+            intercom::BSTR bstrError = AllocBstr( pAllocator, u"Error message" );
             hr = pErrorSource->ReturnTesterror( 0x81234567, bstrError );
 
             REQUIRE( hr == 0x81234567 );
 
             IErrorInfo* pErrorInfo = nullptr;
             hr = pErrorStore->GetErrorInfo( &pErrorInfo );
-            REQUIRE( hr == S_OK );
+            REQUIRE( hr == intercom::SC_OK );
 
-            BSTR bstrOut = nullptr;
+            intercom::BSTR bstrOut = nullptr;
             hr = pErrorInfo->GetDescription( &bstrOut );
             check_equal( u"Error message", bstrOut );
             pAllocator->FreeBstr( bstrOut );
@@ -340,9 +338,9 @@ TEST_CASE( "Interfaces support error info" )
 
             IErrorInfo* pErrorInfo = nullptr;
             hr = pErrorStore->GetErrorInfo( &pErrorInfo );
-            REQUIRE( hr == S_OK );
+            REQUIRE( hr == intercom::SC_OK );
 
-            BSTR bstrOut = nullptr;
+            intercom::BSTR bstrOut = nullptr;
             hr = pErrorInfo->GetDescription( &bstrOut );
             check_equal( u"permission denied", bstrOut );
             pAllocator->FreeBstr( bstrOut );
@@ -383,5 +381,3 @@ TEST_CASE( "Interfaces support error info" )
 
     UninitializeRuntime();
 }
-
-#endif

--- a/test/cs/ErrorInfoSupport.cs
+++ b/test/cs/ErrorInfoSupport.cs
@@ -8,79 +8,154 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace cs
 {
+    public class ErrorSource : TestLib.IErrorSource_Automation
+    {
+        public class CustomException : Exception
+        {
+            public CustomException( int hr, string msg )
+                : base( msg )
+            {
+                this.HResult = hr;
+            }
+        }
+
+        public void ReturnComerror( int hr, string desc )
+        {
+            throw new CustomException( hr, desc );
+        }
+
+        public void ReturnTesterror( int hr, string desc )
+        {
+            throw new CustomException( hr, desc );
+        }
+
+        public void ReturnIoerror( int hr, string desc )
+        {
+            throw new CustomException( hr, desc );
+        }
+    }
+
     [TestClass]
     public class ErrorInfoSupport
     {
         [TestMethod]
         public void ErrorsShowUpAsExceptions()
         {
-            var lib = new TestLib.ErrorSource();
+            var lib = ( TestLib.IErrorSource_Automation )new TestLib.ErrorTests();
             unchecked
             {
-                Assert.ThrowsException< COMException >(
-                        () => lib.StoreError( (int) 0x80004005, "E_FAIL error message" ),
-                        "E_FAIL error message" );
+                var ex = Assert.ThrowsException< COMException >(
+                        () => lib.ReturnComerror( (int) 0x80004005, "E_FAIL error message" ) );
+                Assert.AreEqual( "E_FAIL error message", ex.Message );
+                ex = Assert.ThrowsException< COMException >(
+                        () => lib.ReturnTesterror( (int) 0x80004005, "E_FAIL error message" ) );
+                Assert.AreEqual( "E_FAIL error message", ex.Message );
             }
         }
 
         [TestMethod]
         public void E_NOTIMPL_ConvertsToNotImplementedException()
         {
-            var lib = new TestLib.ErrorSource();
+            var lib = ( TestLib.IErrorSource_Automation )new TestLib.ErrorTests();
             unchecked
             {
-                Assert.ThrowsException< NotImplementedException >(
-                        () => lib.StoreError( (int) 0x80004001, "E_NOTIMPL error message" ),
-                        "E_NOTIMPL error message" );
+                var ex = Assert.ThrowsException< NotImplementedException >(
+                        () => lib.ReturnComerror( (int) 0x80004001, "E_NOTIMPL error message" ) );
+                Assert.AreEqual( "E_NOTIMPL error message", ex.Message );
+                ex = Assert.ThrowsException< NotImplementedException >(
+                        () => lib.ReturnTesterror( (int) 0x80004001, "E_NOTIMPL error message" ) );
+                Assert.AreEqual( "E_NOTIMPL error message", ex.Message );
             }
         }
 
         [TestMethod]
         public void E_INVALIDARG_ConvertsToInvalidArgumentException()
         {
-            var lib = new TestLib.ErrorSource();
+            var lib = ( TestLib.IErrorSource_Automation )new TestLib.ErrorTests();
             unchecked
             {
-                Assert.ThrowsException< ArgumentException >(
-                        () => lib.StoreError( (int) 0x80070057, "E_INVALIDARG error message" ),
-                        "E_INVALIDARG error message" );
+                var ex = Assert.ThrowsException< ArgumentException >(
+                        () => lib.ReturnComerror( (int) 0x80070057, "E_INVALIDARG error message" ) );
+                Assert.AreEqual( "E_INVALIDARG error message", ex.Message );
+                ex = Assert.ThrowsException< ArgumentException >(
+                        () => lib.ReturnTesterror( (int) 0x80070057, "E_INVALIDARG error message" ) );
+                Assert.AreEqual( "E_INVALIDARG error message", ex.Message );
             }
         }
 
         [TestMethod]
         public void E_POINTER_ConvertsToNullReferenceException()
         {
-            var lib = new TestLib.ErrorSource();
+            var lib = ( TestLib.IErrorSource_Automation )new TestLib.ErrorTests();
             unchecked
             {
-                Assert.ThrowsException< NullReferenceException >(
-                        () => lib.StoreError( (int) 0x80004003, "E_POINTER error message" ),
-                        "E_POINTER error message" );
+                var ex = Assert.ThrowsException< NullReferenceException >(
+                        () => lib.ReturnComerror( (int) 0x80004003, "E_POINTER error message" ) );
+                Assert.AreEqual( "E_POINTER error message", ex.Message );
+                ex = Assert.ThrowsException< NullReferenceException >(
+                        () => lib.ReturnTesterror( (int) 0x80004003, "E_POINTER error message" ) );
+                Assert.AreEqual( "E_POINTER error message", ex.Message );
             }
         }
 
         [TestMethod]
         public void E_NOINTERFACE_ConvertsToInvalidCastException()
         {
-            var lib = new TestLib.ErrorSource();
+            var lib = ( TestLib.IErrorSource_Automation )new TestLib.ErrorTests();
             unchecked
             {
-                Assert.ThrowsException< InvalidCastException >(
-                        () => lib.StoreError( (int) 0x80004002, "E_NOINTERFACE error message" ),
-                        "E_NOINTERFACE error message" );
+                var ex = Assert.ThrowsException< InvalidCastException >(
+                        () => lib.ReturnComerror( (int) 0x80004002, "E_NOINTERFACE error message" ) );
+                Assert.AreEqual( "E_NOINTERFACE error message", ex.Message );
+                ex = Assert.ThrowsException< InvalidCastException >(
+                        () => lib.ReturnTesterror( (int) 0x80004002, "E_NOINTERFACE error message" ) );
+                Assert.AreEqual( "E_NOINTERFACE error message", ex.Message );
             }
         }
 
         [TestMethod]
         public void E_ABORT_ConvertsToCOMException()
         {
-            var lib = new TestLib.ErrorSource();
+            var lib = ( TestLib.IErrorSource_Automation )new TestLib.ErrorTests();
             unchecked
             {
-                Assert.ThrowsException< COMException >(
-                        () => lib.StoreError( (int) 0x80004004, "E_ABORT error message" ),
-                        "E_ABORT error message" );
+                var ex = Assert.ThrowsException< COMException >(
+                        () => lib.ReturnComerror( (int) 0x80004004, "E_ABORT error message" ) );
+                Assert.AreEqual( "E_ABORT error message", ex.Message );
+                ex = Assert.ThrowsException< COMException >(
+                        () => lib.ReturnTesterror( (int) 0x80004004, "E_ABORT error message" ) );
+                Assert.AreEqual( "E_ABORT error message", ex.Message );
             }
+        }
+
+        [TestMethod]
+        public void AccessDenied_ConvertsToUnauthorizedAccessException()
+        {
+            var lib = ( TestLib.IErrorSource_Automation )new TestLib.ErrorTests();
+            var ex = Assert.ThrowsException< UnauthorizedAccessException >(
+                    () => lib.ReturnIoerror( 5, "" ) );
+            Assert.AreEqual( "permission denied", ex.Message );
+        }
+
+        [TestMethod]
+        public void CallbackComErrorMaintainsErrorInfo()
+        {
+            var lib = new TestLib.ErrorTests();
+            lib.TestComerror( new ErrorSource() );
+        }
+
+        [TestMethod]
+        public void CallbackTestErrorMaintainsErrorInfo()
+        {
+            var lib = new TestLib.ErrorTests();
+            lib.TestTesterror( new ErrorSource() );
+        }
+
+        [TestMethod]
+        public void CallbackIoErrorMaintainsErrorInfo()
+        {
+            var lib = new TestLib.ErrorTests();
+            lib.TestIoerror( new ErrorSource() );
         }
     }
 }

--- a/test/testlib/src/error_info.rs
+++ b/test/testlib/src/error_info.rs
@@ -1,35 +1,151 @@
 
 use intercom::*;
 
-#[com_class( ErrorSource)]
-pub struct ErrorSource;
+#[com_interface]
+pub trait IErrorSource
+{
+    fn return_comerror(
+        &self, 
+        hr : raw::HRESULT,
+        desc : &str
+    ) -> ComResult<()>;
+
+    fn return_testerror(
+        &self, 
+        hr : raw::HRESULT,
+        desc : &str
+    ) -> Result<(), TestError>;
+
+    fn return_ioerror(
+        &self, 
+        hr : raw::HRESULT,
+        desc : &str
+    ) -> Result<(), std::io::Error>;
+}
+
+#[com_class( ErrorTests, IErrorSource )]
+pub struct ErrorTests;
+
+#[com_interface]
+#[com_impl]
+impl ErrorTests
+{
+    pub fn new() -> ErrorTests { ErrorTests }
+
+    pub fn test_comerror( &self, source : ComItf<IErrorSource> ) -> ComResult<()>
+    {
+        let err = source.return_comerror(
+                raw::HRESULT::new( 123 ),
+                "Error message" );
+
+        match err {
+            Ok(..) => Err( ComError::E_FAIL ),
+            Err( e ) => {
+
+                if e.hresult.hr != 123 {
+                    return Err( ComError::E_INVALIDARG );
+                }
+                
+                if e.description() != Some( "Error message" ) {
+                    return Err( ComError::E_INVALIDARG );
+                }
+
+                Ok(())
+            }
+        }
+    }
+
+    pub fn test_testerror( &self, source : ComItf<IErrorSource> ) -> ComResult<()>
+    {
+        let err = source.return_testerror(
+                raw::HRESULT::new( 123 ),
+                "Error message" );
+
+        match err {
+            Ok(..) => Err( ComError::E_FAIL ),
+            Err( e ) => {
+
+                if e.0.hr != 123 {
+                    return Err( ComError::E_INVALIDARG );
+                }
+                
+                if e.1 != "Error message" {
+                    return Err( ComError::E_INVALIDARG );
+                }
+
+                Ok(())
+            }
+        }
+    }
+
+    pub fn test_ioerror( &self, source : ComItf<IErrorSource> ) -> ComResult<()>
+    {
+        let err = source.return_ioerror(
+                raw::HRESULT::new( raw::E_ACCESSDENIED.hr ),
+                "Access denied" );
+
+        match err {
+            Ok(..) => Err( ComError::E_FAIL ),
+            Err( e ) => {
+
+                if e.kind() != std::io::ErrorKind::PermissionDenied {
+                    return Err( ComError::E_INVALIDARG );
+                }
+
+                use std::error::Error;
+                if e.description() != "Access denied" {
+                    return Err( ComError::E_INVALIDARG );
+                }
+
+                Ok(())
+            }
+        }
+    }
+}
+
+#[com_impl]
+impl IErrorSource for ErrorTests
+{
+    fn return_comerror(
+        &self,
+        hr : raw::HRESULT,
+        desc : &str
+    ) -> ComResult<()>
+    {
+        Err( ComError::new_message( hr, desc.to_string() ) )
+    }
+
+    fn return_testerror(
+        &self,
+        hr : raw::HRESULT,
+        desc : &str
+    ) -> Result<(), TestError>
+    {
+        Err( TestError( hr, desc.to_string() ) )
+    }
+
+    fn return_ioerror(
+        &self,
+        hr : raw::HRESULT,
+        _desc : &str
+    ) -> Result<(), std::io::Error>
+    {
+        Err( std::io::Error::from_raw_os_error( hr.hr ) )
+    }
+}
 
 #[derive(Debug)]
 pub struct TestError( raw::HRESULT, String );
+
 impl std::error::Error for TestError {
     fn description( &self ) -> &str { &self.1 }
     fn cause( &self ) -> Option<&std::error::Error> { None }
 }
+
 impl std::fmt::Display for TestError {
     fn fmt( &self, f : &mut std::fmt::Formatter ) -> std::fmt::Result
     {
         write!( f, "{}", self.1 )
-    }
-}
-
-#[com_interface]
-#[com_impl]
-impl ErrorSource
-{
-    pub fn new() -> ErrorSource { ErrorSource }
-
-    pub fn store_error(
-        &self, 
-        hr : raw::HRESULT,
-        desc : String
-    ) -> Result<(), TestError>
-    {
-        Err( TestError( hr, desc ) )
     }
 }
 

--- a/test/testlib/src/error_info.rs
+++ b/test/testlib/src/error_info.rs
@@ -43,11 +43,13 @@ impl ErrorTests
             Err( e ) => {
 
                 if e.hresult.hr != 123 {
-                    return Err( ComError::E_INVALIDARG );
+                    return Err( ComError::E_INVALIDARG
+                            .with_message( format!( "Bad HRESULT: {}", e.hresult.hr ) ) );
                 }
                 
                 if e.description() != Some( "Error message" ) {
-                    return Err( ComError::E_INVALIDARG );
+                    return Err( ComError::E_INVALIDARG
+                            .with_message( format!( "Bad message: {:?}", e.description() ) ) );
                 }
 
                 Ok(())
@@ -66,11 +68,13 @@ impl ErrorTests
             Err( e ) => {
 
                 if e.0.hr != 123 {
-                    return Err( ComError::E_INVALIDARG );
+                    return Err( ComError::E_INVALIDARG
+                            .with_message( format!( "Bad HRESULT: {}", e.0.hr ) ) );
                 }
                 
                 if e.1 != "Error message" {
-                    return Err( ComError::E_INVALIDARG );
+                    return Err( ComError::E_INVALIDARG
+                            .with_message( format!( "Bad message: {:?}", e.1 ) ) );
                 }
 
                 Ok(())
@@ -89,12 +93,14 @@ impl ErrorTests
             Err( e ) => {
 
                 if e.kind() != std::io::ErrorKind::PermissionDenied {
-                    return Err( ComError::E_INVALIDARG );
+                    return Err( ComError::E_INVALIDARG
+                            .with_message( format!( "Bad kind: {:?}", e.kind() ) ) );
                 }
 
                 use std::error::Error;
                 if e.description() != "Access denied" {
-                    return Err( ComError::E_INVALIDARG );
+                    return Err( ComError::E_INVALIDARG
+                            .with_message( format!( "Bad message: {:?}", e.description() ) ) );
                 }
 
                 Ok(())

--- a/test/testlib/src/error_info.rs
+++ b/test/testlib/src/error_info.rs
@@ -132,11 +132,13 @@ impl IErrorSource for ErrorTests
 
     fn return_ioerror(
         &self,
-        hr : raw::HRESULT,
+        _hr : raw::HRESULT,
         _desc : &str
     ) -> Result<(), std::io::Error>
     {
-        Err( std::io::Error::from_raw_os_error( hr.hr ) )
+        Err( std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "permission denied" ) )
     }
 }
 

--- a/test/testlib/src/error_info.rs
+++ b/test/testlib/src/error_info.rs
@@ -5,7 +5,7 @@ use intercom::*;
 pub struct ErrorSource;
 
 #[derive(Debug)]
-pub struct TestError( HRESULT, String );
+pub struct TestError( raw::HRESULT, String );
 impl std::error::Error for TestError {
     fn description( &self ) -> &str { &self.1 }
     fn cause( &self ) -> Option<&std::error::Error> { None }
@@ -23,7 +23,11 @@ impl ErrorSource
 {
     pub fn new() -> ErrorSource { ErrorSource }
 
-    pub fn store_error( &self, hr : HRESULT, desc : String ) -> Result<(), TestError>
+    pub fn store_error(
+        &self, 
+        hr : raw::HRESULT,
+        desc : String
+    ) -> Result<(), TestError>
     {
         Err( TestError( hr, desc ) )
     }

--- a/test/testlib/src/interface_params.rs
+++ b/test/testlib/src/interface_params.rs
@@ -22,7 +22,7 @@ impl ISharedInterface for SharedImplementation {
     fn divide_by( &self, other: ComItf<ISharedInterface> ) -> ComResult<u32> {
         let divisor = other.get_value();
         match divisor {
-            0 => Err( intercom::E_INVALIDARG ),
+            0 => Err( ComError::E_INVALIDARG ),
             _ => Ok( self.value / divisor ),
         }
     }

--- a/test/testlib/src/lib.rs
+++ b/test/testlib/src/lib.rs
@@ -30,7 +30,7 @@ pub mod unicode; use unicode::*;
     ClassCreator,
     CreatedClass,
     SharedImplementation,
-    ErrorSource,
+    ErrorTests,
     AllocTests,
     StringTests,
     TypeSystemCaller,

--- a/test/testlib/src/lib.rs
+++ b/test/testlib/src/lib.rs
@@ -19,6 +19,7 @@ pub mod alloc; use alloc::*;
 pub mod strings; use strings::*;
 pub mod type_system_callbacks; use type_system_callbacks::*;
 pub mod variant; use variant::*;
+pub mod unicode; use unicode::*;
 
 // Declare available COM classes.
 #[com_library(
@@ -34,6 +35,7 @@ pub mod variant; use variant::*;
     StringTests,
     TypeSystemCaller,
     VariantTests,
+    UnicodeConversion,
 )]
 #[allow(dead_code)]  // #[com_library] requires an item so we need one here for now.
 struct S;

--- a/test/testlib/src/result.rs
+++ b/test/testlib/src/result.rs
@@ -10,16 +10,16 @@ pub struct ResultOperations { }
 impl ResultOperations {
     pub fn new() -> ResultOperations { ResultOperations {} }
 
-    pub fn s_ok( &mut self ) -> HRESULT {
-        S_OK
+    pub fn s_ok( &mut self ) -> raw::HRESULT {
+        raw::S_OK
     }
 
-    pub fn not_impl( &mut self ) -> HRESULT {
-        E_NOTIMPL
+    pub fn not_impl( &mut self ) -> raw::HRESULT {
+        raw::E_NOTIMPL
     }
 
     pub fn sqrt( &mut self, value : f64 ) -> ComResult<f64> {
-        if value < 0.0 { return Err( E_INVALIDARG ) }
+        if value < 0.0 { return Err( ComError::E_INVALIDARG ) }
         Ok( value.sqrt() )
     }
 

--- a/test/testlib/src/strings.rs
+++ b/test/testlib/src/strings.rs
@@ -49,7 +49,7 @@ impl IStringTests for StringTests
         }
 
         println!( "Unrecognized string: {}", s );
-        Err( intercom::E_FAIL )
+        Err( ComError::E_FAIL )
     }
 
     fn index_to_string( &self, i : u32 ) -> ComResult<String> {
@@ -61,32 +61,32 @@ impl IStringTests for StringTests
         }
 
         println!( "Unrecognized index: {}", i );
-        Err( intercom::E_FAIL )
+        Err( ComError::E_FAIL )
     }
 
     fn bstr_parameter( &self, s : &BStr, ptr : usize ) -> ComResult<()> {
 
         let string = s.to_string()
-                .map_err( |_| intercom::E_INVALIDARG )?;
+                .map_err( |_| ComError::E_INVALIDARG )?;
 
         if string != "\u{1F600}" {
-            return Err( intercom::E_FAIL );
+            return Err( ComError::E_FAIL );
         }
 
         if s.as_ptr() as usize == ptr {
             Ok(())
         } else {
-            Err( intercom::E_POINTER )
+            Err( ComError::E_POINTER )
         }
     }
 
     fn bstring_parameter( &self, s : BString ) -> ComResult<()> {
 
         let string = s.to_string()
-                .map_err( |_| intercom::E_INVALIDARG )?;
+                .map_err( |_| ComError::E_INVALIDARG )?;
 
         if string != "\u{1F600}" {
-            Err( intercom::E_FAIL )
+            Err( ComError::E_FAIL )
         } else {
             Ok(())
         }
@@ -103,20 +103,20 @@ impl IStringTests for StringTests
     fn cstr_parameter( &self, s : &CStr, ptr : usize ) -> ComResult<()> {
 
         if s.to_string_lossy() != "\u{1F600}" {
-            return Err( intercom::E_FAIL );
+            return Err( ComError::E_FAIL );
         }
 
         if s.as_ptr() as usize == ptr {
             Ok(())
         } else {
-            Err( intercom::E_POINTER )
+            Err( ComError::E_POINTER )
         }
     }
 
     fn cstring_parameter( &self, s : CString ) -> ComResult<()> {
 
         if s.to_string_lossy() != "\u{1F600}" {
-            Err( intercom::E_FAIL )
+            Err( ComError::E_FAIL )
         } else {
             Ok(())
         }
@@ -138,7 +138,7 @@ impl IStringTests for StringTests
 
         // Caller expects E_INVALIDARG, use E_FAIL to indicate something
         // went wrong.
-        Err( intercom::E_FAIL )
+        Err( ComError::E_FAIL )
     }
 }
 

--- a/test/testlib/src/type_system_callbacks.rs
+++ b/test/testlib/src/type_system_callbacks.rs
@@ -17,7 +17,7 @@ impl TypeSystemCaller
         if actual == i {
             Ok(())
         } else {
-            Err( intercom::E_FAIL )
+            Err( ComError::E_FAIL )
         }
     }
 
@@ -29,7 +29,7 @@ impl TypeSystemCaller
         if actual == expected {
             Ok(())
         } else {
-            Err( intercom::E_FAIL )
+            Err( ComError::E_FAIL )
         }
     }
 
@@ -47,11 +47,11 @@ impl TypeSystemCaller
         let ( bstr, ptr ) = callback.bstring_return_value()?;
 
         if bstr.to_string().unwrap() != "\u{1F4A9}" {
-            return Err( intercom::E_FAIL );
+            return Err( ComError::E_FAIL );
         }
 
         if bstr.as_ptr() as usize != ptr {
-            return Err( intercom::E_POINTER );
+            return Err( ComError::E_POINTER );
         }
 
         Ok(())
@@ -71,11 +71,11 @@ impl TypeSystemCaller
         let ( cstr, ptr ) = callback.cstring_return_value()?;
 
         if cstr.to_string_lossy() != "\u{1F4A9}" {
-            return Err( intercom::E_FAIL );
+            return Err( ComError::E_FAIL );
         }
 
         if cstr.as_ptr() as usize != ptr {
-            return Err( intercom::E_POINTER );
+            return Err( ComError::E_POINTER );
         }
 
         Ok(())

--- a/test/testlib/src/unicode.rs
+++ b/test/testlib/src/unicode.rs
@@ -1,0 +1,76 @@
+
+use std::os::raw::c_char;
+use intercom::*;
+
+#[com_class( UnicodeConversion )]
+pub struct UnicodeConversion;
+
+#[com_interface]
+#[com_impl]
+impl UnicodeConversion {
+
+    pub fn new() -> UnicodeConversion { UnicodeConversion }
+
+    fn utf8_to_utf16(
+        &self,
+        input : *const c_char,
+    ) -> ComResult<*mut u16>
+    {
+        if input.is_null() {
+            return Ok( std::ptr::null_mut() )
+        }
+
+        let cstr = unsafe {
+            CStr::from_ptr( input )
+        };
+        let rust_str = cstr.to_str().map_err( |_| ComError::E_INVALIDARG )?;
+
+        let utf16 : Vec<_> = rust_str.encode_utf16().collect();
+        let buffer_len = ( utf16.len() + 1 ) * 2;
+        let buffer = intercom::alloc::allocate( ( utf16.len() + 1 ) * 2 ) as *mut u16;
+
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                    utf16.as_ptr() as *const c_char,
+                    buffer as *mut c_char,
+                    buffer_len );
+        }
+
+        Ok( buffer )
+    }
+
+    fn utf16_to_utf8(
+        &self,
+        input : *const u16,
+    ) -> ComResult<*mut c_char>
+    {
+        if input.is_null() {
+            return Ok( std::ptr::null_mut() )
+        }
+
+        let slice = unsafe {
+
+            // Find the first zero byte.
+            let mut len = 0usize;
+            while *input.offset( len as isize ) != 0 {
+                len += 1;
+            }
+
+            std::slice::from_raw_parts( input, len )
+        };
+
+        let s = String::from_utf16( slice ).map_err( |_| ComError::E_INVALIDARG )?;
+        let cstring = CString::new( s ).map_err( |_| ComError::E_INVALIDARG )?;
+        let utf8bytes = cstring.to_bytes();
+
+        let buffer = intercom::alloc::allocate( utf8bytes.len() + 1 ) as *mut c_char;
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                    utf8bytes.as_ptr() as *const c_char,
+                    buffer as *mut c_char,
+                    utf8bytes.len() + 1 );
+        }
+
+        Ok( buffer )
+    }
+}


### PR DESCRIPTION
Closes #74

- [x] Change `ComResult<S>` to `Result<S, ComError>`
- [x] Introduce `RawComResult<S>` to the few places where we want to handle low level HRESULT codes directly.
- [x] Implement `load_error` when turning incoming `HRESULT` to `ComError`. This should check whether the interface `SupportsErrorInfo`.
- [x] Draft a proper error handling API.
    - ComError constructors
    - Ways to match on error code