### PR TITLE
Make ComItf safer

### DIFF
--- a/intercom-cli/src/embed/setup_configuration.rs
+++ b/intercom-cli/src/embed/setup_configuration.rs
@@ -61,29 +61,29 @@ pub trait IEnumSetupInstances
     fn next(
         &self,
         celt : u32
-    ) -> ComResult< ( ComItf<dyn ISetupInstance>, u32 ) >;
+    ) -> ComResult< ( ComRc<dyn ISetupInstance>, u32 ) >;
 
     fn skip( &self, celt : u32 ) -> ComResult<()>;
 
     fn reset( &self ) -> ComResult<()>;
 
-    fn clone( &self ) -> ComResult< ComItf<dyn IEnumSetupInstances> >;
+    fn clone( &self ) -> ComResult< ComRc<dyn IEnumSetupInstances> >;
 }
 
 #[com_interface( com_iid = "26AAB78C-4A60-49D6-AF3B-3C35BC93365D" )]
 pub trait ISetupConfiguration2
 {
     fn enum_instances( &self )
-        -> ComResult< ComItf<dyn IEnumSetupInstances> >;
+        -> ComResult< ComRc<dyn IEnumSetupInstances> >;
 
     fn get_instance_for_current_process( &self )
-        -> ComResult< ComItf<dyn ISetupInstance> >;
+        -> ComResult< ComRc<dyn ISetupInstance> >;
 
     fn get_instance_for_path( &self, path : String )
-        -> ComResult< ComItf<dyn ISetupInstance> >;
+        -> ComResult< ComRc<dyn ISetupInstance> >;
 
     fn enum_all_instances( &self )
-        -> ComResult< ComItf<dyn IEnumSetupInstances> >;
+        -> ComResult< ComRc<dyn IEnumSetupInstances> >;
 }
 
 pub struct ToolPaths {

--- a/intercom/src/combox.rs
+++ b/intercom/src/combox.rs
@@ -121,15 +121,19 @@ impl<T: CoClass> AsRef<ComBox<T>> for ComStruct<T>
 impl<I: ComInterface + ?Sized, T: HasInterface<I>> From<ComStruct<T>> for ComRc<I> {
 
     fn from( source : ComStruct<T> ) -> ComRc<I> {
-        let rc = ComRc::attach( source.as_comitf() );
-        std::mem::forget( source );
-        rc
+        // as_comitf does not change the reference count so attach is safe
+        // as long as we forget the source so it won't release it either.
+        unsafe {
+            let rc = ComRc::attach( source.as_comitf() );
+            std::mem::forget( source );
+            rc
+        }
     }
 }
 
 impl<I: ComInterface + ?Sized, T: HasInterface<I>> From<&ComStruct<T>> for ComRc<I> {
     fn from( combox : &ComStruct<T> ) -> Self {
-        ComRc::copy( &combox.as_comitf() )
+        ComRc::from( &combox.as_comitf() )
     }
 }
 

--- a/intercom/src/comrc.rs
+++ b/intercom/src/comrc.rs
@@ -33,6 +33,13 @@ impl<T : ComInterface + ?Sized> ComRc<T> {
     /// reference counting.
     ///
     /// Does not increment the reference count.
+    ///
+    /// # Safety
+    ///
+    /// Given this does not increment the reference count, it must be used
+    /// only if the `ComItf` is one that would leave the reference dangling.
+    /// If something already owns the `ComItf` and will do `release` on it,
+    /// the drop of the returned `ComRc` will result in a double-release.
     pub unsafe fn attach( itf : ComItf<T> ) -> ComRc<T> {
         ComRc { itf }
     }

--- a/intercom/src/comrc.rs
+++ b/intercom/src/comrc.rs
@@ -17,9 +17,13 @@ impl<T: ComInterface + ?Sized> std::fmt::Debug for ComRc<T> {
 
 impl<T: ComInterface + ?Sized> Clone for ComRc<T> {
     fn clone( &self ) -> Self {
-        let rc = ComRc { itf : self.itf };
-        rc.itf.as_ref().add_ref();
-        rc
+        ComRc::from( &self.itf )
+    }
+}
+
+impl<T: ComInterface + ?Sized> From<&ComItf<T>> for ComRc<T> {
+    fn from(source: &ComItf<T>) -> Self {
+        ComItf::as_rc(source)
     }
 }
 
@@ -29,7 +33,7 @@ impl<T : ComInterface + ?Sized> ComRc<T> {
     /// reference counting.
     ///
     /// Does not increment the reference count.
-    pub fn attach( itf : ComItf<T> ) -> ComRc<T> {
+    pub unsafe fn attach( itf : ComItf<T> ) -> ComRc<T> {
         ComRc { itf }
     }
 
@@ -38,7 +42,9 @@ impl<T : ComInterface + ?Sized> ComRc<T> {
     ///
     /// Does not increment the reference count.
     pub fn detach( mut rc : ComRc<T> ) -> ComItf<T> {
-        unsafe { std::mem::replace( &mut rc.itf, ComItf::null_itf() ) }
+        unsafe {
+            std::mem::replace(&mut rc.itf, ComItf::null_itf())
+        }
     }
 
     /// Creates a `ComItf<T>` from a raw type system COM interface pointer..
@@ -52,25 +58,19 @@ impl<T : ComInterface + ?Sized> ComRc<T> {
     pub unsafe fn wrap<TS: TypeSystem>(
         ptr : raw::InterfacePtr<TS, T>
     ) -> Option<ComRc<T>> {
-        ComItf::maybe_wrap( ptr ).map(ComRc::attach)
-    }
-
-    pub fn copy( itf : &ComItf<T> ) -> ComRc<T> {
-
-        let iunk : &ComItf<dyn IUnknown> = itf.as_ref();
-        iunk.add_ref();
-        ComRc::attach( *itf )
+        ComItf::maybe_wrap( ptr ).map( |itf| ComRc::attach(itf) )
     }
 
     // ComRc is a smart pointer and shouldn't introduce methods on 'self'.
     #[allow(clippy::wrong_self_convention)]
     pub fn into_unknown( mut other : ComRc<T> ) -> ComRc<dyn IUnknown> {
 
-        let itf = unsafe {
-            std::mem::replace( &mut other.itf, ComItf::null_itf() )
-        };
-
-        ComRc::attach( ComItf::as_unknown( &itf ) )
+        // We'll steal the interface off the current ComRc. This prevents the
+        // current ComRc from releasing it so we are free to do attach here.
+        unsafe {
+            let itf = std::mem::replace( &mut other.itf, ComItf::null_itf() );
+            ComRc::attach( ComItf::as_unknown( &itf ) )
+        }
     }
 }
 

--- a/intercom/src/type_system.rs
+++ b/intercom/src/type_system.rs
@@ -215,7 +215,7 @@ impl<TS: TypeSystem, TPtr> ExternType<TS> for *const TPtr where TPtr: Bidirectio
 
 /// `ComItf` extern type implementation.
 
-impl<I: crate::ComInterface + ?Sized> BidirectionalTypeInfo for crate::ComItf<I>
+impl<I: crate::ComInterface + ?Sized> BidirectionalTypeInfo for &crate::ComItf<I>
     where I: BidirectionalTypeInfo
 {
 
@@ -224,15 +224,15 @@ impl<I: crate::ComInterface + ?Sized> BidirectionalTypeInfo for crate::ComItf<I>
     fn indirection_level() -> u32 { <I as BidirectionalTypeInfo>::indirection_level() + 1 }
 }
 
-impl<TS: TypeSystem, I: crate::ComInterface + ?Sized> ExternType<TS>
-        for crate::ComItf<I>
+impl<'a, TS: TypeSystem, I: crate::ComInterface + ?Sized> ExternType<TS>
+        for &'a crate::ComItf<I>
     where I: BidirectionalTypeInfo
 {
 
     type ExternInputType = crate::raw::InterfacePtr<TS, I>;
     type ExternOutputType = crate::raw::InterfacePtr<TS, I>;
-    type OwnedExternType = crate::raw::InterfacePtr<TS, I>;
-    type OwnedNativeType = crate::raw::InterfacePtr<TS, I>;
+    type OwnedExternType = &'a crate::ComItf<I>;
+    type OwnedNativeType = crate::ComItf<I>;
 }
 
 impl<TS: TypeSystem, I: crate::ComInterface + ?Sized> ExternType<TS>
@@ -288,6 +288,14 @@ impl<TS: TypeSystem, I: crate::ComInterface + ?Sized>
 {
     unsafe fn intercom_from( source: &crate::ComItf<I> ) -> ComResult<Self> {
         Ok( crate::ComItf::ptr( source ) )
+    }
+}
+
+impl<TS: TypeSystem, I: crate::ComInterface + ?Sized>
+    IntercomFrom<&&crate::ComItf<I>> for crate::raw::InterfacePtr<TS, I>
+{
+    unsafe fn intercom_from( source: &&crate::ComItf<I> ) -> ComResult<Self> {
+        Ok( crate::ComItf::ptr( *source ) )
     }
 }
 

--- a/intercom/src/variant.rs
+++ b/intercom/src/variant.rs
@@ -402,10 +402,10 @@ impl<T: HasInterface<dyn IUnknown>> From< ComStruct<T> > for Variant {
     }
 }
 
-impl<T: ComInterface + ?Sized> From< ComItf<T> > for Variant {
-    fn from( src : ComItf<T> ) -> Self {
+impl<T: ComInterface + ?Sized> From< &ComItf<T> > for Variant {
+    fn from( src : &ComItf<T> ) -> Self {
         let iunk : &ComItf<dyn IUnknown> = src.as_ref();
-        Variant::IUnknown( ComRc::copy( iunk ) )
+        Variant::IUnknown( ComRc::from( iunk ) )
     }
 }
 

--- a/test/testlib/src/error_info.rs
+++ b/test/testlib/src/error_info.rs
@@ -32,7 +32,7 @@ impl ErrorTests
 {
     pub fn new() -> ErrorTests { ErrorTests }
 
-    pub fn test_comerror( &self, source : ComItf<dyn IErrorSource> ) -> ComResult<()>
+    pub fn test_comerror( &self, source : &ComItf<dyn IErrorSource> ) -> ComResult<()>
     {
         let err = source.return_comerror(
                 raw::HRESULT::new( 123 ),
@@ -57,7 +57,7 @@ impl ErrorTests
         }
     }
 
-    pub fn test_testerror( &self, source : ComItf<dyn IErrorSource> ) -> ComResult<()>
+    pub fn test_testerror( &self, source : &ComItf<dyn IErrorSource> ) -> ComResult<()>
     {
         let err = source.return_testerror(
                 raw::HRESULT::new( 123 ),
@@ -82,7 +82,7 @@ impl ErrorTests
         }
     }
 
-    pub fn test_ioerror( &self, source : ComItf<dyn IErrorSource> ) -> ComResult<()>
+    pub fn test_ioerror( &self, source : &ComItf<dyn IErrorSource> ) -> ComResult<()>
     {
         let err = source.return_ioerror(
                 raw::HRESULT::new( raw::E_ACCESSDENIED.hr ),

--- a/test/testlib/src/interface_params.rs
+++ b/test/testlib/src/interface_params.rs
@@ -5,7 +5,7 @@ use intercom::*;
 pub trait ISharedInterface {
     fn get_value( &self ) -> u32;
     fn set_value( &mut self, v : u32 );
-    fn divide_by( &self, divisor: ComItf<dyn ISharedInterface> ) -> ComResult<u32>;
+    fn divide_by( &self, divisor: &ComItf<dyn ISharedInterface> ) -> ComResult<u32>;
 }
 
 #[com_class( ISharedInterface)]
@@ -19,7 +19,7 @@ impl SharedImplementation {
 impl ISharedInterface for SharedImplementation {
     fn get_value( &self ) -> u32 { self.value }
     fn set_value( &mut self, v : u32 ) { self.value = v }
-    fn divide_by( &self, other: ComItf<dyn ISharedInterface> ) -> ComResult<u32> {
+    fn divide_by( &self, other: &ComItf<dyn ISharedInterface> ) -> ComResult<u32> {
         let divisor = other.get_value();
         match divisor {
             0 => Err( ComError::E_INVALIDARG ),

--- a/test/testlib/src/return_interfaces.rs
+++ b/test/testlib/src/return_interfaces.rs
@@ -22,7 +22,7 @@ impl ClassCreator {
     pub fn create_child(
         &self,
         id : i32,
-        parent : ComItf<dyn IParent>
+        parent : &ComItf<dyn IParent>
     ) -> ComResult<ComRc<CreatedClass>>
     {
         Ok( ComRc::from( &ComStruct::new(

--- a/test/testlib/src/type_system_callbacks.rs
+++ b/test/testlib/src/type_system_callbacks.rs
@@ -11,7 +11,7 @@ impl TypeSystemCaller
 {
     pub fn new() -> Self { TypeSystemCaller }
 
-    pub fn call_string( &self, i: u32, callback : ComItf<dyn IStringTests> ) -> ComResult<()> {
+    pub fn call_string( &self, i: u32, callback : &ComItf<dyn IStringTests> ) -> ComResult<()> {
 
         let actual = callback.string_to_index( STRING_DATA[ i as usize ] )?;
         if actual == i {
@@ -21,7 +21,7 @@ impl TypeSystemCaller
         }
     }
 
-    fn receive_string( &self, i : u32, callback : ComItf<dyn IStringTests> ) -> ComResult<()> {
+    fn receive_string( &self, i : u32, callback : &ComItf<dyn IStringTests> ) -> ComResult<()> {
 
         let actual = callback.index_to_string( i )?;
         let expected = STRING_DATA[ i as usize ];
@@ -33,17 +33,17 @@ impl TypeSystemCaller
         }
     }
 
-    fn pass_bstr( &self, callback : ComItf<dyn IStringTests> ) -> ComResult<()> {
+    fn pass_bstr( &self, callback : &ComItf<dyn IStringTests> ) -> ComResult<()> {
         let bstr = BString::from( "\u{1F4A9}" );
         callback.bstr_parameter( &bstr, bstr.as_ptr() as usize )
     }
 
-    fn pass_bstring( &self, callback : ComItf<dyn IStringTests> ) -> ComResult<()> {
+    fn pass_bstring( &self, callback : &ComItf<dyn IStringTests> ) -> ComResult<()> {
         let bstr = BString::from( "\u{1F4A9}" );
         callback.bstring_parameter( bstr )
     }
 
-    fn receive_bstring( &self, callback : ComItf<dyn IStringTests> ) -> ComResult<()> {
+    fn receive_bstring( &self, callback : &ComItf<dyn IStringTests> ) -> ComResult<()> {
         let ( bstr, ptr ) = callback.bstring_return_value()?;
 
         if bstr.to_string().unwrap() != "\u{1F4A9}" {
@@ -57,17 +57,17 @@ impl TypeSystemCaller
         Ok(())
     }
 
-    fn pass_cstr( &self, callback : ComItf<dyn IStringTests> ) -> ComResult<()> {
+    fn pass_cstr( &self, callback : &ComItf<dyn IStringTests> ) -> ComResult<()> {
         let cstr = CString::new( "\u{1F4A9}" ).unwrap();
         callback.cstr_parameter( &cstr, cstr.as_ptr() as usize )
     }
 
-    fn pass_cstring( &self, callback : ComItf<dyn IStringTests> ) -> ComResult<()> {
+    fn pass_cstring( &self, callback : &ComItf<dyn IStringTests> ) -> ComResult<()> {
         let cstr = CString::new( "\u{1F4A9}" ).unwrap();
         callback.cstring_parameter( cstr )
     }
 
-    fn receive_cstring( &self, callback : ComItf<dyn IStringTests> ) -> ComResult<()> {
+    fn receive_cstring( &self, callback : &ComItf<dyn IStringTests> ) -> ComResult<()> {
         let ( cstr, ptr ) = callback.cstring_return_value()?;
 
         if cstr.to_string_lossy() != "\u{1F4A9}" {


### PR DESCRIPTION
ComItf is now extern type only as `&ComItf` - this prevents users from writing methods that accept input parameters as `ComItf<I>`, which is an owned type with no ties to a lifetime. Also removed the `Clone` implementation from `ComItf` which would have allowed the user to bypass the reference counting.

Removal of `Clone` required changes to the way errors are stored as the previous `Cell` needed a `Copy` type - then again, we already did `add_ref`/`release` around the cell storage so we should have just used `ComRc` instead.