### PR TITLE
Improve build script error reporting

### DIFF
--- a/intercom-build/src/lib.rs
+++ b/intercom-build/src/lib.rs
@@ -3,18 +3,64 @@ extern crate intercom_common;
 mod os;
 mod host;
 
+use std::io::Write;
+
 #[derive(Debug)]
 pub enum BuildError {
     ParseError( String ),
     IoError( String, std::io::Error ),
-    CommandError( String ),
+    CommandError( String, String, String ),
+}
+
+impl BuildError {
+    fn print_as_warning( &self, w : &mut Write ) -> Result<(), std::io::Error> {
+
+        let msg : std::borrow::Cow<str> = match *self {
+            BuildError::ParseError( ref m, .. ) => m.into(),
+            BuildError::IoError( ref m, ref e ) => format!( "{}: {}", m, e ).into(),
+            BuildError::CommandError( ref m, .. ) => m.into(),
+        };
+
+        writeln!( w, "cargo:warning={}", msg )?;
+
+        match *self {
+            BuildError::CommandError( _, ref stdout, ref stderr ) => {
+
+                if stdout.len() > 0 {
+                    writeln!( w, "cargo:warning=" )?;
+                    writeln!( w, "cargo:warning=Program stdout:" )?;
+                    writeln!( w, "cargo:warning=---------------" )?;
+                    for line in stdout.split( '\n' ) {
+                        writeln!( w, "cargo:warning={}", line )?;
+                    }
+                }
+
+                if stderr.len() > 0 {
+                    writeln!( w, "cargo:warning=" )?;
+                    writeln!( w, "cargo:warning=Program stderr:" )?;
+                    writeln!( w, "cargo:warning=---------------" )?;
+                    for line in stderr.split( '\n' ) {
+                        writeln!( w, "cargo:warning={}", line )?;
+                    }
+                }
+
+                if stdout.len() == 0 && stderr.len() == 0 {
+                    writeln!( w, "cargo:warning=(Command produced no output)" )?;
+                }
+            },
+            _ => {}  // No extra lines.
+        }
+
+        Ok(())
+    }
 }
 
 pub fn build( all_type_systems : bool ) {
     match os::build( all_type_systems ) {
         Ok(..) => {}
         Err( e ) => {
-            println!( "cargo:warning=Error during Intercom build step: {:?}", e );
+            e.print_as_warning( &mut std::io::stdout() )
+                    .expect( "Cannot write to stdout" );
             println!( "cargo:warning=Some Intercom functionality might not be available" );
         }
     }

--- a/intercom-build/src/lib.rs
+++ b/intercom-build/src/lib.rs
@@ -23,10 +23,12 @@ impl BuildError {
 
         writeln!( w, "cargo:warning={}", msg )?;
 
+        // Handle all the errors that provide extra info.
+        // (Only one currently, but we'll still want to structure this as a match)
+        #[allow(clippy::single_match)]
         match *self {
             BuildError::CommandError( _, ref stdout, ref stderr ) => {
-
-                if stdout.len() > 0 {
+                if ! stdout.is_empty() {
                     writeln!( w, "cargo:warning=" )?;
                     writeln!( w, "cargo:warning=Program stdout:" )?;
                     writeln!( w, "cargo:warning=---------------" )?;
@@ -35,7 +37,7 @@ impl BuildError {
                     }
                 }
 
-                if stderr.len() > 0 {
+                if ! stderr.is_empty() {
                     writeln!( w, "cargo:warning=" )?;
                     writeln!( w, "cargo:warning=Program stderr:" )?;
                     writeln!( w, "cargo:warning=---------------" )?;
@@ -44,7 +46,10 @@ impl BuildError {
                     }
                 }
 
-                if stdout.len() == 0 && stderr.len() == 0 {
+                // If the program didn't provide stdout or stderr, we'll want to
+                // inform the user of that so they aren't left confused on why
+                // our error messages are crap.
+                if stdout.is_empty() && stderr.is_empty() {
                     writeln!( w, "cargo:warning=(Command produced no output)" )?;
                 }
             },

--- a/intercom-build/src/lib.rs
+++ b/intercom-build/src/lib.rs
@@ -3,6 +3,19 @@ extern crate intercom_common;
 mod os;
 mod host;
 
+#[derive(Debug)]
+pub enum BuildError {
+    ParseError( String ),
+    IoError( String, std::io::Error ),
+    CommandError( String ),
+}
+
 pub fn build( all_type_systems : bool ) {
-    os::build( all_type_systems )
+    match os::build( all_type_systems ) {
+        Ok(..) => {}
+        Err( e ) => {
+            println!( "cargo:warning=Error during Intercom build step: {:?}", e );
+            println!( "cargo:warning=Some Intercom functionality might not be available" );
+        }
+    }
 }

--- a/intercom-build/src/os/mod.rs
+++ b/intercom-build/src/os/mod.rs
@@ -1,4 +1,6 @@
 
+use ::BuildError;
+
 #[cfg(windows)]
 mod windows;
 
@@ -6,4 +8,4 @@ mod windows;
 pub use self::windows::build;
 
 #[cfg(not(windows))]
-pub fn build(_: bool) {}
+pub fn build(_: bool) -> Result<(), BuildError> { Ok(()) }

--- a/intercom-build/src/os/mod.rs
+++ b/intercom-build/src/os/mod.rs
@@ -1,11 +1,13 @@
 
-use ::BuildError;
 
 #[cfg(windows)]
 mod windows;
 
 #[cfg(windows)]
 pub use self::windows::build;
+
+#[cfg(not(windows))]
+use ::BuildError;
 
 #[cfg(not(windows))]
 pub fn build(_: bool) -> Result<(), BuildError> { Ok(()) }

--- a/intercom-common/src/generators/idl.rs
+++ b/intercom-common/src/generators/idl.rs
@@ -201,22 +201,29 @@ impl IdlModel {
                     .get_ident()
                     .expect( "coclass had no name" )
                     .to_string();
-            let coclass = &c.structs()[ &class_name ];
+            let coclass = &c.structs().get( &class_name )
+                    .ok_or_else( || GeneratorError::TypeNotFound( class_name ) )?;
 
             // Get the interfaces the class implements.
             let interfaces = coclass.interfaces().iter()
                 .flat_map(|itf_name| {
-                    let itf = &c.interfaces()[ &itf_name.to_string() ];
-                    itf.variants().iter()
-                        .filter( itf_variant_filter.as_ref() )
-                        .map( |(_, itf_variant)| {
+                    let result = c.interfaces().get( &itf_name.to_string() )
+                            .ok_or_else( || GeneratorError::TypeNotFound( itf_name.to_string() ) );
 
-                            foreign.get_name( c, match all_type_systems {
-                                false => itf.name(),
-                                true => itf_variant.unique_name(),
-                            } )
-                        } ).collect::<Vec<_>>()
-                } ).collect();
+                    match result {
+                        Ok( itf ) => itf.variants().iter()
+                            .filter( itf_variant_filter.as_ref() )
+                            .map( |(_, itf_variant)| {
+
+                                Ok( foreign.get_name( c, match all_type_systems {
+                                    false => itf.name(),
+                                    true => itf_variant.unique_name(),
+                                } ) )
+                            } ).collect::<Vec<_>>(),
+                        Err( e ) => vec![ Err( e ) ],
+                    }
+                } )
+                .collect::<Result<Vec<_>, GeneratorError>>()?;
 
             let clsid = coclass.clsid().as_ref()
                     .ok_or_else( || GeneratorError::MissingClsid(

--- a/intercom-common/src/generators/mod.rs
+++ b/intercom-common/src/generators/mod.rs
@@ -23,6 +23,9 @@ pub enum GeneratorError {
     #[fail( display = "Unsupported type: {}", _0 )]
     UnsupportedType( String ),
 
+    #[fail( display = "Type not found: {}", _0 )]
+    TypeNotFound( String ),
+
     #[fail( display = "{}", _0 )]
     IoError( #[cause] ::std::io::Error ),
 }


### PR DESCRIPTION
Fixes #94 

The build script uses `cargo:warning` to raise issues encountered during the build. This avoids the build from failing and Rustc from giving better error messages on things like syntax errors.