### PR TITLE
Simplify Azure Pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 ### Utilities for writing COM components in Rust
 
 [![crates.io](https://img.shields.io/crates/v/intercom.svg)](https://crates.io/crates/intercom)
+[![Build Status](https://dev.azure.com/intercom-rs/Intercom/_apis/build/status/Rantanen.intercom?branchName=master)](https://dev.azure.com/intercom-rs/Intercom/_build/latest?definitionId=1&branchName=master)
 [![Build status](https://ci.appveyor.com/api/projects/status/q88b7xk6l72kup0y/branch/master?svg=true)](https://ci.appveyor.com/project/Rantanen/intercom/branch/master)
 [![Build Status](https://travis-ci.org/Rantanen/intercom.svg?branch=master)](https://travis-ci.org/Rantanen/intercom)
 [![CircleCI](https://circleci.com/gh/Rantanen/intercom/tree/master.svg?style=svg)](https://circleci.com/gh/Rantanen/intercom/tree/master)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,19 +48,8 @@ steps:
     cmake --build .
   displayName: "Build integration tests"
 
-# Run tests on Linux (raw file name)
-- script: |
+- bash: |
     build/bin/cpp-raw
     build/bin/cpp-dl
     build/bin/cpp-wrapper
-  displayName: "Run integration tests (Linux)"
-  condition: and(succeeded(), ne( variables['Agent.OS'], 'Windows_NT' ))
-
-# Run tests on Windows (.exe suffix)
-- script:
-    dir
-    build\bin\cpp-raw.exe
-    build\bin\cpp-dl.exe
-    build\bin\cpp-wrapper.exe
-  displayName: "Run integration tests (Windows)"
-  condition: and(succeeded(), eq( variables['Agent.OS'], 'Windows_NT' ))
+  displayName: "Run integration tests"


### PR DESCRIPTION
If we use `bash` step, we should be able to run the tests with the same command on both Windows and Linux.

(Also added badge to README.md)