### PR TITLE
Add .gitattributes for common tests

### DIFF
--- a/intercom-attributes/tests/data/.gitattributes
+++ b/intercom-attributes/tests/data/.gitattributes
@@ -1,0 +1,5 @@
+# The output references should never use autocrlf on Windows.
+# Our test framework ensures these are consistent. Any problems should be
+# fixed in the intercom-common/tests/lib.rs
+*.stdout    binary
+*.stderr    binary


### PR DESCRIPTION
Our stdout/stderr reference files are updated with LF line breaks, which causes weird things in Windows with autocrlf.