### PR TITLE
Remove useless accessors from model

### DIFF
--- a/intercom-common/src/attributes/com_impl.rs
+++ b/intercom-common/src/attributes/com_impl.rs
@@ -25,15 +25,15 @@ pub fn expand_com_impl(
     // Parse the attribute.
     let mut output = vec![];
     let imp = model::ComImpl::parse(item_tokens.clone().into())?;
-    let struct_ident = imp.struct_name();
-    let itf_ident = imp.interface_name();
-    let maybe_dyn = match imp.is_trait_impl() {
+    let struct_ident = imp.struct_name;
+    let itf_ident = imp.interface_name;
+    let maybe_dyn = match imp.is_trait_impl {
         true => quote_spanned!(itf_ident.span() => dyn),
         false => quote!(),
     };
 
-    for (_, impl_variant) in imp.variants() {
-        let itf_unique_ident = impl_variant.interface_unique_name();
+    for (_, impl_variant) in imp.variants {
+        let itf_unique_ident = impl_variant.interface_unique_name;
         let vtable_struct_ident = idents::vtable_struct(&itf_unique_ident, itf_ident.span());
         let vtable_instance_ident =
             idents::vtable_instance(&struct_ident, &itf_unique_ident, itf_ident.span());
@@ -134,7 +134,7 @@ pub fn expand_com_impl(
         // seem okay. So in case we encounter any errors we'll just skip the method
         // silently. This is done by breaking out of the 'catch' before adding the
         // method to the vtable fields.
-        for method_info in impl_variant.methods() {
+        for method_info in impl_variant.methods {
             let method_ident = &method_info.unique_name;
             let method_rust_ident = &method_info.display_name;
             let method_impl_ident =

--- a/intercom-common/src/attributes/com_library.rs
+++ b/intercom-common/src/attributes/com_library.rs
@@ -25,7 +25,7 @@ pub fn expand_com_library(
     // Create the match-statmeent patterns for each supposedly visible COM class.
     let mut match_arms = vec![];
     let mut creatable_classes = vec![];
-    for struct_path in lib.coclasses() {
+    for struct_path in &lib.coclasses {
         // Construct the match pattern.
         let clsid_path = idents::clsid_path(struct_path);
         match_arms.push(quote!(
@@ -146,9 +146,9 @@ fn get_dll_get_class_object_function(match_arms: &[TokenStream]) -> TokenStream
 fn create_get_typelib_function(lib: &model::ComLibrary) -> Result<TokenStream, String>
 {
     let lib_name = lib_name();
-    let libid = utils::get_guid_tokens(lib.libid(), Span::call_site());
+    let libid = utils::get_guid_tokens(&lib.libid, Span::call_site());
     let create_class_typeinfo = lib
-        .coclasses()
+        .coclasses
         .iter()
         .map(|p| p.map_ident(|i| format!("get_intercom_coclass_info_for_{}", i)))
         .collect::<Result<Vec<_>, _>>()?;

--- a/intercom-common/src/model/comimpl.rs
+++ b/intercom-common/src/model/comimpl.rs
@@ -13,19 +13,19 @@ use syn::spanned::Spanned;
 #[derive(Debug)]
 pub struct ComImpl
 {
-    struct_name: Ident,
-    interface_display_name: Ident,
-    is_trait_impl: bool,
-    variants: IndexMap<ModelTypeSystem, ComImplVariant>,
+    pub struct_name: Ident,
+    pub interface_name: Ident,
+    pub is_trait_impl: bool,
+    pub variants: IndexMap<ModelTypeSystem, ComImplVariant>,
     pub impl_span: Span,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct ComImplVariant
 {
-    type_system: ModelTypeSystem,
-    interface_unique_name: Ident,
-    methods: Vec<ComMethodInfo>,
+    pub type_system: ModelTypeSystem,
+    pub interface_unique_name: Ident,
+    pub methods: Vec<ComMethodInfo>,
 }
 
 impl ComImpl
@@ -91,56 +91,11 @@ impl ComImpl
         .unwrap_or_else(Span::call_site);
         Ok(ComImpl {
             struct_name: struct_ident,
-            interface_display_name: itf_ident,
+            interface_name: itf_ident,
             impl_span,
             variants,
             is_trait_impl,
         })
-    }
-
-    /// Temp accessor for the automation variant.
-    pub fn aut(&self) -> &ComImplVariant
-    {
-        &self.variants[&ModelTypeSystem::Automation]
-    }
-
-    /// Struct name that the trait is implemented for.
-    pub fn struct_name(&self) -> &Ident
-    {
-        &self.struct_name
-    }
-
-    /// Interface variants.
-    pub fn variants(&self) -> &IndexMap<ModelTypeSystem, ComImplVariant>
-    {
-        &self.variants
-    }
-
-    /// Trait name that is implemented. Struct name if this is an implicit impl.
-    pub fn interface_name(&self) -> &Ident
-    {
-        &self.interface_display_name
-    }
-
-    /// True if a valid trait is implemented, false for implicit impls.
-    pub fn is_trait_impl(&self) -> bool
-    {
-        self.is_trait_impl
-    }
-}
-
-impl ComImplVariant
-{
-    /// Implemented methods.
-    pub fn methods(&self) -> &Vec<ComMethodInfo>
-    {
-        &self.methods
-    }
-
-    /// Unique interface name.
-    pub fn interface_unique_name(&self) -> &Ident
-    {
-        &self.interface_unique_name
     }
 }
 
@@ -156,9 +111,9 @@ mod test
         let itf = ComImpl::parse(quote!(impl Foo { fn foo( &self ) {} fn bar( &self ) {} }))
             .expect("com_impl attribute parsing failed");
 
-        assert_eq!(itf.struct_name(), "Foo");
-        assert_eq!(itf.interface_name(), "Foo");
-        assert_eq!(itf.is_trait_impl(), false);
+        assert_eq!(itf.struct_name, "Foo");
+        assert_eq!(itf.interface_name, "Foo");
+        assert_eq!(itf.is_trait_impl, false);
         assert_eq!(itf.variants[&Automation].methods.len(), 2);
         assert_eq!(itf.variants[&Automation].methods[0].display_name, "foo");
         assert_eq!(
@@ -184,9 +139,9 @@ mod test
             ComImpl::parse(quote!(impl IFoo for Bar { fn one( &self ) {} fn two( &self ) {} }))
                 .expect("com_impl attribute parsing failed");
 
-        assert_eq!(itf.struct_name(), "Bar");
-        assert_eq!(itf.interface_name(), "IFoo");
-        assert_eq!(itf.is_trait_impl(), true);
+        assert_eq!(itf.struct_name, "Bar");
+        assert_eq!(itf.interface_name, "IFoo");
+        assert_eq!(itf.is_trait_impl, true);
         assert_eq!(itf.variants[&Automation].methods.len(), 2);
         assert_eq!(itf.variants[&Automation].methods[0].display_name, "one");
         assert_eq!(

--- a/intercom-common/src/model/cominterface.rs
+++ b/intercom-common/src/model/cominterface.rs
@@ -33,24 +33,24 @@ impl ComInterfaceAttr
 #[derive(Debug)]
 pub struct ComInterface
 {
-    display_name: Ident,
-    visibility: Visibility,
-    base_interface: Option<Ident>,
-    variants: IndexMap<ModelTypeSystem, ComInterfaceVariant>,
-    item_type: crate::utils::InterfaceType,
+    pub display_name: Ident,
+    pub visibility: Visibility,
+    pub base_interface: Option<Ident>,
+    pub variants: IndexMap<ModelTypeSystem, ComInterfaceVariant>,
+    pub item_type: crate::utils::InterfaceType,
     pub span: Span,
-    is_unsafe: bool,
+    pub is_unsafe: bool,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct ComInterfaceVariant
 {
-    display_name: Ident,
-    unique_name: Ident,
-    unique_base_interface: Option<Ident>,
-    type_system: ModelTypeSystem,
-    iid: GUID,
-    methods: Vec<ComMethodInfo>,
+    pub display_name: Ident,
+    pub unique_name: Ident,
+    pub unique_base_interface: Option<Ident>,
+    pub type_system: ModelTypeSystem,
+    pub iid: GUID,
+    pub methods: Vec<ComMethodInfo>,
 }
 
 impl ComInterface
@@ -185,83 +185,6 @@ impl ComInterface
             variants,
         })
     }
-
-    /// Temp accessor for the automation variant.
-    pub fn aut(&self) -> &ComInterfaceVariant
-    {
-        &self.variants[&ModelTypeSystem::Automation]
-    }
-
-    /// Interface name.
-    pub fn name(&self) -> &Ident
-    {
-        &self.display_name
-    }
-
-    /// Interface visibility.
-    pub fn visibility(&self) -> &Visibility
-    {
-        &self.visibility
-    }
-
-    /// The base interface.
-    pub fn base_interface(&self) -> &Option<Ident>
-    {
-        &self.base_interface
-    }
-
-    /// Interface variants.
-    pub fn variants(&self) -> &IndexMap<ModelTypeSystem, ComInterfaceVariant>
-    {
-        &self.variants
-    }
-
-    /// The type of the associated item for the #[com_interface] attribute.
-    ///
-    /// Either an impl or a trait.
-    pub fn item_type(&self) -> crate::utils::InterfaceType
-    {
-        self.item_type
-    }
-
-    /// True, if the interface requires unsafe impl.
-    pub fn is_unsafe(&self) -> bool
-    {
-        self.is_unsafe
-    }
-}
-
-impl ComInterfaceVariant
-{
-    /// Interface unique name.
-    pub fn unique_name(&self) -> &Ident
-    {
-        &self.unique_name
-    }
-
-    /// Interface base interface variant unique name.
-    pub fn unique_base_interface(&self) -> &Option<Ident>
-    {
-        &self.unique_base_interface
-    }
-
-    /// Implemented methods.
-    pub fn methods(&self) -> &Vec<ComMethodInfo>
-    {
-        &self.methods
-    }
-
-    /// Interface IID.
-    pub fn iid(&self) -> &GUID
-    {
-        &self.iid
-    }
-
-    /// Gets the type system this interface variant represents.
-    pub fn type_system(&self) -> ModelTypeSystem
-    {
-        self.type_system
-    }
 }
 
 #[cfg(test)]
@@ -289,14 +212,14 @@ mod test
         )
         .expect("com_interface attribute parsing failed");
 
-        assert_eq!(itf.name(), "ITrait");
-        assert_eq!(itf.visibility(), &Visibility::Inherited);
-        assert_eq!(itf.base_interface().as_ref().unwrap(), "IUnknown");
+        assert_eq!(itf.display_name, "ITrait");
+        assert_eq!(itf.visibility, Visibility::Inherited);
+        assert_eq!(itf.base_interface.as_ref().unwrap(), "IUnknown");
 
         let variant = &itf.variants[&Automation];
         assert_eq!(
-            variant.iid(),
-            &GUID::parse("12345678-1234-1234-1234-567890ABCDEF").unwrap()
+            variant.iid,
+            GUID::parse("12345678-1234-1234-1234-567890ABCDEF").unwrap()
         );
         assert_eq!(variant.methods.len(), 2);
         assert_eq!(variant.methods[0].display_name, "foo");
@@ -304,8 +227,8 @@ mod test
 
         let variant = &itf.variants[&Raw];
         assert_eq!(
-            variant.iid(),
-            &GUID::parse("12345678-1234-1234-1234-567890FEDCBA").unwrap()
+            variant.iid,
+            GUID::parse("12345678-1234-1234-1234-567890FEDCBA").unwrap()
         );
         assert_eq!(variant.methods.len(), 2);
         assert_eq!(variant.methods[0].display_name, "foo");
@@ -328,16 +251,16 @@ mod test
         )
         .expect("com_interface attribute parsing failed");
 
-        assert_eq!(itf.name(), "IAutoGuid");
+        assert_eq!(itf.display_name, "IAutoGuid");
 
         let pub_visibility: Visibility = parse_quote!(pub);
-        assert_eq!(itf.visibility(), &pub_visibility);
-        assert_eq!(itf.base_interface().as_ref().unwrap(), "IUnknown");
+        assert_eq!(itf.visibility, pub_visibility);
+        assert_eq!(itf.base_interface.as_ref().unwrap(), "IUnknown");
 
         let variant = &itf.variants[&Automation];
         assert_eq!(
-            variant.iid(),
-            &GUID::parse("3DC87B73-0998-30B6-75EA-D4F564454D4B").unwrap()
+            variant.iid,
+            GUID::parse("3DC87B73-0998-30B6-75EA-D4F564454D4B").unwrap()
         );
         assert_eq!(variant.methods.len(), 2);
         assert_eq!(variant.methods[0].display_name, "one");
@@ -345,8 +268,8 @@ mod test
 
         let variant = &itf.variants[&Raw];
         assert_eq!(
-            variant.iid(),
-            &GUID::parse("D552E455-9FB2-34A2-61C0-34BDE0A9095D").unwrap()
+            variant.iid,
+            GUID::parse("D552E455-9FB2-34A2-61C0-34BDE0A9095D").unwrap()
         );
         assert_eq!(variant.methods.len(), 2);
         assert_eq!(variant.methods[0].display_name, "one");
@@ -369,16 +292,16 @@ mod test
         )
         .expect("com_interface attribute parsing failed");
 
-        assert_eq!(itf.name(), "IAutoGuid");
+        assert_eq!(itf.display_name, "IAutoGuid");
 
         let pub_visibility: Visibility = parse_quote!(pub);
-        assert_eq!(itf.visibility(), &pub_visibility);
-        assert_eq!(itf.base_interface().as_ref().unwrap(), "IBase");
+        assert_eq!(itf.visibility, pub_visibility);
+        assert_eq!(itf.base_interface.as_ref().unwrap(), "IBase");
 
         let variant = &itf.variants[&ModelTypeSystem::Automation];
         assert_eq!(
-            variant.iid(),
-            &GUID::parse("3DC87B73-0998-30B6-75EA-D4F564454D4B").unwrap()
+            variant.iid,
+            GUID::parse("3DC87B73-0998-30B6-75EA-D4F564454D4B").unwrap()
         );
         assert_eq!(variant.methods.len(), 2);
         assert_eq!(variant.methods[0].display_name, "one");
@@ -388,8 +311,8 @@ mod test
 
         let variant = &itf.variants[&ModelTypeSystem::Raw];
         assert_eq!(
-            variant.iid(),
-            &GUID::parse("D552E455-9FB2-34A2-61C0-34BDE0A9095D").unwrap()
+            variant.iid,
+            GUID::parse("D552E455-9FB2-34A2-61C0-34BDE0A9095D").unwrap()
         );
         assert_eq!(variant.methods.len(), 2);
         assert_eq!(variant.methods[0].display_name, "one");
@@ -414,16 +337,16 @@ mod test
         )
         .expect("com_interface attribute parsing failed");
 
-        assert_eq!(itf.name(), "IAutoGuid");
+        assert_eq!(itf.display_name, "IAutoGuid");
 
         let pub_visibility: Visibility = parse_quote!(pub);
-        assert_eq!(itf.visibility(), &pub_visibility);
-        assert_eq!(itf.base_interface(), &None);
+        assert_eq!(itf.visibility, pub_visibility);
+        assert_eq!(itf.base_interface, None);
 
         let variant = &itf.variants[&Automation];
         assert_eq!(
-            variant.iid(),
-            &GUID::parse("3DC87B73-0998-30B6-75EA-D4F564454D4B").unwrap()
+            variant.iid,
+            GUID::parse("3DC87B73-0998-30B6-75EA-D4F564454D4B").unwrap()
         );
         assert_eq!(variant.methods.len(), 2);
         assert_eq!(variant.methods[0].unique_name, "one_Automation");
@@ -431,8 +354,8 @@ mod test
 
         let variant = &itf.variants[&Raw];
         assert_eq!(
-            variant.iid(),
-            &GUID::parse("D552E455-9FB2-34A2-61C0-34BDE0A9095D").unwrap()
+            variant.iid,
+            GUID::parse("D552E455-9FB2-34A2-61C0-34BDE0A9095D").unwrap()
         );
         assert_eq!(variant.methods.len(), 2);
         assert_eq!(variant.methods[0].unique_name, "one_Raw");

--- a/intercom-common/src/model/comlibrary.rs
+++ b/intercom-common/src/model/comlibrary.rs
@@ -16,9 +16,9 @@ const EMPTY: [Path; 0] = [];
 #[derive(Debug, PartialEq)]
 pub struct ComLibrary
 {
-    name: String,
-    libid: GUID,
-    coclasses: Vec<Path>,
+    pub name: String,
+    pub libid: GUID,
+    pub coclasses: Vec<Path>,
 }
 
 impl ComLibrary
@@ -40,24 +40,6 @@ impl ComLibrary
             coclasses: attr.args().into_iter().cloned().collect(),
             libid,
         })
-    }
-
-    /// Library name.
-    pub fn name(&self) -> &str
-    {
-        &self.name
-    }
-
-    /// Library LIBID.
-    pub fn libid(&self) -> &GUID
-    {
-        &self.libid
-    }
-
-    /// CoClasses exposed by the library.
-    pub fn coclasses(&self) -> &[Path]
-    {
-        &self.coclasses
     }
 
     /// CoClasses exposed by the library.
@@ -87,19 +69,19 @@ mod test
         )
         .expect("com_library attribute parsing failed");
 
-        assert_eq!(lib.name(), "library_name");
+        assert_eq!(lib.name, "library_name");
         assert_eq!(
-            lib.libid(),
-            &GUID {
+            lib.libid,
+            GUID {
                 data1: 0x12345678,
                 data2: 0x1234,
                 data3: 0x1234,
                 data4: [0x12, 0x34, 0x56, 0x78, 0x90, 0xAB, 0xCD, 0xEF]
             }
         );
-        assert_eq!(lib.coclasses().len(), 2);
-        assert_eq!(lib.coclasses()[0], parse_quote!(Foo));
-        assert_eq!(lib.coclasses()[1], parse_quote!(Bar));
+        assert_eq!(lib.coclasses.len(), 2);
+        assert_eq!(lib.coclasses[0], parse_quote!(Foo));
+        assert_eq!(lib.coclasses[1], parse_quote!(Bar));
     }
 
     #[test]
@@ -113,24 +95,24 @@ mod test
         let lib = ComLibrary::parse("another_library".into(), quote!(One, Two))
             .expect("com_library attribute parsing failed");
 
-        assert_eq!(lib.name(), "another_library");
+        assert_eq!(lib.name, "another_library");
         assert_eq!(
-            lib.libid(),
-            &GUID::parse("696B2FAE-AC56-3E08-7C2C-ABAA8DB8F6E3").unwrap()
+            lib.libid,
+            GUID::parse("696B2FAE-AC56-3E08-7C2C-ABAA8DB8F6E3").unwrap()
         );
-        assert_eq!(lib.coclasses().len(), 2);
-        assert_eq!(lib.coclasses()[0], parse_quote!(One));
-        assert_eq!(lib.coclasses()[1], parse_quote!(Two));
+        assert_eq!(lib.coclasses.len(), 2);
+        assert_eq!(lib.coclasses[0], parse_quote!(One));
+        assert_eq!(lib.coclasses[1], parse_quote!(Two));
     }
 
     #[test]
     fn parse_com_library_with_empty_parameters()
     {
         let lib = ComLibrary::parse("lib".into(), quote!()).unwrap();
-        assert_eq!(lib.coclasses().len(), 0);
+        assert_eq!(lib.coclasses.len(), 0);
         assert_eq!(
-            lib.libid(),
-            &GUID::parse("22EC0095-CD17-3AFD-6C4F-531464178911").unwrap()
+            lib.libid,
+            GUID::parse("22EC0095-CD17-3AFD-6C4F-531464178911").unwrap()
         );
     }
 }

--- a/intercom-common/src/model/comstruct.rs
+++ b/intercom-common/src/model/comstruct.rs
@@ -15,10 +15,10 @@ intercom_attribute!(
 #[derive(Debug, PartialEq)]
 pub struct ComStruct
 {
-    name: Ident,
-    clsid: Option<GUID>,
-    visibility: Visibility,
-    interfaces: Vec<Ident>,
+    pub name: Ident,
+    pub clsid: Option<GUID>,
+    pub visibility: Visibility,
+    pub interfaces: Vec<Ident>,
 }
 
 impl ComStruct
@@ -66,30 +66,6 @@ impl ComStruct
             interfaces,
         })
     }
-
-    /// Struct name.
-    pub fn name(&self) -> &Ident
-    {
-        &self.name
-    }
-
-    /// Struct CLSID.
-    pub fn clsid(&self) -> &Option<GUID>
-    {
-        &self.clsid
-    }
-
-    /// Struct visibility.
-    pub fn visibility(&self) -> &::syn::Visibility
-    {
-        &self.visibility
-    }
-
-    /// Interfaces implemented by the struct.
-    pub fn interfaces(&self) -> &[Ident]
-    {
-        &self.interfaces
-    }
 }
 
 #[cfg(test)]
@@ -109,14 +85,14 @@ mod test
         )
         .expect("com_class attribute parsing failed");
 
-        assert_eq!(cls.name(), "S");
+        assert_eq!(cls.name, "S");
         assert_eq!(
-            cls.clsid(),
-            &Some(GUID::parse("12345678-1234-1234-1234-567890ABCDEF").unwrap())
+            cls.clsid,
+            Some(GUID::parse("12345678-1234-1234-1234-567890ABCDEF").unwrap())
         );
-        assert_eq!(cls.interfaces().len(), 2);
-        assert_eq!(cls.interfaces()[0], "Foo");
-        assert_eq!(cls.interfaces()[1], "Bar");
+        assert_eq!(cls.interfaces.len(), 2);
+        assert_eq!(cls.interfaces[0], "Foo");
+        assert_eq!(cls.interfaces[1], "Bar");
     }
 
     #[test]
@@ -139,15 +115,15 @@ mod test
         )
         .expect("com_class attribute parsing failed");
 
-        assert_eq!(cls.name(), "MyStruct");
+        assert_eq!(cls.name, "MyStruct");
         assert_eq!(
-            cls.clsid(),
-            &Some(GUID::parse("28F57CBA-6AF4-3D3F-7C55-1CF1394D5C7A").unwrap())
+            cls.clsid,
+            Some(GUID::parse("28F57CBA-6AF4-3D3F-7C55-1CF1394D5C7A").unwrap())
         );
-        assert_eq!(cls.interfaces().len(), 3);
-        assert_eq!(cls.interfaces()[0], "MyStruct");
-        assert_eq!(cls.interfaces()[1], "IThings");
-        assert_eq!(cls.interfaces()[2], "IStuff");
+        assert_eq!(cls.interfaces.len(), 3);
+        assert_eq!(cls.interfaces[0], "MyStruct");
+        assert_eq!(cls.interfaces[1], "IThings");
+        assert_eq!(cls.interfaces[2], "IStuff");
     }
 
     #[test]
@@ -162,9 +138,9 @@ mod test
         )
         .expect("com_class attribute parsing failed");
 
-        assert_eq!(cls.name(), "EmptyType");
-        assert_eq!(cls.clsid(), &None);
-        assert_eq!(cls.interfaces().len(), 0);
+        assert_eq!(cls.name, "EmptyType");
+        assert_eq!(cls.clsid, None);
+        assert_eq!(cls.interfaces.len(), 0);
     }
 
     #[test]
@@ -179,8 +155,8 @@ mod test
         )
         .expect("com_class attribute parsing failed");
 
-        assert_eq!(cls.name(), "EmptyType");
-        assert_eq!(cls.clsid(), &None);
-        assert_eq!(cls.interfaces().len(), 1);
+        assert_eq!(cls.name, "EmptyType");
+        assert_eq!(cls.clsid, None);
+        assert_eq!(cls.interfaces.len(), 1);
     }
 }


### PR DESCRIPTION
This has been annoying me for a while now. I based the original implementation on all the C++ nagging how "raw fields are bad", but since things are immutable-by-default in Rust, I don't think the usual arguments apply here.