### PR TITLE
Removed direction member from TypeContext

### DIFF
--- a/intercom-common/src/attributes/com_impl.rs
+++ b/intercom-common/src/attributes/com_impl.rs
@@ -132,7 +132,7 @@ pub fn expand_com_impl(
                     .into_iter()
                     .map( |com_arg| {
                         let name = &com_arg.name;
-                        let com_ty = &com_arg.handler.com_ty();
+                        let com_ty = &com_arg.handler.com_ty( com_arg.dir );
                         let dir = match com_arg.dir {
                             Direction::In => quote!(),
                             Direction::Out | Direction::Retval => quote!( *mut )
@@ -146,7 +146,7 @@ pub fn expand_com_impl(
             let ( in_temporaries, in_params ) : ( Vec<_>, Vec<_> ) = method_info.args
                     .iter()
                     .map( |ca| {
-                        let conversion = ca.handler.com_to_rust( &ca.name );
+                        let conversion = ca.handler.com_to_rust( &ca.name, Direction::In );
                         ( conversion.temporary, conversion.value )
                     } )
                     .unzip();

--- a/intercom-common/src/attributes/com_interface.rs
+++ b/intercom-common/src/attributes/com_interface.rs
@@ -246,7 +246,7 @@ fn process_itf_variant(
                 .into_iter()
                 .map( |com_arg| {
                     let name = &com_arg.name;
-                    let com_ty = &com_arg.handler.com_ty();
+                    let com_ty = &com_arg.handler.com_ty( com_arg.dir );
                     let dir = match com_arg.dir {
                         Direction::In => quote!(),
                         Direction::Out | Direction::Retval => quote!( *mut )
@@ -308,7 +308,7 @@ fn rust_to_com_delegate(
             .iter()
             .map( |ca| {
                 let ident = &ca.name;
-                let ty = &ca.handler.com_ty();
+                let ty = &ca.handler.com_ty( Direction::Retval );
                 let default = ca.handler.default_value();
                 quote!( let mut #ident : #ty = #default; )
             } ).collect::<Vec<_>>();
@@ -320,7 +320,7 @@ fn rust_to_com_delegate(
                 let name = com_arg.name;
                 match com_arg.dir {
                     Direction::In => {
-                        let param = com_arg.handler.rust_to_com( &name );
+                        let param = com_arg.handler.rust_to_com( &name, Direction::In );
                         ( param.temporary, param.value )
                     },
                     Direction::Out | Direction::Retval

--- a/intercom-common/src/generators/cpp.rs
+++ b/intercom-common/src/generators/cpp.rs
@@ -243,7 +243,7 @@ impl CppModel {
                         };
 
                         // Get the foreign type for the arg type in C++ format.
-                        let com_ty = a.handler.com_ty();
+                        let com_ty = a.handler.com_ty( dir );
                         let type_info = foreign.get_ty( &com_ty )
                                 .ok_or_else( || GeneratorError::UnsupportedType(
                                                 utils::ty_to_string( &a.ty ) ) )?;

--- a/intercom-common/src/generators/idl.rs
+++ b/intercom-common/src/generators/idl.rs
@@ -138,7 +138,7 @@ impl IdlModel {
                         };
 
                         // Get the foreign type for the arg type.
-                        let com_ty = a.handler.com_ty();
+                        let com_ty = a.handler.com_ty( a.dir );
                         let idl_type = foreign
                             .get_ty( &com_ty )
                             .ok_or_else( || GeneratorError::UnsupportedType(

--- a/intercom-common/src/methodinfo.rs
+++ b/intercom-common/src/methodinfo.rs
@@ -49,7 +49,7 @@ impl RustArg {
     pub fn new( name: Ident, ty: Type, type_system: ModelTypeSystem ) -> RustArg {
 
         let tyhandler = get_ty_handler(
-                &ty, TypeContext::new( Direction::In, type_system ) );
+                &ty, TypeContext::new( type_system ) );
         RustArg {
             name,
             ty,
@@ -83,7 +83,7 @@ impl ComArg {
     ) -> ComArg {
 
         let tyhandler = get_ty_handler(
-                &ty, TypeContext::new( dir, type_system ) );
+                &ty, TypeContext::new( type_system ) );
         ComArg {
             name,
             ty,
@@ -99,7 +99,7 @@ impl ComArg {
     ) -> ComArg {
 
         let tyhandler = get_ty_handler(
-                &rustarg.ty, TypeContext::new( dir, type_system ) );
+                &rustarg.ty, TypeContext::new( type_system ) );
         ComArg {
             name: rustarg.name,
             ty: rustarg.ty,


### PR DESCRIPTION
The direction member in the TypeContext struct was very difficult to work with when I tried to implement structs which are essentially nested types. The type handles of the individual fields of the structs should not be aware of the direction of struct. The direction is now given as a parameter during code generation,for the type handler.