### PR TITLE
Import syn types explicitly

### DIFF
--- a/intercom-common/src/ast_converters.rs
+++ b/intercom-common/src/ast_converters.rs
@@ -1,6 +1,6 @@
 
 use prelude::*;
-use syn::*;
+use syn::{ Attribute, FnArg, GenericArgument, Ident, Item, Pat, Path, Type, TypeReference };
 
 /// Extract the underlying Type from various AST types.
 pub trait GetType {

--- a/intercom-common/src/attributes/com_class.rs
+++ b/intercom-common/src/attributes/com_class.rs
@@ -7,7 +7,6 @@ use utils;
 use model;
 
 use tyhandlers::{ModelTypeSystem};
-use syn::*;
 
 /// Expands the `com_class` attribute.
 ///

--- a/intercom-common/src/attributes/com_impl.rs
+++ b/intercom-common/src/attributes/com_impl.rs
@@ -10,7 +10,6 @@ use model;
 
 extern crate proc_macro;
 use self::proc_macro::TokenStream;
-use syn::*;
 
 /// Expands the `com_impl` attribute.
 ///

--- a/intercom-common/src/attributes/com_interface.rs
+++ b/intercom-common/src/attributes/com_interface.rs
@@ -12,7 +12,6 @@ use model;
 use methodinfo::ComMethodInfo;
 
 extern crate proc_macro;
-use syn::*;
 
 /// Interface level output.
 #[derive(Default)]
@@ -335,7 +334,7 @@ fn rust_to_com_delegate(
     // parameters.
     let params = iter::once( quote!( comptr.ptr ) ).chain( params );
 
-    // Create the return statement. 
+    // Create the return statement.
     let return_ident = Ident::new( "__result", Span::call_site() );
     let return_statement = method_info
             .returnhandler

--- a/intercom-common/src/methodinfo.rs
+++ b/intercom-common/src/methodinfo.rs
@@ -1,7 +1,7 @@
 
 use prelude::*;
 use std::rc::Rc;
-use syn::*;
+use syn::{ ArgSelfRef, FnArg, FnDecl, MethodSig, PathArguments, ReturnType, Type };
 
 use ast_converters::*;
 use tyhandlers::{Direction, TypeContext, ModelTypeSystem, TypeHandler, get_ty_handler};
@@ -310,6 +310,8 @@ fn hresult_ty() -> Type {
 #[cfg(test)]
 mod tests {
 
+    use syn::{ Item };
+
     use super::*;
     use tyhandlers::ModelTypeSystem::*;
 
@@ -397,7 +399,7 @@ mod tests {
 
     fn test_info( code : &str, ts : ModelTypeSystem) -> ComMethodInfo {
 
-        let item = parse_str( code ).unwrap();
+        let item = syn::parse_str( code ).unwrap();
         let ( ident, decl, unsafety ) = match item {
             Item::Fn( ref f ) => ( f.ident.clone(), f.decl.as_ref(), f.unsafety.is_some() ),
             _ => panic!( "Code isn't function" ),

--- a/intercom-common/src/returnhandlers.rs
+++ b/intercom-common/src/returnhandlers.rs
@@ -1,6 +1,6 @@
 
 use prelude::*;
-use syn::*;
+use syn::{ Type };
 use methodinfo::{ComArg};
 use tyhandlers::{self, TypeContext, ModelTypeSystem, Direction};
 use utils;


### PR DESCRIPTION
Syn exports its own Result type which conflicts with the standard Result type leading to compilation errors.