### PR TITLE
Use extern "system" over extern "stdcall"/"C"

### DIFF
--- a/intercom-attributes/tests/data/com_impl.target.rs
+++ b/intercom-attributes/tests/data/com_impl.target.rs
@@ -170,16 +170,16 @@ impl Foo {
 }
 #[allow(non_snake_case)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Automation_query_interface(self_vtable:
-                                                              intercom::RawComPtr,
-                                                          riid:
-                                                              <intercom::REFIID
-                                                              as
-                                                              intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
-                                                          out:
-                                                              *mut <intercom::RawComPtr
+unsafe extern "system" fn __Foo_Foo_Automation_query_interface(self_vtable:
+                                                                   intercom::RawComPtr,
+                                                               riid:
+                                                                   <intercom::REFIID
                                                                    as
-                                                                   intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
+                                                                   intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
+                                                               out:
+                                                                   *mut <intercom::RawComPtr
+                                                                        as
+                                                                        intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
  ->
      <intercom::raw::HRESULT as
      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType {
@@ -190,8 +190,8 @@ unsafe extern "C" fn __Foo_Foo_Automation_query_interface(self_vtable:
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Automation_add_ref(self_vtable:
-                                                      intercom::RawComPtr)
+unsafe extern "system" fn __Foo_Foo_Automation_add_ref(self_vtable:
+                                                           intercom::RawComPtr)
  ->
      <u32 as
      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType {
@@ -202,8 +202,8 @@ unsafe extern "C" fn __Foo_Foo_Automation_add_ref(self_vtable:
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Automation_release(self_vtable:
-                                                      intercom::RawComPtr)
+unsafe extern "system" fn __Foo_Foo_Automation_release(self_vtable:
+                                                           intercom::RawComPtr)
  ->
      <u32 as
      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType {
@@ -214,8 +214,8 @@ unsafe extern "C" fn __Foo_Foo_Automation_release(self_vtable:
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Automation_simple_method_Automation(self_vtable:
-                                                                       intercom::RawComPtr)
+unsafe extern "system" fn __Foo_Foo_Automation_simple_method_Automation(self_vtable:
+                                                                            intercom::RawComPtr)
  ->
      <() as
      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType {
@@ -246,11 +246,12 @@ unsafe extern "C" fn __Foo_Foo_Automation_simple_method_Automation(self_vtable:
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Automation_arg_method_Automation(self_vtable:
-                                                                    intercom::RawComPtr,
-                                                                a:
-                                                                    <u16 as
-                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType)
+unsafe extern "system" fn __Foo_Foo_Automation_arg_method_Automation(self_vtable:
+                                                                         intercom::RawComPtr,
+                                                                     a:
+                                                                         <u16
+                                                                         as
+                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType)
  ->
      <() as
      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType {
@@ -283,8 +284,8 @@ unsafe extern "C" fn __Foo_Foo_Automation_arg_method_Automation(self_vtable:
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Automation_simple_result_method_Automation(self_vtable:
-                                                                              intercom::RawComPtr)
+unsafe extern "system" fn __Foo_Foo_Automation_simple_result_method_Automation(self_vtable:
+                                                                                   intercom::RawComPtr)
  ->
      <u16 as
      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType {
@@ -315,12 +316,12 @@ unsafe extern "C" fn __Foo_Foo_Automation_simple_result_method_Automation(self_v
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Automation_com_result_method_Automation(self_vtable:
-                                                                           intercom::RawComPtr,
-                                                                       __out:
-                                                                           *mut <u16
-                                                                                as
-                                                                                intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
+unsafe extern "system" fn __Foo_Foo_Automation_com_result_method_Automation(self_vtable:
+                                                                                intercom::RawComPtr,
+                                                                            __out:
+                                                                                *mut <u16
+                                                                                     as
+                                                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
  ->
      <intercom::raw::HRESULT as
      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType {
@@ -363,12 +364,12 @@ unsafe extern "C" fn __Foo_Foo_Automation_com_result_method_Automation(self_vtab
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Automation_rust_result_method_Automation(self_vtable:
-                                                                            intercom::RawComPtr,
-                                                                        __out:
-                                                                            *mut <u16
-                                                                                 as
-                                                                                 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
+unsafe extern "system" fn __Foo_Foo_Automation_rust_result_method_Automation(self_vtable:
+                                                                                 intercom::RawComPtr,
+                                                                             __out:
+                                                                                 *mut <u16
+                                                                                      as
+                                                                                      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
  ->
      <intercom::raw::HRESULT as
      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType {
@@ -411,20 +412,20 @@ unsafe extern "C" fn __Foo_Foo_Automation_rust_result_method_Automation(self_vta
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Automation_tuple_result_method_Automation(self_vtable:
-                                                                             intercom::RawComPtr,
-                                                                         __out1:
-                                                                             *mut <u8
-                                                                                  as
-                                                                                  intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
-                                                                         __out2:
-                                                                             *mut <u16
-                                                                                  as
-                                                                                  intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
-                                                                         __out3:
-                                                                             *mut <u32
-                                                                                  as
-                                                                                  intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
+unsafe extern "system" fn __Foo_Foo_Automation_tuple_result_method_Automation(self_vtable:
+                                                                                  intercom::RawComPtr,
+                                                                              __out1:
+                                                                                  *mut <u8
+                                                                                       as
+                                                                                       intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+                                                                              __out2:
+                                                                                  *mut <u16
+                                                                                       as
+                                                                                       intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+                                                                              __out3:
+                                                                                  *mut <u32
+                                                                                       as
+                                                                                       intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
  ->
      <intercom::raw::HRESULT as
      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType {
@@ -473,12 +474,12 @@ unsafe extern "C" fn __Foo_Foo_Automation_tuple_result_method_Automation(self_vt
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Automation_string_method_Automation(self_vtable:
-                                                                       intercom::RawComPtr,
-                                                                   input:
-                                                                       <String
-                                                                       as
-                                                                       intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType)
+unsafe extern "system" fn __Foo_Foo_Automation_string_method_Automation(self_vtable:
+                                                                            intercom::RawComPtr,
+                                                                        input:
+                                                                            <String
+                                                                            as
+                                                                            intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType)
  ->
      <String as
      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType {
@@ -511,16 +512,16 @@ unsafe extern "C" fn __Foo_Foo_Automation_string_method_Automation(self_vtable:
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Automation_string_result_method_Automation(self_vtable:
-                                                                              intercom::RawComPtr,
-                                                                          input:
-                                                                              <String
-                                                                              as
-                                                                              intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
-                                                                          __out:
-                                                                              *mut <String
+unsafe extern "system" fn __Foo_Foo_Automation_string_result_method_Automation(self_vtable:
+                                                                                   intercom::RawComPtr,
+                                                                               input:
+                                                                                   <String
                                                                                    as
-                                                                                   intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
+                                                                                   intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
+                                                                               __out:
+                                                                                   *mut <String
+                                                                                        as
+                                                                                        intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
  ->
      <intercom::raw::HRESULT as
      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType {
@@ -565,20 +566,20 @@ unsafe extern "C" fn __Foo_Foo_Automation_string_result_method_Automation(self_v
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Automation_complete_method_Automation(self_vtable:
-                                                                         intercom::RawComPtr,
-                                                                     a:
-                                                                         <u16
-                                                                         as
-                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
-                                                                     b:
-                                                                         <i16
-                                                                         as
-                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
-                                                                     __out:
-                                                                         *mut <bool
+unsafe extern "system" fn __Foo_Foo_Automation_complete_method_Automation(self_vtable:
+                                                                              intercom::RawComPtr,
+                                                                          a:
+                                                                              <u16
                                                                               as
-                                                                              intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
+                                                                              intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
+                                                                          b:
+                                                                              <i16
+                                                                              as
+                                                                              intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
+                                                                          __out:
+                                                                              *mut <bool
+                                                                                   as
+                                                                                   intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
  ->
      <intercom::raw::HRESULT as
      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType {
@@ -625,15 +626,16 @@ unsafe extern "C" fn __Foo_Foo_Automation_complete_method_Automation(self_vtable
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Automation_bool_method_Automation(self_vtable:
-                                                                     intercom::RawComPtr,
-                                                                 input:
-                                                                     <bool as
-                                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
-                                                                 __out:
-                                                                     *mut <bool
+unsafe extern "system" fn __Foo_Foo_Automation_bool_method_Automation(self_vtable:
+                                                                          intercom::RawComPtr,
+                                                                      input:
+                                                                          <bool
                                                                           as
-                                                                          intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
+                                                                          intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
+                                                                      __out:
+                                                                          *mut <bool
+                                                                               as
+                                                                               intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
  ->
      <intercom::raw::HRESULT as
      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType {
@@ -678,16 +680,16 @@ unsafe extern "C" fn __Foo_Foo_Automation_bool_method_Automation(self_vtable:
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Automation_variant_method_Automation(self_vtable:
-                                                                        intercom::RawComPtr,
-                                                                    input:
-                                                                        <Variant
-                                                                        as
-                                                                        intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
-                                                                    __out:
-                                                                        *mut <Variant
+unsafe extern "system" fn __Foo_Foo_Automation_variant_method_Automation(self_vtable:
+                                                                             intercom::RawComPtr,
+                                                                         input:
+                                                                             <Variant
                                                                              as
-                                                                             intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
+                                                                             intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
+                                                                         __out:
+                                                                             *mut <Variant
+                                                                                  as
+                                                                                  intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
  ->
      <intercom::raw::HRESULT as
      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType {
@@ -762,15 +764,16 @@ const __Foo_Foo_AutomationVtbl_INSTANCE: __Foo_AutomationVtbl =
                              __Foo_Foo_Automation_variant_method_Automation,};
 #[allow(non_snake_case)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Raw_query_interface(self_vtable:
-                                                       intercom::RawComPtr,
-                                                   riid:
-                                                       <intercom::REFIID as
-                                                       intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
-                                                   out:
-                                                       *mut <intercom::RawComPtr
+unsafe extern "system" fn __Foo_Foo_Raw_query_interface(self_vtable:
+                                                            intercom::RawComPtr,
+                                                        riid:
+                                                            <intercom::REFIID
                                                             as
-                                                            intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
+                                                            intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
+                                                        out:
+                                                            *mut <intercom::RawComPtr
+                                                                 as
+                                                                 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
  ->
      <intercom::raw::HRESULT as
      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType {
@@ -781,7 +784,8 @@ unsafe extern "C" fn __Foo_Foo_Raw_query_interface(self_vtable:
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Raw_add_ref(self_vtable: intercom::RawComPtr)
+unsafe extern "system" fn __Foo_Foo_Raw_add_ref(self_vtable:
+                                                    intercom::RawComPtr)
  ->
      <u32 as
      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType {
@@ -792,7 +796,8 @@ unsafe extern "C" fn __Foo_Foo_Raw_add_ref(self_vtable: intercom::RawComPtr)
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Raw_release(self_vtable: intercom::RawComPtr)
+unsafe extern "system" fn __Foo_Foo_Raw_release(self_vtable:
+                                                    intercom::RawComPtr)
  ->
      <u32 as
      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType {
@@ -803,8 +808,8 @@ unsafe extern "C" fn __Foo_Foo_Raw_release(self_vtable: intercom::RawComPtr)
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Raw_simple_method_Raw(self_vtable:
-                                                         intercom::RawComPtr)
+unsafe extern "system" fn __Foo_Foo_Raw_simple_method_Raw(self_vtable:
+                                                              intercom::RawComPtr)
  ->
      <() as
      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType {
@@ -834,11 +839,11 @@ unsafe extern "C" fn __Foo_Foo_Raw_simple_method_Raw(self_vtable:
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Raw_arg_method_Raw(self_vtable:
-                                                      intercom::RawComPtr,
-                                                  a:
-                                                      <u16 as
-                                                      intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType)
+unsafe extern "system" fn __Foo_Foo_Raw_arg_method_Raw(self_vtable:
+                                                           intercom::RawComPtr,
+                                                       a:
+                                                           <u16 as
+                                                           intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType)
  ->
      <() as
      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType {
@@ -870,8 +875,8 @@ unsafe extern "C" fn __Foo_Foo_Raw_arg_method_Raw(self_vtable:
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Raw_simple_result_method_Raw(self_vtable:
-                                                                intercom::RawComPtr)
+unsafe extern "system" fn __Foo_Foo_Raw_simple_result_method_Raw(self_vtable:
+                                                                     intercom::RawComPtr)
  ->
      <u16 as
      intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType {
@@ -901,11 +906,11 @@ unsafe extern "C" fn __Foo_Foo_Raw_simple_result_method_Raw(self_vtable:
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Raw_com_result_method_Raw(self_vtable:
-                                                             intercom::RawComPtr,
-                                                         __out:
-                                                             *mut <u16 as
-                                                                  intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
+unsafe extern "system" fn __Foo_Foo_Raw_com_result_method_Raw(self_vtable:
+                                                                  intercom::RawComPtr,
+                                                              __out:
+                                                                  *mut <u16 as
+                                                                       intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
  ->
      <intercom::raw::HRESULT as
      intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType {
@@ -947,11 +952,12 @@ unsafe extern "C" fn __Foo_Foo_Raw_com_result_method_Raw(self_vtable:
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Raw_rust_result_method_Raw(self_vtable:
-                                                              intercom::RawComPtr,
-                                                          __out:
-                                                              *mut <u16 as
-                                                                   intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
+unsafe extern "system" fn __Foo_Foo_Raw_rust_result_method_Raw(self_vtable:
+                                                                   intercom::RawComPtr,
+                                                               __out:
+                                                                   *mut <u16
+                                                                        as
+                                                                        intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
  ->
      <intercom::raw::HRESULT as
      intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType {
@@ -993,17 +999,20 @@ unsafe extern "C" fn __Foo_Foo_Raw_rust_result_method_Raw(self_vtable:
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Raw_tuple_result_method_Raw(self_vtable:
-                                                               intercom::RawComPtr,
-                                                           __out1:
-                                                               *mut <u8 as
-                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
-                                                           __out2:
-                                                               *mut <u16 as
-                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
-                                                           __out3:
-                                                               *mut <u32 as
-                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
+unsafe extern "system" fn __Foo_Foo_Raw_tuple_result_method_Raw(self_vtable:
+                                                                    intercom::RawComPtr,
+                                                                __out1:
+                                                                    *mut <u8
+                                                                         as
+                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
+                                                                __out2:
+                                                                    *mut <u16
+                                                                         as
+                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
+                                                                __out3:
+                                                                    *mut <u32
+                                                                         as
+                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
  ->
      <intercom::raw::HRESULT as
      intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType {
@@ -1051,11 +1060,11 @@ unsafe extern "C" fn __Foo_Foo_Raw_tuple_result_method_Raw(self_vtable:
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Raw_string_method_Raw(self_vtable:
-                                                         intercom::RawComPtr,
-                                                     input:
-                                                         <String as
-                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType)
+unsafe extern "system" fn __Foo_Foo_Raw_string_method_Raw(self_vtable:
+                                                              intercom::RawComPtr,
+                                                          input:
+                                                              <String as
+                                                              intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType)
  ->
      <String as
      intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType {
@@ -1087,15 +1096,16 @@ unsafe extern "C" fn __Foo_Foo_Raw_string_method_Raw(self_vtable:
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Raw_string_result_method_Raw(self_vtable:
-                                                                intercom::RawComPtr,
-                                                            input:
-                                                                <String as
-                                                                intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
-                                                            __out:
-                                                                *mut <String
+unsafe extern "system" fn __Foo_Foo_Raw_string_result_method_Raw(self_vtable:
+                                                                     intercom::RawComPtr,
+                                                                 input:
+                                                                     <String
                                                                      as
-                                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
+                                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
+                                                                 __out:
+                                                                     *mut <String
+                                                                          as
+                                                                          intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
  ->
      <intercom::raw::HRESULT as
      intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType {
@@ -1139,17 +1149,17 @@ unsafe extern "C" fn __Foo_Foo_Raw_string_result_method_Raw(self_vtable:
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Raw_complete_method_Raw(self_vtable:
-                                                           intercom::RawComPtr,
-                                                       a:
-                                                           <u16 as
-                                                           intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
-                                                       b:
-                                                           <i16 as
-                                                           intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
-                                                       __out:
-                                                           *mut <bool as
-                                                                intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
+unsafe extern "system" fn __Foo_Foo_Raw_complete_method_Raw(self_vtable:
+                                                                intercom::RawComPtr,
+                                                            a:
+                                                                <u16 as
+                                                                intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
+                                                            b:
+                                                                <i16 as
+                                                                intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
+                                                            __out:
+                                                                *mut <bool as
+                                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
  ->
      <intercom::raw::HRESULT as
      intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType {
@@ -1195,14 +1205,14 @@ unsafe extern "C" fn __Foo_Foo_Raw_complete_method_Raw(self_vtable:
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Raw_bool_method_Raw(self_vtable:
-                                                       intercom::RawComPtr,
-                                                   input:
-                                                       <bool as
-                                                       intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
-                                                   __out:
-                                                       *mut <bool as
-                                                            intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
+unsafe extern "system" fn __Foo_Foo_Raw_bool_method_Raw(self_vtable:
+                                                            intercom::RawComPtr,
+                                                        input:
+                                                            <bool as
+                                                            intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
+                                                        __out:
+                                                            *mut <bool as
+                                                                 intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
  ->
      <intercom::raw::HRESULT as
      intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType {
@@ -1246,14 +1256,15 @@ unsafe extern "C" fn __Foo_Foo_Raw_bool_method_Raw(self_vtable:
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Raw_variant_method_Raw(self_vtable:
-                                                          intercom::RawComPtr,
-                                                      input:
-                                                          <Variant as
-                                                          intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
-                                                      __out:
-                                                          *mut <Variant as
-                                                               intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
+unsafe extern "system" fn __Foo_Foo_Raw_variant_method_Raw(self_vtable:
+                                                               intercom::RawComPtr,
+                                                           input:
+                                                               <Variant as
+                                                               intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
+                                                           __out:
+                                                               *mut <Variant
+                                                                    as
+                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
  ->
      <intercom::raw::HRESULT as
      intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType {

--- a/intercom-attributes/tests/data/com_interface.target.rs
+++ b/intercom-attributes/tests/data/com_interface.target.rs
@@ -48,93 +48,98 @@ pub const IID_Foo_Automation: intercom::IID =
 #[doc(hidden)]
 pub struct __Foo_AutomationVtbl {
     pub __base: intercom::IUnknownVtbl,
-    pub simple_method_Automation: unsafe extern "C" fn(self_vtable:
-                                                           intercom::RawComPtr)
+    pub simple_method_Automation: unsafe extern "system" fn(self_vtable:
+                                                                intercom::RawComPtr)
                                       ->
                                           <() as
                                           intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
-    pub arg_method_Automation: unsafe extern "C" fn(self_vtable:
-                                                        intercom::RawComPtr,
-                                                    a:
-                                                        <u16 as
-                                                        intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType)
-                                   ->
-                                       <() as
-                                       intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
-    pub simple_result_method_Automation: unsafe extern "C" fn(self_vtable:
-                                                                  intercom::RawComPtr)
-                                             ->
-                                                 <u16 as
-                                                 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
-    pub com_result_method_Automation: unsafe extern "C" fn(self_vtable:
-                                                               intercom::RawComPtr,
-                                                           __out:
-                                                               *mut <u16 as
-                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
-                                          ->
-                                              <intercom::raw::HRESULT as
-                                              intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
-    pub rust_result_method_Automation: unsafe extern "C" fn(self_vtable:
-                                                                intercom::RawComPtr,
-                                                            __out:
-                                                                *mut <u16 as
-                                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
-                                           ->
-                                               <intercom::raw::HRESULT as
-                                               intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
-    pub complete_method_Automation: unsafe extern "C" fn(self_vtable:
+    pub arg_method_Automation: unsafe extern "system" fn(self_vtable:
                                                              intercom::RawComPtr,
                                                          a:
                                                              <u16 as
-                                                             intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
-                                                         b:
-                                                             <i16 as
-                                                             intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
-                                                         __out:
-                                                             *mut <bool as
-                                                                  intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
+                                                             intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType)
+                                   ->
+                                       <() as
+                                       intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+    pub simple_result_method_Automation: unsafe extern "system" fn(self_vtable:
+                                                                       intercom::RawComPtr)
+                                             ->
+                                                 <u16 as
+                                                 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+    pub com_result_method_Automation: unsafe extern "system" fn(self_vtable:
+                                                                    intercom::RawComPtr,
+                                                                __out:
+                                                                    *mut <u16
+                                                                         as
+                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
+                                          ->
+                                              <intercom::raw::HRESULT as
+                                              intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+    pub rust_result_method_Automation: unsafe extern "system" fn(self_vtable:
+                                                                     intercom::RawComPtr,
+                                                                 __out:
+                                                                     *mut <u16
+                                                                          as
+                                                                          intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
+                                           ->
+                                               <intercom::raw::HRESULT as
+                                               intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+    pub complete_method_Automation: unsafe extern "system" fn(self_vtable:
+                                                                  intercom::RawComPtr,
+                                                              a:
+                                                                  <u16 as
+                                                                  intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
+                                                              b:
+                                                                  <i16 as
+                                                                  intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
+                                                              __out:
+                                                                  *mut <bool
+                                                                       as
+                                                                       intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
                                         ->
                                             <intercom::raw::HRESULT as
                                             intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
-    pub string_method_Automation: unsafe extern "C" fn(self_vtable:
-                                                           intercom::RawComPtr,
-                                                       msg:
-                                                           <String as
-                                                           intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType)
+    pub string_method_Automation: unsafe extern "system" fn(self_vtable:
+                                                                intercom::RawComPtr,
+                                                            msg:
+                                                                <String as
+                                                                intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType)
                                       ->
                                           <String as
                                           intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
-    pub comitf_method_Automation: unsafe extern "C" fn(self_vtable:
-                                                           intercom::RawComPtr,
-                                                       itf:
-                                                           <ComItf<Foo> as
-                                                           intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
-                                                       __out:
-                                                           *mut <ComItf<IUnknown>
+    pub comitf_method_Automation: unsafe extern "system" fn(self_vtable:
+                                                                intercom::RawComPtr,
+                                                            itf:
+                                                                <ComItf<Foo>
                                                                 as
-                                                                intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
+                                                                intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
+                                                            __out:
+                                                                *mut <ComItf<IUnknown>
+                                                                     as
+                                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
                                       ->
                                           <intercom::raw::HRESULT as
                                           intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
-    pub bool_method_Automation: unsafe extern "C" fn(self_vtable:
-                                                         intercom::RawComPtr,
-                                                     input:
-                                                         <bool as
-                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
-                                                     __out:
-                                                         *mut <bool as
-                                                              intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
+    pub bool_method_Automation: unsafe extern "system" fn(self_vtable:
+                                                              intercom::RawComPtr,
+                                                          input:
+                                                              <bool as
+                                                              intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
+                                                          __out:
+                                                              *mut <bool as
+                                                                   intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
                                     ->
                                         <intercom::raw::HRESULT as
                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
-    pub variant_method_Automation: unsafe extern "C" fn(self_vtable:
-                                                            intercom::RawComPtr,
-                                                        input:
-                                                            <Variant as
-                                                            intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
-                                                        __out:
-                                                            *mut <Variant as
-                                                                 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
+    pub variant_method_Automation: unsafe extern "system" fn(self_vtable:
+                                                                 intercom::RawComPtr,
+                                                             input:
+                                                                 <Variant as
+                                                                 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
+                                                             __out:
+                                                                 *mut <Variant
+                                                                      as
+                                                                      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
                                        ->
                                            <intercom::raw::HRESULT as
                                            intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
@@ -151,91 +156,93 @@ pub const IID_Foo_Raw: intercom::IID =
 #[doc(hidden)]
 pub struct __Foo_RawVtbl {
     pub __base: intercom::IUnknownVtbl,
-    pub simple_method_Raw: unsafe extern "C" fn(self_vtable:
-                                                    intercom::RawComPtr)
+    pub simple_method_Raw: unsafe extern "system" fn(self_vtable:
+                                                         intercom::RawComPtr)
                                ->
                                    <() as
                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
-    pub arg_method_Raw: unsafe extern "C" fn(self_vtable: intercom::RawComPtr,
-                                             a:
-                                                 <u16 as
-                                                 intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType)
-                            ->
-                                <() as
-                                intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
-    pub simple_result_method_Raw: unsafe extern "C" fn(self_vtable:
-                                                           intercom::RawComPtr)
-                                      ->
-                                          <u16 as
-                                          intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
-    pub com_result_method_Raw: unsafe extern "C" fn(self_vtable:
-                                                        intercom::RawComPtr,
-                                                    __out:
-                                                        *mut <u16 as
-                                                             intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
-                                   ->
-                                       <intercom::raw::HRESULT as
-                                       intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
-    pub rust_result_method_Raw: unsafe extern "C" fn(self_vtable:
-                                                         intercom::RawComPtr,
-                                                     __out:
-                                                         *mut <u16 as
-                                                              intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
-                                    ->
-                                        <intercom::raw::HRESULT as
-                                        intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
-    pub complete_method_Raw: unsafe extern "C" fn(self_vtable:
+    pub arg_method_Raw: unsafe extern "system" fn(self_vtable:
                                                       intercom::RawComPtr,
                                                   a:
                                                       <u16 as
-                                                      intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
-                                                  b:
-                                                      <i16 as
-                                                      intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
-                                                  __out:
-                                                      *mut <bool as
-                                                           intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
+                                                      intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType)
+                            ->
+                                <() as
+                                intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+    pub simple_result_method_Raw: unsafe extern "system" fn(self_vtable:
+                                                                intercom::RawComPtr)
+                                      ->
+                                          <u16 as
+                                          intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
+    pub com_result_method_Raw: unsafe extern "system" fn(self_vtable:
+                                                             intercom::RawComPtr,
+                                                         __out:
+                                                             *mut <u16 as
+                                                                  intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
+                                   ->
+                                       <intercom::raw::HRESULT as
+                                       intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
+    pub rust_result_method_Raw: unsafe extern "system" fn(self_vtable:
+                                                              intercom::RawComPtr,
+                                                          __out:
+                                                              *mut <u16 as
+                                                                   intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
+                                    ->
+                                        <intercom::raw::HRESULT as
+                                        intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
+    pub complete_method_Raw: unsafe extern "system" fn(self_vtable:
+                                                           intercom::RawComPtr,
+                                                       a:
+                                                           <u16 as
+                                                           intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
+                                                       b:
+                                                           <i16 as
+                                                           intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
+                                                       __out:
+                                                           *mut <bool as
+                                                                intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
                                  ->
                                      <intercom::raw::HRESULT as
                                      intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
-    pub string_method_Raw: unsafe extern "C" fn(self_vtable:
-                                                    intercom::RawComPtr,
-                                                msg:
-                                                    <String as
-                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType)
+    pub string_method_Raw: unsafe extern "system" fn(self_vtable:
+                                                         intercom::RawComPtr,
+                                                     msg:
+                                                         <String as
+                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType)
                                ->
                                    <String as
                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
-    pub comitf_method_Raw: unsafe extern "C" fn(self_vtable:
-                                                    intercom::RawComPtr,
-                                                itf:
-                                                    <ComItf<Foo> as
-                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
-                                                __out:
-                                                    *mut <ComItf<IUnknown> as
-                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
+    pub comitf_method_Raw: unsafe extern "system" fn(self_vtable:
+                                                         intercom::RawComPtr,
+                                                     itf:
+                                                         <ComItf<Foo> as
+                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
+                                                     __out:
+                                                         *mut <ComItf<IUnknown>
+                                                              as
+                                                              intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
                                ->
                                    <intercom::raw::HRESULT as
                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
-    pub bool_method_Raw: unsafe extern "C" fn(self_vtable:
-                                                  intercom::RawComPtr,
-                                              input:
-                                                  <bool as
-                                                  intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
-                                              __out:
-                                                  *mut <bool as
-                                                       intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
+    pub bool_method_Raw: unsafe extern "system" fn(self_vtable:
+                                                       intercom::RawComPtr,
+                                                   input:
+                                                       <bool as
+                                                       intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
+                                                   __out:
+                                                       *mut <bool as
+                                                            intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
                              ->
                                  <intercom::raw::HRESULT as
                                  intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
-    pub variant_method_Raw: unsafe extern "C" fn(self_vtable:
-                                                     intercom::RawComPtr,
-                                                 input:
-                                                     <Variant as
-                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
-                                                 __out:
-                                                     *mut <Variant as
-                                                          intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
+    pub variant_method_Raw: unsafe extern "system" fn(self_vtable:
+                                                          intercom::RawComPtr,
+                                                      input:
+                                                          <Variant as
+                                                          intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
+                                                      __out:
+                                                          *mut <Variant as
+                                                               intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
                                 ->
                                     <intercom::raw::HRESULT as
                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,

--- a/intercom-attributes/tests/data/com_library.target.rs
+++ b/intercom-attributes/tests/data/com_library.target.rs
@@ -32,9 +32,10 @@ pub(crate) fn get_intercom_coclass_info_for_SimpleType()
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-pub unsafe extern "C" fn DllGetClassObject(rclsid: intercom::REFCLSID,
-                                           riid: intercom::REFIID,
-                                           pout: *mut intercom::RawComPtr)
+pub unsafe extern "system" fn DllGetClassObject(rclsid: intercom::REFCLSID,
+                                                riid: intercom::REFIID,
+                                                pout:
+                                                    *mut intercom::RawComPtr)
  -> intercom::raw::HRESULT {
     let mut com_struct =
         intercom::ComStruct::new(intercom::ClassFactory::new(rclsid,
@@ -87,9 +88,9 @@ pub(crate) fn get_intercom_typelib() -> intercom::typelib::TypeLib {
                                       "1.0".into(), types)
 }
 #[no_mangle]
-pub unsafe extern "C" fn IntercomTypeLib(type_system:
-                                             intercom::type_system::TypeSystemName,
-                                         out: *mut intercom::RawComPtr)
+pub unsafe extern "system" fn IntercomTypeLib(type_system:
+                                                  intercom::type_system::TypeSystemName,
+                                              out: *mut intercom::RawComPtr)
  -> intercom::raw::HRESULT {
     let mut tlib = intercom::ComStruct::new(get_intercom_typelib());
     let rc =
@@ -108,9 +109,9 @@ pub unsafe extern "C" fn IntercomTypeLib(type_system:
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-pub unsafe extern "C" fn IntercomListClassObjects(pcount: *mut usize,
-                                                  pclsids:
-                                                      *mut *const intercom::CLSID)
+pub unsafe extern "system" fn IntercomListClassObjects(pcount: *mut usize,
+                                                       pclsids:
+                                                           *mut *const intercom::CLSID)
  -> intercom::raw::HRESULT {
     if pcount.is_null() { return intercom::raw::E_POINTER; }
     if pclsids.is_null() { return intercom::raw::E_POINTER; }

--- a/intercom-attributes/tests/data/private_item.target.rs
+++ b/intercom-attributes/tests/data/private_item.target.rs
@@ -22,8 +22,8 @@ const IID_IFoo_Automation: intercom::IID =
 #[doc(hidden)]
 struct __IFoo_AutomationVtbl {
     pub __base: intercom::IUnknownVtbl,
-    pub trait_method_Automation: unsafe extern "C" fn(self_vtable:
-                                                          intercom::RawComPtr)
+    pub trait_method_Automation: unsafe extern "system" fn(self_vtable:
+                                                               intercom::RawComPtr)
                                      ->
                                          <() as
                                          intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
@@ -40,8 +40,8 @@ const IID_IFoo_Raw: intercom::IID =
 #[doc(hidden)]
 struct __IFoo_RawVtbl {
     pub __base: intercom::IUnknownVtbl,
-    pub trait_method_Raw: unsafe extern "C" fn(self_vtable:
-                                                   intercom::RawComPtr)
+    pub trait_method_Raw: unsafe extern "system" fn(self_vtable:
+                                                        intercom::RawComPtr)
                               ->
                                   <() as
                                   intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
@@ -359,16 +359,16 @@ impl Foo {
 }
 #[allow(non_snake_case)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Automation_query_interface(self_vtable:
-                                                              intercom::RawComPtr,
-                                                          riid:
-                                                              <intercom::REFIID
-                                                              as
-                                                              intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
-                                                          out:
-                                                              *mut <intercom::RawComPtr
+unsafe extern "system" fn __Foo_Foo_Automation_query_interface(self_vtable:
+                                                                   intercom::RawComPtr,
+                                                               riid:
+                                                                   <intercom::REFIID
                                                                    as
-                                                                   intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
+                                                                   intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
+                                                               out:
+                                                                   *mut <intercom::RawComPtr
+                                                                        as
+                                                                        intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
  ->
      <intercom::raw::HRESULT as
      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType {
@@ -379,8 +379,8 @@ unsafe extern "C" fn __Foo_Foo_Automation_query_interface(self_vtable:
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Automation_add_ref(self_vtable:
-                                                      intercom::RawComPtr)
+unsafe extern "system" fn __Foo_Foo_Automation_add_ref(self_vtable:
+                                                           intercom::RawComPtr)
  ->
      <u32 as
      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType {
@@ -391,8 +391,8 @@ unsafe extern "C" fn __Foo_Foo_Automation_add_ref(self_vtable:
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Automation_release(self_vtable:
-                                                      intercom::RawComPtr)
+unsafe extern "system" fn __Foo_Foo_Automation_release(self_vtable:
+                                                           intercom::RawComPtr)
  ->
      <u32 as
      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType {
@@ -403,8 +403,8 @@ unsafe extern "C" fn __Foo_Foo_Automation_release(self_vtable:
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Automation_struct_method_Automation(self_vtable:
-                                                                       intercom::RawComPtr)
+unsafe extern "system" fn __Foo_Foo_Automation_struct_method_Automation(self_vtable:
+                                                                            intercom::RawComPtr)
  ->
      <() as
      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType {
@@ -445,15 +445,16 @@ const __Foo_Foo_AutomationVtbl_INSTANCE: __Foo_AutomationVtbl =
                              __Foo_Foo_Automation_struct_method_Automation,};
 #[allow(non_snake_case)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Raw_query_interface(self_vtable:
-                                                       intercom::RawComPtr,
-                                                   riid:
-                                                       <intercom::REFIID as
-                                                       intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
-                                                   out:
-                                                       *mut <intercom::RawComPtr
+unsafe extern "system" fn __Foo_Foo_Raw_query_interface(self_vtable:
+                                                            intercom::RawComPtr,
+                                                        riid:
+                                                            <intercom::REFIID
                                                             as
-                                                            intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
+                                                            intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
+                                                        out:
+                                                            *mut <intercom::RawComPtr
+                                                                 as
+                                                                 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
  ->
      <intercom::raw::HRESULT as
      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType {
@@ -464,7 +465,8 @@ unsafe extern "C" fn __Foo_Foo_Raw_query_interface(self_vtable:
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Raw_add_ref(self_vtable: intercom::RawComPtr)
+unsafe extern "system" fn __Foo_Foo_Raw_add_ref(self_vtable:
+                                                    intercom::RawComPtr)
  ->
      <u32 as
      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType {
@@ -475,7 +477,8 @@ unsafe extern "C" fn __Foo_Foo_Raw_add_ref(self_vtable: intercom::RawComPtr)
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Raw_release(self_vtable: intercom::RawComPtr)
+unsafe extern "system" fn __Foo_Foo_Raw_release(self_vtable:
+                                                    intercom::RawComPtr)
  ->
      <u32 as
      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType {
@@ -486,8 +489,8 @@ unsafe extern "C" fn __Foo_Foo_Raw_release(self_vtable: intercom::RawComPtr)
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_Foo_Raw_struct_method_Raw(self_vtable:
-                                                         intercom::RawComPtr)
+unsafe extern "system" fn __Foo_Foo_Raw_struct_method_Raw(self_vtable:
+                                                              intercom::RawComPtr)
  ->
      <() as
      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType {
@@ -537,8 +540,8 @@ pub const IID_Foo_Automation: intercom::IID =
 #[doc(hidden)]
 pub struct __Foo_AutomationVtbl {
     pub __base: intercom::IUnknownVtbl,
-    pub struct_method_Automation: unsafe extern "C" fn(self_vtable:
-                                                           intercom::RawComPtr)
+    pub struct_method_Automation: unsafe extern "system" fn(self_vtable:
+                                                                intercom::RawComPtr)
                                       ->
                                           <() as
                                           intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
@@ -555,8 +558,8 @@ pub const IID_Foo_Raw: intercom::IID =
 #[doc(hidden)]
 pub struct __Foo_RawVtbl {
     pub __base: intercom::IUnknownVtbl,
-    pub struct_method_Raw: unsafe extern "C" fn(self_vtable:
-                                                    intercom::RawComPtr)
+    pub struct_method_Raw: unsafe extern "system" fn(self_vtable:
+                                                         intercom::RawComPtr)
                                ->
                                    <() as
                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
@@ -677,16 +680,16 @@ impl IFoo for Foo {
 }
 #[allow(non_snake_case)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_IFoo_Automation_query_interface(self_vtable:
-                                                               intercom::RawComPtr,
-                                                           riid:
-                                                               <intercom::REFIID
-                                                               as
-                                                               intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
-                                                           out:
-                                                               *mut <intercom::RawComPtr
+unsafe extern "system" fn __Foo_IFoo_Automation_query_interface(self_vtable:
+                                                                    intercom::RawComPtr,
+                                                                riid:
+                                                                    <intercom::REFIID
                                                                     as
-                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
+                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
+                                                                out:
+                                                                    *mut <intercom::RawComPtr
+                                                                         as
+                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
  ->
      <intercom::raw::HRESULT as
      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType {
@@ -697,8 +700,8 @@ unsafe extern "C" fn __Foo_IFoo_Automation_query_interface(self_vtable:
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_IFoo_Automation_add_ref(self_vtable:
-                                                       intercom::RawComPtr)
+unsafe extern "system" fn __Foo_IFoo_Automation_add_ref(self_vtable:
+                                                            intercom::RawComPtr)
  ->
      <u32 as
      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType {
@@ -709,8 +712,8 @@ unsafe extern "C" fn __Foo_IFoo_Automation_add_ref(self_vtable:
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_IFoo_Automation_release(self_vtable:
-                                                       intercom::RawComPtr)
+unsafe extern "system" fn __Foo_IFoo_Automation_release(self_vtable:
+                                                            intercom::RawComPtr)
  ->
      <u32 as
      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType {
@@ -721,8 +724,8 @@ unsafe extern "C" fn __Foo_IFoo_Automation_release(self_vtable:
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_IFoo_Automation_trait_method_Automation(self_vtable:
-                                                                       intercom::RawComPtr)
+unsafe extern "system" fn __Foo_IFoo_Automation_trait_method_Automation(self_vtable:
+                                                                            intercom::RawComPtr)
  ->
      <() as
      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType {
@@ -763,15 +766,16 @@ const __Foo_IFoo_AutomationVtbl_INSTANCE: __IFoo_AutomationVtbl =
                               __Foo_IFoo_Automation_trait_method_Automation,};
 #[allow(non_snake_case)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_IFoo_Raw_query_interface(self_vtable:
-                                                        intercom::RawComPtr,
-                                                    riid:
-                                                        <intercom::REFIID as
-                                                        intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
-                                                    out:
-                                                        *mut <intercom::RawComPtr
+unsafe extern "system" fn __Foo_IFoo_Raw_query_interface(self_vtable:
+                                                             intercom::RawComPtr,
+                                                         riid:
+                                                             <intercom::REFIID
                                                              as
-                                                             intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
+                                                             intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
+                                                         out:
+                                                             *mut <intercom::RawComPtr
+                                                                  as
+                                                                  intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
  ->
      <intercom::raw::HRESULT as
      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType {
@@ -782,7 +786,8 @@ unsafe extern "C" fn __Foo_IFoo_Raw_query_interface(self_vtable:
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_IFoo_Raw_add_ref(self_vtable: intercom::RawComPtr)
+unsafe extern "system" fn __Foo_IFoo_Raw_add_ref(self_vtable:
+                                                     intercom::RawComPtr)
  ->
      <u32 as
      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType {
@@ -793,7 +798,8 @@ unsafe extern "C" fn __Foo_IFoo_Raw_add_ref(self_vtable: intercom::RawComPtr)
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_IFoo_Raw_release(self_vtable: intercom::RawComPtr)
+unsafe extern "system" fn __Foo_IFoo_Raw_release(self_vtable:
+                                                     intercom::RawComPtr)
  ->
      <u32 as
      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType {
@@ -804,8 +810,8 @@ unsafe extern "C" fn __Foo_IFoo_Raw_release(self_vtable: intercom::RawComPtr)
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "C" fn __Foo_IFoo_Raw_trait_method_Raw(self_vtable:
-                                                         intercom::RawComPtr)
+unsafe extern "system" fn __Foo_IFoo_Raw_trait_method_Raw(self_vtable:
+                                                              intercom::RawComPtr)
  ->
      <() as
      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType {

--- a/intercom-attributes/tests/lib.rs
+++ b/intercom-attributes/tests/lib.rs
@@ -1,5 +1,3 @@
-#![cfg(not(windows))]  // No one likes Rustfmt. :(
-
 extern crate difference;
 extern crate regex;
 extern crate term;
@@ -73,13 +71,6 @@ fn check_expansions() {
         // somewhat of an issue on AppVeyor.
         target_code = target_code.replace( "\r", "" );
         source_code = source_code.replace( "\r", "" );
-
-        // Normalize the calling conventions.
-        // The expected results use "stdcall". "C" is more likely
-        // to appear in the tests on its own.
-        // See https://github.com/Rantanen/intercom/pull/31#issuecomment-353516541
-        target_code = target_code.replace( "stdcall", "C" );
-        source_code = source_code.replace( "stdcall", "C" );
 
         // Use rustfmt to format both pieces of code so that we have a
         // canonical format for them. Without rustfmt we'd need to match the

--- a/intercom-common/src/attributes/common.rs
+++ b/intercom-common/src/attributes/common.rs
@@ -25,10 +25,12 @@ pub fn tokens_to_tokenstream<T: IntoIterator<Item=TokenStream>>(
             .chain( tokens.into_iter().map( Into::into ) ) )
 }
 
-// https://msdn.microsoft.com/en-us/library/984x0h58.aspx
-#[cfg(windows)]
-pub fn get_calling_convetion() -> &'static str { "stdcall" }
-
-#[cfg(not(windows))]
-pub fn get_calling_convetion() -> &'static str { "C" }
+pub fn get_calling_convetion() -> &'static str {
+    // https://msdn.microsoft.com/en-us/library/984x0h58.aspx
+    //
+    // This equals __stdcall on 32-bit Windows, 'C' call everywhere else.
+    // Microsoft only has one 64-bit calling convention so it doesn't
+    // matter there.
+    "system"
+}
 

--- a/intercom/src/classfactory.rs
+++ b/intercom/src/classfactory.rs
@@ -10,20 +10,10 @@ use super::*;
 
 #[allow(non_camel_case_types)]
 #[doc(hidden)]
-#[cfg(windows)]
 pub struct ClassFactoryVtbl {
     pub __base: IUnknownVtbl,
-    pub create_instance: unsafe extern "stdcall" fn( RawComPtr, RawComPtr, REFIID, *mut RawComPtr ) -> raw::HRESULT,
-    pub lock_server: unsafe extern "stdcall" fn( RawComPtr, bool ) -> raw::HRESULT
-}
-
-#[allow(non_camel_case_types)]
-#[doc(hidden)]
-#[cfg(not(windows))]
-pub struct ClassFactoryVtbl {
-    pub __base: IUnknownVtbl,
-    pub create_instance: unsafe extern "C" fn( RawComPtr, RawComPtr, REFIID, *mut RawComPtr ) -> raw::HRESULT,
-    pub lock_server: unsafe extern "C" fn( RawComPtr, bool ) -> raw::HRESULT
+    pub create_instance: unsafe extern "system" fn( RawComPtr, RawComPtr, REFIID, *mut RawComPtr ) -> raw::HRESULT,
+    pub lock_server: unsafe extern "system" fn( RawComPtr, bool ) -> raw::HRESULT
 }
 
 #[doc(hidden)]
@@ -70,71 +60,7 @@ impl< T: Fn( REFCLSID ) -> RawComResult< RawComPtr > > ClassFactory<T> {
     /// # Safety
     ///
     /// The pointers _must_ be valid.
-    #[cfg(windows)]
-    pub unsafe extern "stdcall" fn create_instance(
-        self_vtbl : RawComPtr,
-        _outer : RawComPtr,
-        riid : REFIID,
-        out : *mut RawComPtr,
-    ) -> raw::HRESULT
-    {
-        Self::create_instance_agnostic(self_vtbl, _outer, riid, out)
-    }
-
-    /// # Safety
-    ///
-    /// The pointers _must_ be valid.
-    #[cfg(not(windows))]
-    pub unsafe extern "C" fn create_instance(
-        self_vtbl : RawComPtr,
-        _outer : RawComPtr,
-        riid : REFIID,
-        out : *mut RawComPtr,
-    ) -> raw::HRESULT
-    {
-        Self::create_instance_agnostic(self_vtbl, _outer, riid, out)
-    }
-
-    /// # Safety
-    ///
-    /// The pointers _must_ be valid.
-    #[cfg(windows)]
-    pub unsafe extern "stdcall" fn lock_server(
-        self_vtbl : RawComPtr,
-        lock : bool
-    ) -> raw::HRESULT
-    {
-        Self::lock_server_agnostic(self_vtbl, lock)
-    }
-
-    /// # Safety
-    ///
-    /// The pointers _must_ be valid.
-    #[cfg(not(windows))]
-    pub unsafe extern "C" fn lock_server(
-        self_vtbl : RawComPtr,
-        lock : bool
-    ) -> raw::HRESULT
-    {
-        Self::lock_server_agnostic(self_vtbl, lock)
-    }
-
-    pub fn create_vtable() -> &'static ClassFactoryVtbl {
-        &ClassFactoryVtbl {
-            __base : IUnknownVtbl {
-                query_interface_Automation : ComBox::< Self >::query_interface_ptr,
-                add_ref_Automation : ComBox::< Self >::add_ref_ptr,
-                release_Automation : ComBox::< Self >::release_ptr,
-            },
-            create_instance : Self::create_instance,
-            lock_server : Self::lock_server
-        }
-    }
-
-    /// # Safety
-    ///
-    /// The pointers _must_ be valid.
-    unsafe fn create_instance_agnostic(
+    pub unsafe extern "system" fn create_instance(
         self_vtbl : RawComPtr,
         _outer : RawComPtr,
         riid : REFIID,
@@ -168,7 +94,7 @@ impl< T: Fn( REFCLSID ) -> RawComResult< RawComPtr > > ClassFactory<T> {
     /// # Safety
     ///
     /// The pointers _must_ be valid.
-    unsafe fn lock_server_agnostic(
+    pub unsafe extern "system" fn lock_server(
         self_vtbl : RawComPtr,
         lock : bool
     ) -> raw::HRESULT
@@ -179,6 +105,18 @@ impl< T: Fn( REFCLSID ) -> RawComResult< RawComPtr > > ClassFactory<T> {
             ComBox::<Self>::release_ptr( self_vtbl );
         }
         raw::S_OK
+    }
+
+    pub fn create_vtable() -> &'static ClassFactoryVtbl {
+        &ClassFactoryVtbl {
+            __base : IUnknownVtbl {
+                query_interface_Automation : ComBox::< Self >::query_interface_ptr,
+                add_ref_Automation : ComBox::< Self >::add_ref_ptr,
+                release_Automation : ComBox::< Self >::release_ptr,
+            },
+            create_instance : Self::create_instance,
+            lock_server : Self::lock_server
+        }
     }
 }
 

--- a/intercom/src/combox.rs
+++ b/intercom/src/combox.rs
@@ -302,8 +302,7 @@ impl<T: CoClass> ComBox<T> {
     /// # Safety
     ///
     /// The `self_iunk` _must_ be a valid COM pointer.
-    #[cfg(windows)]
-    pub unsafe extern "stdcall" fn query_interface_ptr(
+    pub unsafe extern "system" fn query_interface_ptr(
         self_iunk : RawComPtr,
         riid : REFIID,
         out : *mut RawComPtr,
@@ -312,41 +311,12 @@ impl<T: CoClass> ComBox<T> {
         ComBox::query_interface( ComBox::<T>::from_ptr( self_iunk ), riid, out )
     }
 
-    /// Pointer variant of the `query_interface` function.
-    ///
-    /// # Safety
-    ///
-    /// The `self_iunk` _must_ be a valid COM pointer.
-    #[cfg(not(windows))]
-    pub unsafe extern "C" fn query_interface_ptr(
-        self_iunk : RawComPtr,
-        riid : REFIID,
-        out : *mut RawComPtr
-    ) -> raw::HRESULT
-    {
-        ComBox::query_interface( ComBox::<T>::from_ptr( self_iunk ), riid, out )
-    }
-
     /// Pointer variant of the `add_ref` function.
     ///
     /// # Safety
     ///
     /// The `self_iunk` _must_ be a valid COM pointer.
-    #[cfg(windows)]
-    pub unsafe extern "stdcall" fn add_ref_ptr(
-        self_iunk : RawComPtr
-    ) -> u32
-    {
-        ComBox::add_ref( ComBox::<T>::from_ptr( self_iunk ) )
-    }
-
-    /// Pointer variant of the `add_ref` function.
-    ///
-    /// # Safety
-    ///
-    /// The `self_iunk` _must_ be a valid COM pointer.
-    #[cfg(not(windows))]
-    pub unsafe extern "C" fn add_ref_ptr(
+    pub unsafe extern "system" fn add_ref_ptr(
         self_iunk : RawComPtr
     ) -> u32
     {
@@ -358,8 +328,7 @@ impl<T: CoClass> ComBox<T> {
     /// # Safety
     ///
     /// The `self_iunk` _must_ be a valid COM pointer.
-    #[cfg(windows)]
-    pub unsafe extern "stdcall" fn release_ptr(
+    pub unsafe extern "system" fn release_ptr(
         self_iunk : RawComPtr
     ) -> u32
     {
@@ -371,37 +340,7 @@ impl<T: CoClass> ComBox<T> {
     /// # Safety
     ///
     /// The `self_iunk` _must_ be a valid COM pointer.
-    #[cfg(not(windows))]
-    pub unsafe extern "C" fn release_ptr(
-        self_iunk : RawComPtr
-    ) -> u32
-    {
-        ComBox::release( self_iunk as *mut ComBox< T > )
-    }
-
-    /// Pointer variant of the `release` function.
-    ///
-    /// # Safety
-    ///
-    /// The `self_iunk` _must_ be a valid COM pointer.
-    #[cfg(windows)]
-    pub unsafe extern "stdcall" fn interface_supports_error_info_ptr(
-        self_iunk : RawComPtr,
-        riid : REFIID,
-    ) -> raw::HRESULT
-    {
-        ComBox::interface_supports_error_info(
-                ComBox::<T>::from_ptr( self_iunk ),
-                riid )
-    }
-
-    /// Pointer variant of the `release` function.
-    ///
-    /// # Safety
-    ///
-    /// The `self_iunk` _must_ be a valid COM pointer.
-    #[cfg(not(windows))]
-    pub unsafe extern "C" fn interface_supports_error_info_ptr(
+    pub unsafe extern "system" fn interface_supports_error_info_ptr(
         self_iunk : RawComPtr,
         riid : REFIID,
     ) -> raw::HRESULT


### PR DESCRIPTION
`extern "system"` equals:
- `extern "stdcall"` on 32-bit Windows.
- `extern "C"` everywhere else.

Given 64-bit Windows has only one calling convention anyway this should be good enough for our needs. The biggest benefit of this is that our attribute tests don't need to hack around different calling conventions in the target files anymore. \o/