### PR TITLE
Reduce appveyor builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,5 +36,5 @@ build_script:
     - cmd: .\scripts\ci.bat
 
 test_script:
-    - cargo test --all-features
+    - cargo test --release --all-features
     - ps: .\scripts\test.ps1

--- a/scripts/ci.bat
+++ b/scripts/ci.bat
@@ -6,11 +6,7 @@ popd
 
 echo on
 
-REM Build Intercom
-cargo build
-if %errorlevel% neq 0 exit /b %errorlevel%
-
-REM Build C++ test suite
+REM Build Intercom and the C++ test suite
 del /s /q build\x64
 mkdir build
 mkdir build\x64

--- a/test/cpp-dl/CMakeLists.txt
+++ b/test/cpp-dl/CMakeLists.txt
@@ -21,7 +21,7 @@ ${PROJECT_SOURCE_DIR}/shared_functions.cpp
 file(GLOB multilib_sources ${MULTILIB_DIR}/src)
 add_custom_command(
     OUTPUT ${PROJECT_SOURCE_DIR}/generated/multi_lib.h ${PROJECT_SOURCE_DIR}/generated/multi_lib.cpp
-    COMMAND cargo run cpp ${MULTILIB_DIR} ${PROJECT_SOURCE_DIR}/generated
+    COMMAND cargo run --release cpp ${MULTILIB_DIR} ${PROJECT_SOURCE_DIR}/generated
     WORKING_DIRECTORY ${INTERCOM_ROOT}/intercom-cli
     DEPENDS ${multilib_sources})
 
@@ -29,7 +29,7 @@ add_custom_command(
 file(GLOB testlib_sources ${TESTLIB_DIR}/src)
 add_custom_command(
     OUTPUT ${PROJECT_SOURCE_DIR}/generated/test_lib.h ${PROJECT_SOURCE_DIR}/generated/test_lib.cpp
-    COMMAND cargo run cpp ${TESTLIB_DIR} ${PROJECT_SOURCE_DIR}/generated
+    COMMAND cargo run --release cpp ${TESTLIB_DIR} ${PROJECT_SOURCE_DIR}/generated
     WORKING_DIRECTORY ${INTERCOM_ROOT}/intercom-cli
     DEPENDS ${testlib_sources})
 

--- a/test/cpp-utility/CMakeLists.txt
+++ b/test/cpp-utility/CMakeLists.txt
@@ -30,7 +30,7 @@ endif()
 file(GLOB testlib_sources ${TESTLIB_DIR}/src)
 add_custom_command(
     OUTPUT ${PROJECT_SOURCE_DIR}/generated/test_lib.h ${PROJECT_SOURCE_DIR}/generated/test_lib.cpp
-    COMMAND cargo run cpp ${TESTLIB_DIR} --all ${PROJECT_SOURCE_DIR}/generated
+    COMMAND cargo run --release cpp ${TESTLIB_DIR} --all ${PROJECT_SOURCE_DIR}/generated
     WORKING_DIRECTORY ${INTERCOM_ROOT}/intercom-cli
     DEPENDS ${testlib_sources})
 


### PR DESCRIPTION
Previously we compiled intercom with 'cargo build' and then later through cmake with 'cargo build --release'.

The first cargo build is now removed and we'll run the tests in release mode so we can reuse the --release build.