### PR TITLE
Use traits to define attribute results to support arbitrary paths

### DIFF
--- a/intercom-attributes/tests/data/macro/com_impl.rs.stdout
+++ b/intercom-attributes/tests/data/macro/com_impl.rs.stdout
@@ -93,6 +93,7 @@ pub struct __intercom_vtable_for_Foo {
         intercom::type_system::RawTypeSystem,
     >>::VTable,
 }
+#[allow(clippy::all)]
 impl intercom::CoClass for Foo {
     type VTableList = __intercom_vtable_for_Foo;
     fn create_vtable_list() -> Self::VTableList {

--- a/intercom-attributes/tests/data/macro/com_impl.rs.stdout
+++ b/intercom-attributes/tests/data/macro/com_impl.rs.stdout
@@ -34,42 +34,81 @@ fn get_intercom_interface_info_for_Foo() -> Vec<intercom::typelib::TypeInfo> {
 }
 
 pub struct Foo;
-#[inline(always)]
 #[allow(non_snake_case)]
-fn __Foo_Foo_AutomationVtbl_offset() -> usize {
-    unsafe { &intercom::ComBoxData::<Foo>::null_vtable().Foo_Automation as *const _ as usize }
+impl intercom::attributes::ComClass<Foo, intercom::type_system::AutomationTypeSystem> for Foo {
+    #[inline(always)]
+    fn offset() -> usize {
+        unsafe { &intercom::ComBoxData::<Foo>::null_vtable().Foo_Automation as *const _ as usize }
+    }
 }
-#[inline(always)]
 #[allow(non_snake_case)]
-fn __Foo_Foo_RawVtbl_offset() -> usize {
-    unsafe { &intercom::ComBoxData::<Foo>::null_vtable().Foo_Raw as *const _ as usize }
+impl intercom::attributes::ComClass<Foo, intercom::type_system::RawTypeSystem> for Foo {
+    #[inline(always)]
+    fn offset() -> usize {
+        unsafe { &intercom::ComBoxData::<Foo>::null_vtable().Foo_Raw as *const _ as usize }
+    }
 }
 #[allow(non_upper_case_globals)]
-const __Foo_ISupportErrorInfoVtbl_INSTANCE: intercom::ISupportErrorInfoVtbl =
-    intercom::ISupportErrorInfoVtbl {
-        __base: intercom::IUnknownVtbl {
-            query_interface_Automation: intercom::ComBoxData::<Foo>::query_interface_ptr,
-            add_ref_Automation: intercom::ComBoxData::<Foo>::add_ref_ptr,
-            release_Automation: intercom::ComBoxData::<Foo>::release_ptr,
-        },
-        interface_supports_error_info_Automation:
-            intercom::ComBoxData::<Foo>::interface_supports_error_info_ptr,
-    };
+impl
+    intercom::attributes::ComImpl<
+        intercom::ISupportErrorInfo,
+        intercom::type_system::AutomationTypeSystem,
+    > for Foo
+{
+    fn vtable()
+     ->
+         &'static <dyn intercom::ISupportErrorInfo as
+intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::VTable{
+        type T = <dyn intercom::ISupportErrorInfo as intercom::attributes::ComInterface<
+            intercom::type_system::AutomationTypeSystem,
+        >>::VTable;
+        &T {
+            __base: {
+                type Vtbl = <dyn intercom::IUnknown as intercom::attributes::ComInterface<
+                    intercom::type_system::AutomationTypeSystem,
+                >>::VTable;
+                Vtbl {
+                    query_interface: intercom::ComBoxData::<Foo>::query_interface_ptr,
+                    add_ref: intercom::ComBoxData::<Foo>::add_ref_ptr,
+                    release: intercom::ComBoxData::<Foo>::release_ptr,
+                }
+            },
+            interface_supports_error_info:
+                intercom::ComBoxData::<Foo>::interface_supports_error_info_ptr,
+        }
+    }
+}
 impl intercom::HasInterface<intercom::IUnknown> for Foo {}
 #[allow(non_snake_case)]
 #[doc(hidden)]
-pub struct __FooVtblList {
-    _ISupportErrorInfo: &'static intercom::ISupportErrorInfoVtbl,
-    Foo_Automation: &'static __Foo_AutomationVtbl,
-    Foo_Raw: &'static __Foo_RawVtbl,
+pub struct __intercom_vtable_for_Foo {
+    _ISupportErrorInfo:
+        &'static <dyn intercom::ISupportErrorInfo as intercom::attributes::ComInterface<
+            intercom::type_system::AutomationTypeSystem,
+        >>::VTable,
+    Foo_Automation: &'static <Foo as intercom::attributes::ComInterface<
+        intercom::type_system::AutomationTypeSystem,
+    >>::VTable,
+    Foo_Raw: &'static <Foo as intercom::attributes::ComInterface<
+        intercom::type_system::RawTypeSystem,
+    >>::VTable,
 }
 impl intercom::CoClass for Foo {
-    type VTableList = __FooVtblList;
+    type VTableList = __intercom_vtable_for_Foo;
     fn create_vtable_list() -> Self::VTableList {
-        __FooVtblList {
-            _ISupportErrorInfo: &__Foo_ISupportErrorInfoVtbl_INSTANCE,
-            Foo_Automation: &__Foo_Foo_AutomationVtbl_INSTANCE,
-            Foo_Raw: &__Foo_Foo_RawVtbl_INSTANCE,
+        __intercom_vtable_for_Foo {
+            _ISupportErrorInfo: <Foo as intercom::attributes::ComImpl<
+                dyn intercom::ISupportErrorInfo,
+                intercom::type_system::AutomationTypeSystem,
+            >>::vtable(),
+            Foo_Automation: <Foo as intercom::attributes::ComImpl<
+                Foo,
+                intercom::type_system::AutomationTypeSystem,
+            >>::vtable(),
+            Foo_Raw: <Foo as intercom::attributes::ComImpl<
+                Foo,
+                intercom::type_system::RawTypeSystem,
+            >>::vtable(),
         }
     }
     fn query_interface(
@@ -79,31 +118,84 @@ impl intercom::CoClass for Foo {
         if riid.is_null() {
             return Err(intercom::raw::E_NOINTERFACE);
         }
-        Ok(match *unsafe { &*riid } {
-            intercom::IID_IUnknown => {
-                (&vtables._ISupportErrorInfo) as *const &intercom::ISupportErrorInfoVtbl
-                    as *mut &intercom::ISupportErrorInfoVtbl as intercom::RawComPtr
-            }
-            intercom::IID_ISupportErrorInfo => {
-                (&vtables._ISupportErrorInfo) as *const &intercom::ISupportErrorInfoVtbl
-                    as *mut &intercom::ISupportErrorInfoVtbl as intercom::RawComPtr
-            }
-            self::IID_Foo_Automation => {
-                &vtables.Foo_Automation as *const &__Foo_AutomationVtbl
-                    as *mut &__Foo_AutomationVtbl as intercom::RawComPtr
-            }
-            self::IID_Foo_Raw => {
-                &vtables.Foo_Raw as *const &__Foo_RawVtbl as *mut &__Foo_RawVtbl
-                    as intercom::RawComPtr
-            }
-            _ => return Err(intercom::raw::E_NOINTERFACE),
-        })
+        unsafe {
+            let riid = &*riid;
+            Ok(
+                if riid
+                    == <dyn intercom::IUnknown as intercom::attributes::ComInterface<
+                        intercom::type_system::AutomationTypeSystem,
+                    >>::iid()
+                {
+                    (&vtables._ISupportErrorInfo) as
+                       *const &<dyn intercom::ISupportErrorInfo as
+                               intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::VTable
+                       as
+                       *mut &<dyn intercom::ISupportErrorInfo as
+                             intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::VTable
+                       as intercom::RawComPtr
+                } else if riid
+                    == <dyn intercom::ISupportErrorInfo as intercom::attributes::ComInterface<
+                        intercom::type_system::AutomationTypeSystem,
+                    >>::iid()
+                {
+                    (&vtables._ISupportErrorInfo) as
+                       *const &<dyn intercom::ISupportErrorInfo as
+                               intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::VTable
+                       as
+                       *mut &<dyn intercom::ISupportErrorInfo as
+                             intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::VTable
+                       as intercom::RawComPtr
+                } else if riid
+                    == <Foo as intercom::attributes::ComInterface<
+                        intercom::type_system::AutomationTypeSystem,
+                    >>::iid()
+                {
+                    &vtables.Foo_Automation
+                        as *const &<Foo as intercom::attributes::ComInterface<
+                            intercom::type_system::AutomationTypeSystem,
+                        >>::VTable
+                        as *mut &<Foo as intercom::attributes::ComInterface<
+                            intercom::type_system::AutomationTypeSystem,
+                        >>::VTable as intercom::RawComPtr
+                } else if riid
+                    == <Foo as intercom::attributes::ComInterface<
+                        intercom::type_system::RawTypeSystem,
+                    >>::iid()
+                {
+                    &vtables.Foo_Raw
+                        as *const &<Foo as intercom::attributes::ComInterface<
+                            intercom::type_system::RawTypeSystem,
+                        >>::VTable
+                        as *mut &<Foo as intercom::attributes::ComInterface<
+                            intercom::type_system::RawTypeSystem,
+                        >>::VTable as intercom::RawComPtr
+                } else {
+                    return Err(intercom::raw::E_NOINTERFACE);
+                },
+            )
+        }
     }
     fn interface_supports_error_info(riid: intercom::REFIID) -> bool {
-        match *unsafe { &*riid } {
-            self::IID_Foo_Automation => true,
-            self::IID_Foo_Raw => true,
-            _ => false,
+        if riid.is_null() {
+            return false;
+        }
+        unsafe {
+            let riid = &*riid;
+            if riid
+                == <Foo as intercom::attributes::ComInterface<
+                    intercom::type_system::AutomationTypeSystem,
+                >>::iid()
+            {
+                true
+            } else if riid
+                == <Foo as intercom::attributes::ComInterface<
+                    intercom::type_system::RawTypeSystem,
+                >>::iid()
+            {
+                true
+            } else {
+                false
+            }
         }
     }
 }
@@ -115,28 +207,46 @@ pub const CLSID_Foo: intercom::CLSID = intercom::GUID {
     data3: 0u16,
     data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8],
 };
-pub fn get_intercom_coclass_info_for_Foo() -> Vec<intercom::typelib::TypeInfo> {
-    // Should be VARIANT_BOOL in Automation interface.
+impl intercom::attributes::HasTypeInfo for Foo {
+    fn gather_type_info() -> Vec<intercom::typelib::TypeInfo> {
+        let mut r =
 
-    <[_]>::into_vec(box [
-        intercom::typelib::TypeInfo::Class(intercom::ComBox::new(
-            intercom::typelib::CoClass::__new(
-                "Foo".into(),
-                intercom::GUID {
-                    data1: 0u32,
-                    data2: 0u16,
-                    data3: 0u16,
-                    data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8],
-                },
-                <[_]>::into_vec(box [intercom::typelib::InterfaceRef {
-                    name: "Foo".into(),
-                    iid_automation: IID_Foo_Automation,
-                    iid_raw: IID_Foo_Raw,
-                }]),
-            ),
-        )),
-        get_intercom_interface_info_for_Foo(),
-    ])
+
+
+
+            // Should be VARIANT_BOOL in Automation interface.
+
+            <[_]>::into_vec(box
+                                [intercom::typelib::TypeInfo::Class(intercom::ComBox::new(intercom::typelib::CoClass::__new("Foo".into(),
+                                                                                                                            intercom::GUID{data1:
+                                                                                                                                               0u32,
+                                                                                                                                           data2:
+                                                                                                                                               0u16,
+                                                                                                                                           data3:
+                                                                                                                                               0u16,
+                                                                                                                                           data4:
+                                                                                                                                               [0u8,
+                                                                                                                                                0u8,
+                                                                                                                                                0u8,
+                                                                                                                                                0u8,
+                                                                                                                                                0u8,
+                                                                                                                                                0u8,
+                                                                                                                                                0u8,
+                                                                                                                                                0u8],},
+                                                                                                                            <[_]>::into_vec(box
+                                                                                                                                                [intercom::typelib::InterfaceRef{name:
+                                                                                                                                                                                     "Foo".into(),
+                                                                                                                                                                                 iid_automation:
+                                                                                                                                                                                     <Foo
+                                                                                                                                                                                         as
+                                                                                                                                                                                         intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::iid().clone(),
+                                                                                                                                                                                 iid_raw:
+                                                                                                                                                                                     <Foo
+                                                                                                                                                                                         as
+                                                                                                                                                                                         intercom::attributes::ComInterface<intercom::type_system::RawTypeSystem>>::iid().clone(),}]))))]);
+        r.extend(<Foo as intercom::attributes::InterfaceHasTypeInfo>::gather_type_info());
+        r
+    }
 }
 impl Foo {
     fn static_method(a: u16, b: i16) {}
@@ -184,7 +294,11 @@ unsafe extern "system" fn __Foo_Foo_Automation_query_interface(
     intercom::type_system::AutomationTypeSystem,
 >>::ExternOutputType {
     intercom::ComBoxData::<Foo>::query_interface(
-        &mut *((self_vtable as usize - __Foo_Foo_AutomationVtbl_offset()) as *mut _),
+        &mut *((self_vtable as usize
+            - <Foo as intercom::attributes::ComClass<
+                Foo,
+                intercom::type_system::AutomationTypeSystem,
+            >>::offset()) as *mut _),
         riid,
         out,
     )
@@ -198,7 +312,11 @@ unsafe extern "system" fn __Foo_Foo_Automation_add_ref(self_vtable:
      <u32 as
 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
     intercom::ComBoxData::<Foo>::add_ref(
-        &mut *((self_vtable as usize - __Foo_Foo_AutomationVtbl_offset()) as *mut _),
+        &mut *((self_vtable as usize
+            - <Foo as intercom::attributes::ComClass<
+                Foo,
+                intercom::type_system::AutomationTypeSystem,
+            >>::offset()) as *mut _),
     )
 }
 #[allow(non_snake_case)]
@@ -210,7 +328,11 @@ unsafe extern "system" fn __Foo_Foo_Automation_release(self_vtable:
      <u32 as
 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
     intercom::ComBoxData::<Foo>::release_ptr(
-        (self_vtable as usize - __Foo_Foo_AutomationVtbl_offset()) as *mut _,
+        (self_vtable as usize
+            - <Foo as intercom::attributes::ComClass<
+                Foo,
+                intercom::type_system::AutomationTypeSystem,
+            >>::offset()) as *mut _,
     )
 }
 #[allow(non_snake_case)]
@@ -230,8 +352,10 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
              {
                  let self_combox =
                      (self_vtable as usize -
-                          __Foo_Foo_AutomationVtbl_offset()) as
-                         *mut intercom::ComBoxData<Foo>;
+                          <Foo as
+                              intercom::attributes::ComClass<Foo,
+                                                             intercom::type_system::AutomationTypeSystem>>::offset())
+                         as *mut intercom::ComBoxData<Foo>;
                  let self_struct: &Foo = &**self_combox;
                  let __result = self_struct.simple_method();
                  Ok({ })
@@ -267,8 +391,10 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
              {
                  let self_combox =
                      (self_vtable as usize -
-                          __Foo_Foo_AutomationVtbl_offset()) as
-                         *mut intercom::ComBoxData<Foo>;
+                          <Foo as
+                              intercom::attributes::ComClass<Foo,
+                                                             intercom::type_system::AutomationTypeSystem>>::offset())
+                         as *mut intercom::ComBoxData<Foo>;
                  let self_struct: &Foo = &**self_combox;
                  let __result =
                      self_struct.arg_method((&<u16 as
@@ -302,8 +428,10 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
              {
                  let self_combox =
                      (self_vtable as usize -
-                          __Foo_Foo_AutomationVtbl_offset()) as
-                         *mut intercom::ComBoxData<Foo>;
+                          <Foo as
+                              intercom::attributes::ComClass<Foo,
+                                                             intercom::type_system::AutomationTypeSystem>>::offset())
+                         as *mut intercom::ComBoxData<Foo>;
                  let self_struct: &Foo = &**self_combox;
                  let __result = self_struct.simple_result_method();
                  Ok({ __result.intercom_into()? })
@@ -336,8 +464,11 @@ unsafe extern "system" fn __Foo_Foo_Automation_com_result_method_Automation(
         >>::ExternOutputType,
         intercom::ComError,
     > = (|| {
-        let self_combox = (self_vtable as usize - __Foo_Foo_AutomationVtbl_offset())
-            as *mut intercom::ComBoxData<Foo>;
+        let self_combox = (self_vtable as usize
+            - <Foo as intercom::attributes::ComClass<
+                Foo,
+                intercom::type_system::AutomationTypeSystem,
+            >>::offset()) as *mut intercom::ComBoxData<Foo>;
         let self_struct: &Foo = &**self_combox;
         let __result = self_struct.com_result_method();
         Ok({
@@ -381,8 +512,11 @@ unsafe extern "system" fn __Foo_Foo_Automation_rust_result_method_Automation(
         >>::ExternOutputType,
         intercom::ComError,
     > = (|| {
-        let self_combox = (self_vtable as usize - __Foo_Foo_AutomationVtbl_offset())
-            as *mut intercom::ComBoxData<Foo>;
+        let self_combox = (self_vtable as usize
+            - <Foo as intercom::attributes::ComClass<
+                Foo,
+                intercom::type_system::AutomationTypeSystem,
+            >>::offset()) as *mut intercom::ComBoxData<Foo>;
         let self_struct: &Foo = &**self_combox;
         let __result = self_struct.rust_result_method();
         Ok({
@@ -432,8 +566,11 @@ unsafe extern "system" fn __Foo_Foo_Automation_tuple_result_method_Automation(
         >>::ExternOutputType,
         intercom::ComError,
     > = (|| {
-        let self_combox = (self_vtable as usize - __Foo_Foo_AutomationVtbl_offset())
-            as *mut intercom::ComBoxData<Foo>;
+        let self_combox = (self_vtable as usize
+            - <Foo as intercom::attributes::ComClass<
+                Foo,
+                intercom::type_system::AutomationTypeSystem,
+            >>::offset()) as *mut intercom::ComBoxData<Foo>;
         let self_struct: &Foo = &**self_combox;
         let __result = self_struct.tuple_result_method();
         Ok({
@@ -482,8 +619,11 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
         >>::ExternOutputType,
         intercom::ComError,
     > = (|| {
-        let self_combox = (self_vtable as usize - __Foo_Foo_AutomationVtbl_offset())
-            as *mut intercom::ComBoxData<Foo>;
+        let self_combox = (self_vtable as usize
+            - <Foo as intercom::attributes::ComClass<
+                Foo,
+                intercom::type_system::AutomationTypeSystem,
+            >>::offset()) as *mut intercom::ComBoxData<Foo>;
         let self_struct: &Foo = &**self_combox;
         let __result = self_struct.string_method(
             (&<String as intercom::type_system::ExternType<
@@ -524,8 +664,11 @@ unsafe extern "system" fn __Foo_Foo_Automation_string_result_method_Automation(
         >>::ExternOutputType,
         intercom::ComError,
     > = (|| {
-        let self_combox = (self_vtable as usize - __Foo_Foo_AutomationVtbl_offset())
-            as *mut intercom::ComBoxData<Foo>;
+        let self_combox = (self_vtable as usize
+            - <Foo as intercom::attributes::ComClass<
+                Foo,
+                intercom::type_system::AutomationTypeSystem,
+            >>::offset()) as *mut intercom::ComBoxData<Foo>;
         let self_struct: &Foo = &**self_combox;
         let __result = self_struct.string_result_method(
             (&<String as intercom::type_system::ExternType<
@@ -582,8 +725,11 @@ unsafe extern "system" fn __Foo_Foo_Automation_complete_method_Automation(
         >>::ExternOutputType,
         intercom::ComError,
     > = (|| {
-        let self_combox = (self_vtable as usize - __Foo_Foo_AutomationVtbl_offset())
-            as *mut intercom::ComBoxData<Foo>;
+        let self_combox = (self_vtable as usize
+            - <Foo as intercom::attributes::ComClass<
+                Foo,
+                intercom::type_system::AutomationTypeSystem,
+            >>::offset()) as *mut intercom::ComBoxData<Foo>;
         let self_struct: &mut Foo = &mut **self_combox;
         let __result = self_struct.complete_method(
             (&<u16 as intercom::type_system::ExternType<
@@ -639,8 +785,11 @@ unsafe extern "system" fn __Foo_Foo_Automation_bool_method_Automation(
         >>::ExternOutputType,
         intercom::ComError,
     > = (|| {
-        let self_combox = (self_vtable as usize - __Foo_Foo_AutomationVtbl_offset())
-            as *mut intercom::ComBoxData<Foo>;
+        let self_combox = (self_vtable as usize
+            - <Foo as intercom::attributes::ComClass<
+                Foo,
+                intercom::type_system::AutomationTypeSystem,
+            >>::offset()) as *mut intercom::ComBoxData<Foo>;
         let self_struct: &Foo = &**self_combox;
         let __result = self_struct.bool_method(
             (&<bool as intercom::type_system::ExternType<
@@ -692,8 +841,11 @@ unsafe extern "system" fn __Foo_Foo_Automation_variant_method_Automation(
         >>::ExternOutputType,
         intercom::ComError,
     > = (|| {
-        let self_combox = (self_vtable as usize - __Foo_Foo_AutomationVtbl_offset())
-            as *mut intercom::ComBoxData<Foo>;
+        let self_combox = (self_vtable as usize
+            - <Foo as intercom::attributes::ComClass<
+                Foo,
+                intercom::type_system::AutomationTypeSystem,
+            >>::offset()) as *mut intercom::ComBoxData<Foo>;
         let self_struct: &Foo = &**self_combox;
         let __result = self_struct.variant_method(
             (&<Variant as intercom::type_system::ExternType<
@@ -725,24 +877,38 @@ unsafe extern "system" fn __Foo_Foo_Automation_variant_method_Automation(
     }
 }
 #[allow(non_upper_case_globals)]
-const __Foo_Foo_AutomationVtbl_INSTANCE: __Foo_AutomationVtbl = __Foo_AutomationVtbl {
-    __base: intercom::IUnknownVtbl {
-        query_interface_Automation: __Foo_Foo_Automation_query_interface,
-        add_ref_Automation: __Foo_Foo_Automation_add_ref,
-        release_Automation: __Foo_Foo_Automation_release,
-    },
-    simple_method_Automation: __Foo_Foo_Automation_simple_method_Automation,
-    arg_method_Automation: __Foo_Foo_Automation_arg_method_Automation,
-    simple_result_method_Automation: __Foo_Foo_Automation_simple_result_method_Automation,
-    com_result_method_Automation: __Foo_Foo_Automation_com_result_method_Automation,
-    rust_result_method_Automation: __Foo_Foo_Automation_rust_result_method_Automation,
-    tuple_result_method_Automation: __Foo_Foo_Automation_tuple_result_method_Automation,
-    string_method_Automation: __Foo_Foo_Automation_string_method_Automation,
-    string_result_method_Automation: __Foo_Foo_Automation_string_result_method_Automation,
-    complete_method_Automation: __Foo_Foo_Automation_complete_method_Automation,
-    bool_method_Automation: __Foo_Foo_Automation_bool_method_Automation,
-    variant_method_Automation: __Foo_Foo_Automation_variant_method_Automation,
-};
+impl intercom::attributes::ComImpl<Foo, intercom::type_system::AutomationTypeSystem> for Foo {
+    fn vtable() -> &'static <Foo as intercom::attributes::ComInterface<
+        intercom::type_system::AutomationTypeSystem,
+    >>::VTable {
+        type T = <Foo as intercom::attributes::ComInterface<
+            intercom::type_system::AutomationTypeSystem,
+        >>::VTable;
+        &T {
+            __base: {
+                type TVtbl = <dyn intercom::IUnknown as intercom::attributes::ComInterface<
+                    intercom::type_system::AutomationTypeSystem,
+                >>::VTable;
+                TVtbl {
+                    query_interface: __Foo_Foo_Automation_query_interface,
+                    add_ref: __Foo_Foo_Automation_add_ref,
+                    release: __Foo_Foo_Automation_release,
+                }
+            },
+            simple_method: __Foo_Foo_Automation_simple_method_Automation,
+            arg_method: __Foo_Foo_Automation_arg_method_Automation,
+            simple_result_method: __Foo_Foo_Automation_simple_result_method_Automation,
+            com_result_method: __Foo_Foo_Automation_com_result_method_Automation,
+            rust_result_method: __Foo_Foo_Automation_rust_result_method_Automation,
+            tuple_result_method: __Foo_Foo_Automation_tuple_result_method_Automation,
+            string_method: __Foo_Foo_Automation_string_method_Automation,
+            string_result_method: __Foo_Foo_Automation_string_result_method_Automation,
+            complete_method: __Foo_Foo_Automation_complete_method_Automation,
+            bool_method: __Foo_Foo_Automation_bool_method_Automation,
+            variant_method: __Foo_Foo_Automation_variant_method_Automation,
+        }
+    }
+}
 #[allow(non_snake_case)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_Raw_query_interface(
@@ -756,11 +922,13 @@ unsafe extern "system" fn __Foo_Foo_Raw_query_interface(
 ) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
     intercom::type_system::AutomationTypeSystem,
 >>::ExternOutputType {
-    intercom::ComBoxData::<Foo>::query_interface(
-        &mut *((self_vtable as usize - __Foo_Foo_RawVtbl_offset()) as *mut _),
-        riid,
-        out,
-    )
+    intercom::ComBoxData::<Foo>::query_interface(&mut *((self_vtable as usize
+                                                             -
+                                                             <Foo as
+                                                                 intercom::attributes::ComClass<Foo,
+                                                                                                intercom::type_system::RawTypeSystem>>::offset())
+                                                            as *mut _), riid,
+                                                 out)
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]
@@ -770,9 +938,11 @@ unsafe extern "system" fn __Foo_Foo_Raw_add_ref(self_vtable:
  ->
      <u32 as
 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
-    intercom::ComBoxData::<Foo>::add_ref(
-        &mut *((self_vtable as usize - __Foo_Foo_RawVtbl_offset()) as *mut _),
-    )
+    intercom::ComBoxData::<Foo>::add_ref(&mut *((self_vtable as usize -
+                                                     <Foo as
+                                                         intercom::attributes::ComClass<Foo,
+                                                                                        intercom::type_system::RawTypeSystem>>::offset())
+                                                    as *mut _))
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]
@@ -782,9 +952,11 @@ unsafe extern "system" fn __Foo_Foo_Raw_release(self_vtable:
  ->
      <u32 as
 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
-    intercom::ComBoxData::<Foo>::release_ptr(
-        (self_vtable as usize - __Foo_Foo_RawVtbl_offset()) as *mut _,
-    )
+    intercom::ComBoxData::<Foo>::release_ptr((self_vtable as usize -
+                                                  <Foo as
+                                                      intercom::attributes::ComClass<Foo,
+                                                                                     intercom::type_system::RawTypeSystem>>::offset())
+                                                 as *mut _)
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]
@@ -802,8 +974,11 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
         (||
              {
                  let self_combox =
-                     (self_vtable as usize - __Foo_Foo_RawVtbl_offset()) as
-                         *mut intercom::ComBoxData<Foo>;
+                     (self_vtable as usize -
+                          <Foo as
+                              intercom::attributes::ComClass<Foo,
+                                                             intercom::type_system::RawTypeSystem>>::offset())
+                         as *mut intercom::ComBoxData<Foo>;
                  let self_struct: &Foo = &**self_combox;
                  let __result = self_struct.simple_method();
                  Ok({ })
@@ -837,8 +1012,11 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
         (||
              {
                  let self_combox =
-                     (self_vtable as usize - __Foo_Foo_RawVtbl_offset()) as
-                         *mut intercom::ComBoxData<Foo>;
+                     (self_vtable as usize -
+                          <Foo as
+                              intercom::attributes::ComClass<Foo,
+                                                             intercom::type_system::RawTypeSystem>>::offset())
+                         as *mut intercom::ComBoxData<Foo>;
                  let self_struct: &Foo = &**self_combox;
                  let __result =
                      self_struct.arg_method((&<u16 as
@@ -871,8 +1049,11 @@ intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::Extern
         (||
              {
                  let self_combox =
-                     (self_vtable as usize - __Foo_Foo_RawVtbl_offset()) as
-                         *mut intercom::ComBoxData<Foo>;
+                     (self_vtable as usize -
+                          <Foo as
+                              intercom::attributes::ComClass<Foo,
+                                                             intercom::type_system::RawTypeSystem>>::offset())
+                         as *mut intercom::ComBoxData<Foo>;
                  let self_struct: &Foo = &**self_combox;
                  let __result = self_struct.simple_result_method();
                  Ok({ __result.intercom_into()? })
@@ -906,7 +1087,11 @@ unsafe extern "system" fn __Foo_Foo_Raw_com_result_method_Raw(
         intercom::ComError,
     > = (|| {
         let self_combox =
-            (self_vtable as usize - __Foo_Foo_RawVtbl_offset()) as *mut intercom::ComBoxData<Foo>;
+            (self_vtable as usize
+                - <Foo as intercom::attributes::ComClass<
+                    Foo,
+                    intercom::type_system::RawTypeSystem,
+                >>::offset()) as *mut intercom::ComBoxData<Foo>;
         let self_struct: &Foo = &**self_combox;
         let __result = self_struct.com_result_method();
         Ok({
@@ -952,7 +1137,11 @@ unsafe extern "system" fn __Foo_Foo_Raw_rust_result_method_Raw(
         intercom::ComError,
     > = (|| {
         let self_combox =
-            (self_vtable as usize - __Foo_Foo_RawVtbl_offset()) as *mut intercom::ComBoxData<Foo>;
+            (self_vtable as usize
+                - <Foo as intercom::attributes::ComClass<
+                    Foo,
+                    intercom::type_system::RawTypeSystem,
+                >>::offset()) as *mut intercom::ComBoxData<Foo>;
         let self_struct: &Foo = &**self_combox;
         let __result = self_struct.rust_result_method();
         Ok({
@@ -1006,7 +1195,11 @@ unsafe extern "system" fn __Foo_Foo_Raw_tuple_result_method_Raw(
         intercom::ComError,
     > = (|| {
         let self_combox =
-            (self_vtable as usize - __Foo_Foo_RawVtbl_offset()) as *mut intercom::ComBoxData<Foo>;
+            (self_vtable as usize
+                - <Foo as intercom::attributes::ComClass<
+                    Foo,
+                    intercom::type_system::RawTypeSystem,
+                >>::offset()) as *mut intercom::ComBoxData<Foo>;
         let self_struct: &Foo = &**self_combox;
         let __result = self_struct.tuple_result_method();
         Ok({
@@ -1055,8 +1248,11 @@ intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::Extern
         (||
              {
                  let self_combox =
-                     (self_vtable as usize - __Foo_Foo_RawVtbl_offset()) as
-                         *mut intercom::ComBoxData<Foo>;
+                     (self_vtable as usize -
+                          <Foo as
+                              intercom::attributes::ComClass<Foo,
+                                                             intercom::type_system::RawTypeSystem>>::offset())
+                         as *mut intercom::ComBoxData<Foo>;
                  let self_struct: &Foo = &**self_combox;
                  let __result =
                      self_struct.string_method((&<String as
@@ -1096,7 +1292,11 @@ unsafe extern "system" fn __Foo_Foo_Raw_string_result_method_Raw(
         intercom::ComError,
     > = (|| {
         let self_combox =
-            (self_vtable as usize - __Foo_Foo_RawVtbl_offset()) as *mut intercom::ComBoxData<Foo>;
+            (self_vtable as usize
+                - <Foo as intercom::attributes::ComClass<
+                    Foo,
+                    intercom::type_system::RawTypeSystem,
+                >>::offset()) as *mut intercom::ComBoxData<Foo>;
         let self_struct: &Foo = &**self_combox;
         let __result = self_struct.string_result_method(
             (&<String as intercom::type_system::ExternType<
@@ -1150,12 +1350,15 @@ unsafe extern "system" fn __Foo_Foo_Raw_complete_method_Raw(
             intercom::type_system::RawTypeSystem,
         >>::ExternOutputType,
         intercom::ComError,
-    > = (|| {
-        let self_combox =
-            (self_vtable as usize - __Foo_Foo_RawVtbl_offset()) as *mut intercom::ComBoxData<Foo>;
-        let self_struct: &mut Foo = &mut **self_combox;
-        let __result =
-            self_struct.complete_method(
+    > =
+        (|| {
+            let self_combox = (self_vtable as usize
+                - <Foo as intercom::attributes::ComClass<
+                    Foo,
+                    intercom::type_system::RawTypeSystem,
+                >>::offset()) as *mut intercom::ComBoxData<Foo>;
+            let self_struct: &mut Foo = &mut **self_combox;
+            let __result = self_struct.complete_method(
                 (&<u16 as intercom::type_system::ExternType<
                     intercom::type_system::RawTypeSystem,
                 >>::intercom_from(a)?)
@@ -1165,19 +1368,19 @@ unsafe extern "system" fn __Foo_Foo_Raw_complete_method_Raw(
                 >>::intercom_from(b)?)
                     .intercom_into()?,
             );
-        Ok({
-            match __result {
-                Ok(v1) => {
-                    *__out = v1.intercom_into()?;
-                    intercom::raw::S_OK
+            Ok({
+                match __result {
+                    Ok(v1) => {
+                        *__out = v1.intercom_into()?;
+                        intercom::raw::S_OK
+                    }
+                    Err(e) => {
+                        *__out = intercom::type_system::ExternDefault::extern_default();
+                        intercom::store_error(e).hresult
+                    }
                 }
-                Err(e) => {
-                    *__out = intercom::type_system::ExternDefault::extern_default();
-                    intercom::store_error(e).hresult
-                }
-            }
-        })
-    })();
+            })
+        })();
     use intercom::ErrorValue;
     match result {
         Ok(v) => v,
@@ -1208,30 +1411,33 @@ unsafe extern "system" fn __Foo_Foo_Raw_bool_method_Raw(
             intercom::type_system::RawTypeSystem,
         >>::ExternOutputType,
         intercom::ComError,
-    > = (|| {
-        let self_combox =
-            (self_vtable as usize - __Foo_Foo_RawVtbl_offset()) as *mut intercom::ComBoxData<Foo>;
-        let self_struct: &Foo = &**self_combox;
-        let __result =
-            self_struct.bool_method(
+    > =
+        (|| {
+            let self_combox = (self_vtable as usize
+                - <Foo as intercom::attributes::ComClass<
+                    Foo,
+                    intercom::type_system::RawTypeSystem,
+                >>::offset()) as *mut intercom::ComBoxData<Foo>;
+            let self_struct: &Foo = &**self_combox;
+            let __result = self_struct.bool_method(
                 (&<bool as intercom::type_system::ExternType<
                     intercom::type_system::RawTypeSystem,
                 >>::intercom_from(input)?)
                     .intercom_into()?,
             );
-        Ok({
-            match __result {
-                Ok(v1) => {
-                    *__out = v1.intercom_into()?;
-                    intercom::raw::S_OK
+            Ok({
+                match __result {
+                    Ok(v1) => {
+                        *__out = v1.intercom_into()?;
+                        intercom::raw::S_OK
+                    }
+                    Err(e) => {
+                        *__out = intercom::type_system::ExternDefault::extern_default();
+                        intercom::store_error(e).hresult
+                    }
                 }
-                Err(e) => {
-                    *__out = intercom::type_system::ExternDefault::extern_default();
-                    intercom::store_error(e).hresult
-                }
-            }
-        })
-    })();
+            })
+        })();
     use intercom::ErrorValue;
     match result {
         Ok(v) => v,
@@ -1264,7 +1470,11 @@ unsafe extern "system" fn __Foo_Foo_Raw_variant_method_Raw(
         intercom::ComError,
     > = (|| {
         let self_combox =
-            (self_vtable as usize - __Foo_Foo_RawVtbl_offset()) as *mut intercom::ComBoxData<Foo>;
+            (self_vtable as usize
+                - <Foo as intercom::attributes::ComClass<
+                    Foo,
+                    intercom::type_system::RawTypeSystem,
+                >>::offset()) as *mut intercom::ComBoxData<Foo>;
         let self_struct: &Foo = &**self_combox;
         let __result = self_struct.variant_method(
             (&<Variant as intercom::type_system::ExternType<
@@ -1296,22 +1506,37 @@ unsafe extern "system" fn __Foo_Foo_Raw_variant_method_Raw(
     }
 }
 #[allow(non_upper_case_globals)]
-const __Foo_Foo_RawVtbl_INSTANCE: __Foo_RawVtbl = __Foo_RawVtbl {
-    __base: intercom::IUnknownVtbl {
-        query_interface_Automation: __Foo_Foo_Raw_query_interface,
-        add_ref_Automation: __Foo_Foo_Raw_add_ref,
-        release_Automation: __Foo_Foo_Raw_release,
-    },
-    simple_method_Raw: __Foo_Foo_Raw_simple_method_Raw,
-    arg_method_Raw: __Foo_Foo_Raw_arg_method_Raw,
-    simple_result_method_Raw: __Foo_Foo_Raw_simple_result_method_Raw,
-    com_result_method_Raw: __Foo_Foo_Raw_com_result_method_Raw,
-    rust_result_method_Raw: __Foo_Foo_Raw_rust_result_method_Raw,
-    tuple_result_method_Raw: __Foo_Foo_Raw_tuple_result_method_Raw,
-    string_method_Raw: __Foo_Foo_Raw_string_method_Raw,
-    string_result_method_Raw: __Foo_Foo_Raw_string_result_method_Raw,
-    complete_method_Raw: __Foo_Foo_Raw_complete_method_Raw,
-    bool_method_Raw: __Foo_Foo_Raw_bool_method_Raw,
-    variant_method_Raw: __Foo_Foo_Raw_variant_method_Raw,
-};
+impl intercom::attributes::ComImpl<Foo, intercom::type_system::RawTypeSystem> for Foo {
+    fn vtable()
+     ->
+         &'static <Foo as
+intercom::attributes::ComInterface<intercom::type_system::RawTypeSystem>>::VTable{
+        type T = <Foo as intercom::attributes::ComInterface<
+            intercom::type_system::RawTypeSystem,
+        >>::VTable;
+        &T {
+            __base: {
+                type TVtbl = <dyn intercom::IUnknown as intercom::attributes::ComInterface<
+                    intercom::type_system::AutomationTypeSystem,
+                >>::VTable;
+                TVtbl {
+                    query_interface: __Foo_Foo_Raw_query_interface,
+                    add_ref: __Foo_Foo_Raw_add_ref,
+                    release: __Foo_Foo_Raw_release,
+                }
+            },
+            simple_method: __Foo_Foo_Raw_simple_method_Raw,
+            arg_method: __Foo_Foo_Raw_arg_method_Raw,
+            simple_result_method: __Foo_Foo_Raw_simple_result_method_Raw,
+            com_result_method: __Foo_Foo_Raw_com_result_method_Raw,
+            rust_result_method: __Foo_Foo_Raw_rust_result_method_Raw,
+            tuple_result_method: __Foo_Foo_Raw_tuple_result_method_Raw,
+            string_method: __Foo_Foo_Raw_string_method_Raw,
+            string_result_method: __Foo_Foo_Raw_string_result_method_Raw,
+            complete_method: __Foo_Foo_Raw_complete_method_Raw,
+            bool_method: __Foo_Foo_Raw_bool_method_Raw,
+            variant_method: __Foo_Foo_Raw_variant_method_Raw,
+        }
+    }
+}
 impl intercom::HasInterface<Foo> for Foo {}

--- a/intercom-attributes/tests/data/macro/com_interface.rs.stdout
+++ b/intercom-attributes/tests/data/macro/com_interface.rs.stdout
@@ -28,204 +28,169 @@ pub trait Foo {
 
     fn variant_method(&self, input: Variant) -> ComResult<Variant>;
 }
-#[doc = "`Foo` interface ID."]
-#[allow(non_upper_case_globals)]
-pub const IID_Foo_Automation: intercom::IID = intercom::GUID {
-    data1: 0u32,
-    data2: 0u16,
-    data3: 0u16,
-    data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8],
-};
 #[allow(non_camel_case_types)]
 #[allow(non_snake_case)]
 #[allow(clippy::all)]
 #[repr(C)]
 #[doc(hidden)]
-pub struct __Foo_AutomationVtbl {
-    pub __base: intercom::IUnknownVtbl,
-    pub simple_method_Automation: unsafe extern "system" fn(self_vtable:
-                                                                intercom::RawComPtr)
-                                      ->
-                                          <() as
-                                          intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
-    pub arg_method_Automation: unsafe extern "system" fn(self_vtable:
-                                                             intercom::RawComPtr,
-                                                         a:
-                                                             <u16 as
-                                                             intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType)
-                                   ->
-                                       <() as
-                                       intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
-    pub simple_result_method_Automation: unsafe extern "system" fn(self_vtable:
-                                                                       intercom::RawComPtr)
-                                             ->
-                                                 <u16 as
-                                                 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
-    pub com_result_method_Automation: unsafe extern "system" fn(self_vtable:
-                                                                    intercom::RawComPtr,
-                                                                __out:
-                                                                    *mut <u16
-                                                                         as
-                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
-                                          ->
-                                              <intercom::raw::HRESULT as
-                                              intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
-    pub rust_result_method_Automation: unsafe extern "system" fn(self_vtable:
-                                                                     intercom::RawComPtr,
-                                                                 __out:
-                                                                     *mut <u16
-                                                                          as
-                                                                          intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
-                                           ->
-                                               <intercom::raw::HRESULT as
-                                               intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
-    pub complete_method_Automation: unsafe extern "system" fn(self_vtable:
-                                                                  intercom::RawComPtr,
-                                                              a:
-                                                                  <u16 as
-                                                                  intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
-                                                              b:
-                                                                  <i16 as
-                                                                  intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
-                                                              __out:
-                                                                  *mut <bool
-                                                                       as
-                                                                       intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
-                                        ->
-                                            <intercom::raw::HRESULT as
-                                            intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
-    pub string_method_Automation: unsafe extern "system" fn(self_vtable:
-                                                                intercom::RawComPtr,
-                                                            msg:
-                                                                <String as
-                                                                intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType)
-                                      ->
-                                          <String as
-                                          intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
-    pub comitf_method_Automation: unsafe extern "system" fn(self_vtable:
-                                                                intercom::RawComPtr,
-                                                            itf:
-                                                                <ComItf<dyn Foo>
-                                                                as
-                                                                intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
-                                                            __out:
-                                                                *mut <ComItf<dyn IUnknown>
-                                                                     as
-                                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
-                                      ->
-                                          <intercom::raw::HRESULT as
-                                          intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
-    pub bool_method_Automation: unsafe extern "system" fn(self_vtable:
-                                                              intercom::RawComPtr,
-                                                          input:
-                                                              <bool as
-                                                              intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
-                                                          __out:
-                                                              *mut <bool as
-                                                                   intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
-                                    ->
-                                        <intercom::raw::HRESULT as
-                                        intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
-    pub variant_method_Automation: unsafe extern "system" fn(self_vtable:
-                                                                 intercom::RawComPtr,
-                                                             input:
-                                                                 <Variant as
-                                                                 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
-                                                             __out:
-                                                                 *mut <Variant
-                                                                      as
-                                                                      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
-                                       ->
-                                           <intercom::raw::HRESULT as
-                                           intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
-}
-#[doc = "`Foo` interface ID."]
-#[allow(non_upper_case_globals)]
-pub const IID_Foo_Raw: intercom::IID = intercom::GUID {
-    data1: 0u32,
-    data2: 0u16,
-    data3: 0u16,
-    data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8],
-};
-#[allow(non_camel_case_types)]
-#[allow(non_snake_case)]
-#[allow(clippy::all)]
-#[repr(C)]
-#[doc(hidden)]
-pub struct __Foo_RawVtbl {
-    pub __base: intercom::IUnknownVtbl,
-    pub simple_method_Raw: unsafe extern "system" fn(self_vtable:
-                                                         intercom::RawComPtr)
-                               ->
-                                   <() as
-                                   intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
-    pub arg_method_Raw: unsafe extern "system" fn(self_vtable:
-                                                      intercom::RawComPtr,
-                                                  a:
-                                                      <u16 as
-                                                      intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType)
-                            ->
-                                <() as
-                                intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
-    pub simple_result_method_Raw: unsafe extern "system" fn(self_vtable:
-                                                                intercom::RawComPtr)
-                                      ->
-                                          <u16 as
-                                          intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
-    pub com_result_method_Raw: unsafe extern "system" fn(self_vtable:
-                                                             intercom::RawComPtr,
-                                                         __out:
-                                                             *mut <u16 as
-                                                                  intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
-                                   ->
-                                       <intercom::raw::HRESULT as
-                                       intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
-    pub rust_result_method_Raw: unsafe extern "system" fn(self_vtable:
-                                                              intercom::RawComPtr,
-                                                          __out:
-                                                              *mut <u16 as
-                                                                   intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
-                                    ->
-                                        <intercom::raw::HRESULT as
-                                        intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
-    pub complete_method_Raw: unsafe extern "system" fn(self_vtable:
-                                                           intercom::RawComPtr,
-                                                       a:
-                                                           <u16 as
-                                                           intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
-                                                       b:
-                                                           <i16 as
-                                                           intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
-                                                       __out:
-                                                           *mut <bool as
-                                                                intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
-                                 ->
-                                     <intercom::raw::HRESULT as
-                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
-    pub string_method_Raw: unsafe extern "system" fn(self_vtable:
+pub struct __IntercomVtableForFoo_Automation {
+    pub __base: <dyn intercom::IUnknown as
+                intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::VTable,
+    pub simple_method: unsafe extern "system" fn(self_vtable:
+                                                     intercom::RawComPtr)
+                           ->
+                               <() as
+                               intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+    pub arg_method: unsafe extern "system" fn(self_vtable:
+                                                  intercom::RawComPtr,
+                                              a:
+                                                  <u16 as
+                                                  intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType)
+                        ->
+                            <() as
+                            intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+    pub simple_result_method: unsafe extern "system" fn(self_vtable:
+                                                            intercom::RawComPtr)
+                                  ->
+                                      <u16 as
+                                      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+    pub com_result_method: unsafe extern "system" fn(self_vtable:
                                                          intercom::RawComPtr,
-                                                     msg:
-                                                         <String as
-                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType)
-                               ->
-                                   <String as
-                                   intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
-    pub comitf_method_Raw: unsafe extern "system" fn(self_vtable:
-                                                         intercom::RawComPtr,
-                                                     itf:
-                                                         <ComItf<dyn Foo> as
-                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
                                                      __out:
-                                                         *mut <ComItf<dyn IUnknown>
-                                                              as
+                                                         *mut <u16 as
+                                                              intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
+                               ->
+                                   <intercom::raw::HRESULT as
+                                   intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+    pub rust_result_method: unsafe extern "system" fn(self_vtable:
+                                                          intercom::RawComPtr,
+                                                      __out:
+                                                          *mut <u16 as
+                                                               intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
+                                ->
+                                    <intercom::raw::HRESULT as
+                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+    pub complete_method: unsafe extern "system" fn(self_vtable:
+                                                       intercom::RawComPtr,
+                                                   a:
+                                                       <u16 as
+                                                       intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
+                                                   b:
+                                                       <i16 as
+                                                       intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
+                                                   __out:
+                                                       *mut <bool as
+                                                            intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
+                             ->
+                                 <intercom::raw::HRESULT as
+                                 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+    pub string_method: unsafe extern "system" fn(self_vtable:
+                                                     intercom::RawComPtr,
+                                                 msg:
+                                                     <String as
+                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType)
+                           ->
+                               <String as
+                               intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+    pub comitf_method: unsafe extern "system" fn(self_vtable:
+                                                     intercom::RawComPtr,
+                                                 itf:
+                                                     <ComItf<dyn Foo> as
+                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
+                                                 __out:
+                                                     *mut <ComItf<dyn IUnknown>
+                                                          as
+                                                          intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
+                           ->
+                               <intercom::raw::HRESULT as
+                               intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+    pub bool_method: unsafe extern "system" fn(self_vtable:
+                                                   intercom::RawComPtr,
+                                               input:
+                                                   <bool as
+                                                   intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
+                                               __out:
+                                                   *mut <bool as
+                                                        intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
+                         ->
+                             <intercom::raw::HRESULT as
+                             intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+    pub variant_method: unsafe extern "system" fn(self_vtable:
+                                                      intercom::RawComPtr,
+                                                  input:
+                                                      <Variant as
+                                                      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
+                                                  __out:
+                                                      *mut <Variant as
+                                                           intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
+                            ->
+                                <intercom::raw::HRESULT as
+                                intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+}
+#[allow(non_camel_case_types)]
+#[allow(non_snake_case)]
+#[allow(clippy::all)]
+#[doc(hidden)]
+impl intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem> for dyn Foo {
+    type VTable = __IntercomVtableForFoo_Automation;
+    fn iid() -> &'static intercom::IID {
+        &intercom::GUID {
+            data1: 0u32,
+            data2: 0u16,
+            data3: 0u16,
+            data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8],
+        }
+    }
+}
+#[allow(non_camel_case_types)]
+#[allow(non_snake_case)]
+#[allow(clippy::all)]
+#[repr(C)]
+#[doc(hidden)]
+pub struct __IntercomVtableForFoo_Raw {
+    pub __base: <dyn intercom::IUnknown as
+                intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::VTable,
+    pub simple_method: unsafe extern "system" fn(self_vtable:
+                                                     intercom::RawComPtr)
+                           ->
+                               <() as
+                               intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+    pub arg_method: unsafe extern "system" fn(self_vtable:
+                                                  intercom::RawComPtr,
+                                              a:
+                                                  <u16 as
+                                                  intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType)
+                        ->
+                            <() as
+                            intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+    pub simple_result_method: unsafe extern "system" fn(self_vtable:
+                                                            intercom::RawComPtr)
+                                  ->
+                                      <u16 as
+                                      intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
+    pub com_result_method: unsafe extern "system" fn(self_vtable:
+                                                         intercom::RawComPtr,
+                                                     __out:
+                                                         *mut <u16 as
                                                               intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
                                ->
                                    <intercom::raw::HRESULT as
                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
-    pub bool_method_Raw: unsafe extern "system" fn(self_vtable:
+    pub rust_result_method: unsafe extern "system" fn(self_vtable:
+                                                          intercom::RawComPtr,
+                                                      __out:
+                                                          *mut <u16 as
+                                                               intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
+                                ->
+                                    <intercom::raw::HRESULT as
+                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
+    pub complete_method: unsafe extern "system" fn(self_vtable:
                                                        intercom::RawComPtr,
-                                                   input:
-                                                       <bool as
+                                                   a:
+                                                       <u16 as
+                                                       intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
+                                                   b:
+                                                       <i16 as
                                                        intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
                                                    __out:
                                                        *mut <bool as
@@ -233,17 +198,63 @@ pub struct __Foo_RawVtbl {
                              ->
                                  <intercom::raw::HRESULT as
                                  intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
-    pub variant_method_Raw: unsafe extern "system" fn(self_vtable:
-                                                          intercom::RawComPtr,
-                                                      input:
-                                                          <Variant as
-                                                          intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
-                                                      __out:
-                                                          *mut <Variant as
-                                                               intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
-                                ->
-                                    <intercom::raw::HRESULT as
-                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
+    pub string_method: unsafe extern "system" fn(self_vtable:
+                                                     intercom::RawComPtr,
+                                                 msg:
+                                                     <String as
+                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType)
+                           ->
+                               <String as
+                               intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
+    pub comitf_method: unsafe extern "system" fn(self_vtable:
+                                                     intercom::RawComPtr,
+                                                 itf:
+                                                     <ComItf<dyn Foo> as
+                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
+                                                 __out:
+                                                     *mut <ComItf<dyn IUnknown>
+                                                          as
+                                                          intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
+                           ->
+                               <intercom::raw::HRESULT as
+                               intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
+    pub bool_method: unsafe extern "system" fn(self_vtable:
+                                                   intercom::RawComPtr,
+                                               input:
+                                                   <bool as
+                                                   intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
+                                               __out:
+                                                   *mut <bool as
+                                                        intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
+                         ->
+                             <intercom::raw::HRESULT as
+                             intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
+    pub variant_method: unsafe extern "system" fn(self_vtable:
+                                                      intercom::RawComPtr,
+                                                  input:
+                                                      <Variant as
+                                                      intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
+                                                  __out:
+                                                      *mut <Variant as
+                                                           intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
+                            ->
+                                <intercom::raw::HRESULT as
+                                intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
+}
+#[allow(non_camel_case_types)]
+#[allow(non_snake_case)]
+#[allow(clippy::all)]
+#[doc(hidden)]
+impl intercom::attributes::ComInterface<intercom::type_system::RawTypeSystem> for dyn Foo {
+    type VTable = __IntercomVtableForFoo_Raw;
+    fn iid() -> &'static intercom::IID {
+        &intercom::GUID {
+            data1: 0u32,
+            data2: 0u16,
+            data3: 0u16,
+            data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8],
+        }
+    }
 }
 #[allow(clippy::all)]
 impl Foo for intercom::ComItf<dyn Foo> {
@@ -255,10 +266,13 @@ impl Foo for intercom::ComItf<dyn Foo> {
         {
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
-            let vtbl = comptr.ptr as *const *const __Foo_AutomationVtbl;
+            let vtbl = comptr.ptr
+                as *const *const <dyn Foo as intercom::attributes::ComInterface<
+                    intercom::type_system::AutomationTypeSystem,
+                >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<(), intercom::ComError> = (|| unsafe {
-                let __result = ((**vtbl).arg_method_Automation)(
+                let __result = ((**vtbl).arg_method)(
                     comptr.ptr,
                     (&<u16 as intercom::type_system::ExternType<
                         intercom::type_system::AutomationTypeSystem,
@@ -283,10 +297,13 @@ impl Foo for intercom::ComItf<dyn Foo> {
         {
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
-            let vtbl = comptr.ptr as *const *const __Foo_RawVtbl;
+            let vtbl = comptr.ptr
+                as *const *const <dyn Foo as intercom::attributes::ComInterface<
+                    intercom::type_system::RawTypeSystem,
+                >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<(), intercom::ComError> = (|| unsafe {
-                let __result = ((**vtbl).arg_method_Raw)(
+                let __result = ((**vtbl).arg_method)(
                     comptr.ptr,
                     (&<u16 as intercom::type_system::ExternType<
                         intercom::type_system::RawTypeSystem,
@@ -316,13 +333,16 @@ impl Foo for intercom::ComItf<dyn Foo> {
         {
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
-            let vtbl = comptr.ptr as *const *const __Foo_AutomationVtbl;
+            let vtbl = comptr.ptr
+                as *const *const <dyn Foo as intercom::attributes::ComInterface<
+                    intercom::type_system::AutomationTypeSystem,
+                >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<ComResult<bool>, intercom::ComError> = (|| unsafe {
                 let mut __out: <bool as intercom::type_system::ExternType<
                     intercom::type_system::AutomationTypeSystem,
                 >>::ExternOutputType = intercom::type_system::ExternDefault::extern_default();
-                let __result = ((**vtbl).bool_method_Automation)(
+                let __result = ((**vtbl).bool_method)(
                     comptr.ptr,
                     (&<bool as intercom::type_system::ExternType<
                         intercom::type_system::AutomationTypeSystem,
@@ -358,13 +378,16 @@ impl Foo for intercom::ComItf<dyn Foo> {
         {
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
-            let vtbl = comptr.ptr as *const *const __Foo_RawVtbl;
+            let vtbl = comptr.ptr
+                as *const *const <dyn Foo as intercom::attributes::ComInterface<
+                    intercom::type_system::RawTypeSystem,
+                >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<ComResult<bool>, intercom::ComError> = (|| unsafe {
                 let mut __out: <bool as intercom::type_system::ExternType<
                     intercom::type_system::RawTypeSystem,
                 >>::ExternOutputType = intercom::type_system::ExternDefault::extern_default();
-                let __result = ((**vtbl).bool_method_Raw)(
+                let __result = ((**vtbl).bool_method)(
                     comptr.ptr,
                     (&<bool as intercom::type_system::ExternType<
                         intercom::type_system::RawTypeSystem,
@@ -407,13 +430,16 @@ impl Foo for intercom::ComItf<dyn Foo> {
         {
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
-            let vtbl = comptr.ptr as *const *const __Foo_AutomationVtbl;
+            let vtbl = comptr.ptr
+                as *const *const <dyn Foo as intercom::attributes::ComInterface<
+                    intercom::type_system::AutomationTypeSystem,
+                >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<ComResult<u16>, intercom::ComError> = (|| unsafe {
                 let mut __out: <u16 as intercom::type_system::ExternType<
                     intercom::type_system::AutomationTypeSystem,
                 >>::ExternOutputType = intercom::type_system::ExternDefault::extern_default();
-                let __result = ((**vtbl).com_result_method_Automation)(comptr.ptr, &mut __out);
+                let __result = ((**vtbl).com_result_method)(comptr.ptr, &mut __out);
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
                     data2: 0u16,
@@ -442,13 +468,16 @@ impl Foo for intercom::ComItf<dyn Foo> {
         {
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
-            let vtbl = comptr.ptr as *const *const __Foo_RawVtbl;
+            let vtbl = comptr.ptr
+                as *const *const <dyn Foo as intercom::attributes::ComInterface<
+                    intercom::type_system::RawTypeSystem,
+                >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<ComResult<u16>, intercom::ComError> = (|| unsafe {
                 let mut __out: <u16 as intercom::type_system::ExternType<
                     intercom::type_system::RawTypeSystem,
                 >>::ExternOutputType = intercom::type_system::ExternDefault::extern_default();
-                let __result = ((**vtbl).com_result_method_Raw)(comptr.ptr, &mut __out);
+                let __result = ((**vtbl).com_result_method)(comptr.ptr, &mut __out);
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
                     data2: 0u16,
@@ -484,7 +513,10 @@ impl Foo for intercom::ComItf<dyn Foo> {
         {
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
-            let vtbl = comptr.ptr as *const *const __Foo_AutomationVtbl;
+            let vtbl = comptr.ptr
+                as *const *const <dyn Foo as intercom::attributes::ComInterface<
+                    intercom::type_system::AutomationTypeSystem,
+                >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<
                 ComResult<ComItf<dyn IUnknown>>,
@@ -493,7 +525,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 let mut __out: <ComItf<dyn IUnknown> as intercom::type_system::ExternType<
                     intercom::type_system::AutomationTypeSystem,
                 >>::ExternOutputType = intercom::type_system::ExternDefault::extern_default();
-                let __result = ((**vtbl).comitf_method_Automation)(
+                let __result = ((**vtbl).comitf_method)(
                     comptr.ptr,
                     (&<ComItf<dyn Foo> as intercom::type_system::ExternType<
                         intercom::type_system::AutomationTypeSystem,
@@ -531,7 +563,10 @@ impl Foo for intercom::ComItf<dyn Foo> {
         {
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
-            let vtbl = comptr.ptr as *const *const __Foo_RawVtbl;
+            let vtbl = comptr.ptr
+                as *const *const <dyn Foo as intercom::attributes::ComInterface<
+                    intercom::type_system::RawTypeSystem,
+                >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<
                 ComResult<ComItf<dyn IUnknown>>,
@@ -540,7 +575,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 let mut __out: <ComItf<dyn IUnknown> as intercom::type_system::ExternType<
                     intercom::type_system::RawTypeSystem,
                 >>::ExternOutputType = intercom::type_system::ExternDefault::extern_default();
-                let __result = ((**vtbl).comitf_method_Raw)(
+                let __result = ((**vtbl).comitf_method)(
                     comptr.ptr,
                     (&<ComItf<dyn Foo> as intercom::type_system::ExternType<
                         intercom::type_system::RawTypeSystem,
@@ -585,13 +620,16 @@ impl Foo for intercom::ComItf<dyn Foo> {
         {
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
-            let vtbl = comptr.ptr as *const *const __Foo_AutomationVtbl;
+            let vtbl = comptr.ptr
+                as *const *const <dyn Foo as intercom::attributes::ComInterface<
+                    intercom::type_system::AutomationTypeSystem,
+                >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<ComResult<bool>, intercom::ComError> = (|| unsafe {
                 let mut __out: <bool as intercom::type_system::ExternType<
                     intercom::type_system::AutomationTypeSystem,
                 >>::ExternOutputType = intercom::type_system::ExternDefault::extern_default();
-                let __result = ((**vtbl).complete_method_Automation)(
+                let __result = ((**vtbl).complete_method)(
                     comptr.ptr,
                     (&<u16 as intercom::type_system::ExternType<
                         intercom::type_system::AutomationTypeSystem,
@@ -631,13 +669,16 @@ impl Foo for intercom::ComItf<dyn Foo> {
         {
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
-            let vtbl = comptr.ptr as *const *const __Foo_RawVtbl;
+            let vtbl = comptr.ptr
+                as *const *const <dyn Foo as intercom::attributes::ComInterface<
+                    intercom::type_system::RawTypeSystem,
+                >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<ComResult<bool>, intercom::ComError> = (|| unsafe {
                 let mut __out: <bool as intercom::type_system::ExternType<
                     intercom::type_system::RawTypeSystem,
                 >>::ExternOutputType = intercom::type_system::ExternDefault::extern_default();
-                let __result = ((**vtbl).complete_method_Raw)(
+                let __result = ((**vtbl).complete_method)(
                     comptr.ptr,
                     (&<u16 as intercom::type_system::ExternType<
                         intercom::type_system::RawTypeSystem,
@@ -684,13 +725,16 @@ impl Foo for intercom::ComItf<dyn Foo> {
         {
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
-            let vtbl = comptr.ptr as *const *const __Foo_AutomationVtbl;
+            let vtbl = comptr.ptr
+                as *const *const <dyn Foo as intercom::attributes::ComInterface<
+                    intercom::type_system::AutomationTypeSystem,
+                >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<Result<u16, i32>, intercom::ComError> = (|| unsafe {
                 let mut __out: <u16 as intercom::type_system::ExternType<
                     intercom::type_system::AutomationTypeSystem,
                 >>::ExternOutputType = intercom::type_system::ExternDefault::extern_default();
-                let __result = ((**vtbl).rust_result_method_Automation)(comptr.ptr, &mut __out);
+                let __result = ((**vtbl).rust_result_method)(comptr.ptr, &mut __out);
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
                     data2: 0u16,
@@ -719,13 +763,16 @@ impl Foo for intercom::ComItf<dyn Foo> {
         {
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
-            let vtbl = comptr.ptr as *const *const __Foo_RawVtbl;
+            let vtbl = comptr.ptr
+                as *const *const <dyn Foo as intercom::attributes::ComInterface<
+                    intercom::type_system::RawTypeSystem,
+                >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<Result<u16, i32>, intercom::ComError> = (|| unsafe {
                 let mut __out: <u16 as intercom::type_system::ExternType<
                     intercom::type_system::RawTypeSystem,
                 >>::ExternOutputType = intercom::type_system::ExternDefault::extern_default();
-                let __result = ((**vtbl).rust_result_method_Raw)(comptr.ptr, &mut __out);
+                let __result = ((**vtbl).rust_result_method)(comptr.ptr, &mut __out);
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
                     data2: 0u16,
@@ -761,10 +808,13 @@ impl Foo for intercom::ComItf<dyn Foo> {
         {
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
-            let vtbl = comptr.ptr as *const *const __Foo_AutomationVtbl;
+            let vtbl = comptr.ptr
+                as *const *const <dyn Foo as intercom::attributes::ComInterface<
+                    intercom::type_system::AutomationTypeSystem,
+                >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<(), intercom::ComError> = (|| unsafe {
-                let __result = ((**vtbl).simple_method_Automation)(comptr.ptr);
+                let __result = ((**vtbl).simple_method)(comptr.ptr);
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
                     data2: 0u16,
@@ -783,10 +833,13 @@ impl Foo for intercom::ComItf<dyn Foo> {
         {
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
-            let vtbl = comptr.ptr as *const *const __Foo_RawVtbl;
+            let vtbl = comptr.ptr
+                as *const *const <dyn Foo as intercom::attributes::ComInterface<
+                    intercom::type_system::RawTypeSystem,
+                >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<(), intercom::ComError> = (|| unsafe {
-                let __result = ((**vtbl).simple_method_Raw)(comptr.ptr);
+                let __result = ((**vtbl).simple_method)(comptr.ptr);
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
                     data2: 0u16,
@@ -810,10 +863,13 @@ impl Foo for intercom::ComItf<dyn Foo> {
         {
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
-            let vtbl = comptr.ptr as *const *const __Foo_AutomationVtbl;
+            let vtbl = comptr.ptr
+                as *const *const <dyn Foo as intercom::attributes::ComInterface<
+                    intercom::type_system::AutomationTypeSystem,
+                >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<u16, intercom::ComError> = (|| unsafe {
-                let __result = ((**vtbl).simple_result_method_Automation)(comptr.ptr);
+                let __result = ((**vtbl).simple_result_method)(comptr.ptr);
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
                     data2: 0u16,
@@ -832,10 +888,13 @@ impl Foo for intercom::ComItf<dyn Foo> {
         {
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
-            let vtbl = comptr.ptr as *const *const __Foo_RawVtbl;
+            let vtbl = comptr.ptr
+                as *const *const <dyn Foo as intercom::attributes::ComInterface<
+                    intercom::type_system::RawTypeSystem,
+                >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<u16, intercom::ComError> = (|| unsafe {
-                let __result = ((**vtbl).simple_result_method_Raw)(comptr.ptr);
+                let __result = ((**vtbl).simple_result_method)(comptr.ptr);
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
                     data2: 0u16,
@@ -859,10 +918,13 @@ impl Foo for intercom::ComItf<dyn Foo> {
         {
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
-            let vtbl = comptr.ptr as *const *const __Foo_AutomationVtbl;
+            let vtbl = comptr.ptr
+                as *const *const <dyn Foo as intercom::attributes::ComInterface<
+                    intercom::type_system::AutomationTypeSystem,
+                >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<String, intercom::ComError> = (|| unsafe {
-                let __result = ((**vtbl).string_method_Automation)(
+                let __result = ((**vtbl).string_method)(
                     comptr.ptr,
                     (&<String as intercom::type_system::ExternType<
                         intercom::type_system::AutomationTypeSystem,
@@ -887,10 +949,13 @@ impl Foo for intercom::ComItf<dyn Foo> {
         {
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
-            let vtbl = comptr.ptr as *const *const __Foo_RawVtbl;
+            let vtbl = comptr.ptr
+                as *const *const <dyn Foo as intercom::attributes::ComInterface<
+                    intercom::type_system::RawTypeSystem,
+                >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<String, intercom::ComError> = (|| unsafe {
-                let __result = ((**vtbl).string_method_Raw)(
+                let __result = ((**vtbl).string_method)(
                     comptr.ptr,
                     (&<String as intercom::type_system::ExternType<
                         intercom::type_system::RawTypeSystem,
@@ -920,13 +985,16 @@ impl Foo for intercom::ComItf<dyn Foo> {
         {
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
-            let vtbl = comptr.ptr as *const *const __Foo_AutomationVtbl;
+            let vtbl = comptr.ptr
+                as *const *const <dyn Foo as intercom::attributes::ComInterface<
+                    intercom::type_system::AutomationTypeSystem,
+                >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<ComResult<Variant>, intercom::ComError> = (|| unsafe {
                 let mut __out: <Variant as intercom::type_system::ExternType<
                     intercom::type_system::AutomationTypeSystem,
                 >>::ExternOutputType = intercom::type_system::ExternDefault::extern_default();
-                let __result = ((**vtbl).variant_method_Automation)(
+                let __result = ((**vtbl).variant_method)(
                     comptr.ptr,
                     (&<Variant as intercom::type_system::ExternType<
                         intercom::type_system::AutomationTypeSystem,
@@ -963,13 +1031,16 @@ impl Foo for intercom::ComItf<dyn Foo> {
         {
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
-            let vtbl = comptr.ptr as *const *const __Foo_RawVtbl;
+            let vtbl = comptr.ptr
+                as *const *const <dyn Foo as intercom::attributes::ComInterface<
+                    intercom::type_system::RawTypeSystem,
+                >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<ComResult<Variant>, intercom::ComError> = (|| unsafe {
                 let mut __out: <Variant as intercom::type_system::ExternType<
                     intercom::type_system::RawTypeSystem,
                 >>::ExternOutputType = intercom::type_system::ExternDefault::extern_default();
-                let __result = ((**vtbl).variant_method_Raw)(
+                let __result = ((**vtbl).variant_method)(
                     comptr.ptr,
                     (&<Variant as intercom::type_system::ExternType<
                         intercom::type_system::RawTypeSystem,
@@ -1008,10 +1079,24 @@ impl Foo for intercom::ComItf<dyn Foo> {
 }
 impl intercom::ComInterface for dyn Foo {
     #[doc = "Returns the IID of the requested interface."]
+    fn iid_ts<TS: intercom::type_system::TypeSystem>() -> &'static intercom::IID
+    where
+        Self: intercom::attributes::ComInterface<TS>,
+    {
+        <Self as intercom::attributes::ComInterface<TS>>::iid()
+    }
     fn iid(ts: intercom::type_system::TypeSystemName) -> Option<&'static intercom::IID> {
         match ts {
-            intercom::type_system::TypeSystemName::Automation => Some(&IID_Foo_Automation),
-            intercom::type_system::TypeSystemName::Raw => Some(&IID_Foo_Raw),
+            intercom::type_system::TypeSystemName::Automation => {
+                Some(<Self as intercom::attributes::ComInterface<
+                    intercom::type_system::AutomationTypeSystem,
+                >>::iid())
+            }
+            intercom::type_system::TypeSystemName::Raw => {
+                Some(<Self as intercom::attributes::ComInterface<
+                    intercom::type_system::RawTypeSystem,
+                >>::iid())
+            }
         }
     }
     fn deref(com_itf: &intercom::ComItf<dyn Foo>) -> &(dyn Foo + 'static) {
@@ -1026,863 +1111,867 @@ impl intercom::type_system::BidirectionalTypeInfo for dyn Foo {
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]
-pub(crate) fn get_intercom_interface_info_for_Foo() -> intercom::typelib::TypeInfo {
-    let variants =
-        <[_]>::into_vec(box
-                            [intercom::ComBox::new(intercom::typelib::InterfaceVariant{ts:
-                                                                                           intercom::type_system::TypeSystemName::Automation,
-                                                                                       iid:
-                                                                                           intercom::GUID{data1:
-                                                                                                              0u32,
-                                                                                                          data2:
-                                                                                                              0u16,
-                                                                                                          data3:
-                                                                                                              0u16,
-                                                                                                          data4:
-                                                                                                              [0u8,
-                                                                                                               0u8,
-                                                                                                               0u8,
-                                                                                                               0u8,
-                                                                                                               0u8,
-                                                                                                               0u8,
-                                                                                                               0u8,
-                                                                                                               0u8],},
-                                                                                       methods:
-                                                                                           <[_]>::into_vec(box
-                                                                                                               [intercom::ComBox::new(intercom::typelib::Method{name:
-                                                                                                                                                                    "simple_method".into(),
-                                                                                                                                                                return_type:
-                                                                                                                                                                    intercom::typelib::Arg{name:
-                                                                                                                                                                                               "".into(),
-                                                                                                                                                                                           ty:
-                                                                                                                                                                                               "void".into(),
-                                                                                                                                                                                           indirection_level:
-                                                                                                                                                                                               0,
-                                                                                                                                                                                           direction:
-                                                                                                                                                                                               intercom::typelib::Direction::Return,},
-                                                                                                                                                                parameters:
-                                                                                                                                                                    <[_]>::into_vec(box
-                                                                                                                                                                                        []),}),
-                                                                                                                intercom::ComBox::new(intercom::typelib::Method{name:
-                                                                                                                                                                    "arg_method".into(),
-                                                                                                                                                                return_type:
-                                                                                                                                                                    intercom::typelib::Arg{name:
-                                                                                                                                                                                               "".into(),
-                                                                                                                                                                                           ty:
-                                                                                                                                                                                               "void".into(),
-                                                                                                                                                                                           indirection_level:
-                                                                                                                                                                                               0,
-                                                                                                                                                                                           direction:
-                                                                                                                                                                                               intercom::typelib::Direction::Return,},
-                                                                                                                                                                parameters:
-                                                                                                                                                                    <[_]>::into_vec(box
-                                                                                                                                                                                        [intercom::typelib::Arg{name:
-                                                                                                                                                                                                                    "a".into(),
-                                                                                                                                                                                                                ty:
-                                                                                                                                                                                                                    <<u16
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::InputTypeInfo>::type_name().into(),
-                                                                                                                                                                                                                indirection_level:
-                                                                                                                                                                                                                    <<u16
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::InputTypeInfo>::indirection_level(),
-                                                                                                                                                                                                                direction:
-                                                                                                                                                                                                                    intercom::typelib::Direction::In,}]),}),
-                                                                                                                intercom::ComBox::new(intercom::typelib::Method{name:
-                                                                                                                                                                    "simple_result_method".into(),
-                                                                                                                                                                return_type:
-                                                                                                                                                                    intercom::typelib::Arg{name:
-                                                                                                                                                                                               "".into(),
-                                                                                                                                                                                           ty:
-                                                                                                                                                                                               <<u16
-                                                                                                                                                                                                as
-                                                                                                                                                                                                intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                   as
-                                                                                                                                                                                                   intercom::type_system::OutputTypeInfo>::type_name().into(),
-                                                                                                                                                                                           indirection_level:
-                                                                                                                                                                                               <<u16
-                                                                                                                                                                                                as
-                                                                                                                                                                                                intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                   as
-                                                                                                                                                                                                   intercom::type_system::OutputTypeInfo>::indirection_level(),
-                                                                                                                                                                                           direction:
-                                                                                                                                                                                               intercom::typelib::Direction::Return,},
-                                                                                                                                                                parameters:
-                                                                                                                                                                    <[_]>::into_vec(box
-                                                                                                                                                                                        []),}),
-                                                                                                                intercom::ComBox::new(intercom::typelib::Method{name:
-                                                                                                                                                                    "com_result_method".into(),
-                                                                                                                                                                return_type:
-                                                                                                                                                                    intercom::typelib::Arg{name:
-                                                                                                                                                                                               "".into(),
-                                                                                                                                                                                           ty:
-                                                                                                                                                                                               <<intercom::raw::HRESULT
-                                                                                                                                                                                                as
-                                                                                                                                                                                                intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                   as
-                                                                                                                                                                                                   intercom::type_system::OutputTypeInfo>::type_name().into(),
-                                                                                                                                                                                           indirection_level:
-                                                                                                                                                                                               <<intercom::raw::HRESULT
-                                                                                                                                                                                                as
-                                                                                                                                                                                                intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                   as
-                                                                                                                                                                                                   intercom::type_system::OutputTypeInfo>::indirection_level(),
-                                                                                                                                                                                           direction:
-                                                                                                                                                                                               intercom::typelib::Direction::Return,},
-                                                                                                                                                                parameters:
-                                                                                                                                                                    <[_]>::into_vec(box
-                                                                                                                                                                                        [intercom::typelib::Arg{name:
-                                                                                                                                                                                                                    "__out".into(),
-                                                                                                                                                                                                                ty:
-                                                                                                                                                                                                                    <<u16
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::OutputTypeInfo>::type_name().into(),
-                                                                                                                                                                                                                indirection_level:
-                                                                                                                                                                                                                    <<u16
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::OutputTypeInfo>::indirection_level(),
-                                                                                                                                                                                                                direction:
-                                                                                                                                                                                                                    intercom::typelib::Direction::Retval,}]),}),
-                                                                                                                intercom::ComBox::new(intercom::typelib::Method{name:
-                                                                                                                                                                    "rust_result_method".into(),
-                                                                                                                                                                return_type:
-                                                                                                                                                                    intercom::typelib::Arg{name:
-                                                                                                                                                                                               "".into(),
-                                                                                                                                                                                           ty:
-                                                                                                                                                                                               <<i32
-                                                                                                                                                                                                as
-                                                                                                                                                                                                intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                   as
-                                                                                                                                                                                                   intercom::type_system::OutputTypeInfo>::type_name().into(),
-                                                                                                                                                                                           indirection_level:
-                                                                                                                                                                                               <<i32
-                                                                                                                                                                                                as
-                                                                                                                                                                                                intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                   as
-                                                                                                                                                                                                   intercom::type_system::OutputTypeInfo>::indirection_level(),
-                                                                                                                                                                                           direction:
-                                                                                                                                                                                               intercom::typelib::Direction::Return,},
-                                                                                                                                                                parameters:
-                                                                                                                                                                    <[_]>::into_vec(box
-                                                                                                                                                                                        [intercom::typelib::Arg{name:
-                                                                                                                                                                                                                    "__out".into(),
-                                                                                                                                                                                                                ty:
-                                                                                                                                                                                                                    <<u16
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::OutputTypeInfo>::type_name().into(),
-                                                                                                                                                                                                                indirection_level:
-                                                                                                                                                                                                                    <<u16
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::OutputTypeInfo>::indirection_level(),
-                                                                                                                                                                                                                direction:
-                                                                                                                                                                                                                    intercom::typelib::Direction::Retval,}]),}),
-                                                                                                                intercom::ComBox::new(intercom::typelib::Method{name:
-                                                                                                                                                                    "complete_method".into(),
-                                                                                                                                                                return_type:
-                                                                                                                                                                    intercom::typelib::Arg{name:
-                                                                                                                                                                                               "".into(),
-                                                                                                                                                                                           ty:
-                                                                                                                                                                                               <<intercom::raw::HRESULT
-                                                                                                                                                                                                as
-                                                                                                                                                                                                intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                   as
-                                                                                                                                                                                                   intercom::type_system::OutputTypeInfo>::type_name().into(),
-                                                                                                                                                                                           indirection_level:
-                                                                                                                                                                                               <<intercom::raw::HRESULT
-                                                                                                                                                                                                as
-                                                                                                                                                                                                intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                   as
-                                                                                                                                                                                                   intercom::type_system::OutputTypeInfo>::indirection_level(),
-                                                                                                                                                                                           direction:
-                                                                                                                                                                                               intercom::typelib::Direction::Return,},
-                                                                                                                                                                parameters:
-                                                                                                                                                                    <[_]>::into_vec(box
-                                                                                                                                                                                        [intercom::typelib::Arg{name:
-                                                                                                                                                                                                                    "a".into(),
-                                                                                                                                                                                                                ty:
-                                                                                                                                                                                                                    <<u16
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::InputTypeInfo>::type_name().into(),
-                                                                                                                                                                                                                indirection_level:
-                                                                                                                                                                                                                    <<u16
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::InputTypeInfo>::indirection_level(),
-                                                                                                                                                                                                                direction:
-                                                                                                                                                                                                                    intercom::typelib::Direction::In,},
-                                                                                                                                                                                         intercom::typelib::Arg{name:
-                                                                                                                                                                                                                    "b".into(),
-                                                                                                                                                                                                                ty:
-                                                                                                                                                                                                                    <<i16
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::InputTypeInfo>::type_name().into(),
-                                                                                                                                                                                                                indirection_level:
-                                                                                                                                                                                                                    <<i16
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::InputTypeInfo>::indirection_level(),
-                                                                                                                                                                                                                direction:
-                                                                                                                                                                                                                    intercom::typelib::Direction::In,},
-                                                                                                                                                                                         intercom::typelib::Arg{name:
-                                                                                                                                                                                                                    "__out".into(),
-                                                                                                                                                                                                                ty:
-                                                                                                                                                                                                                    <<bool
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::OutputTypeInfo>::type_name().into(),
-                                                                                                                                                                                                                indirection_level:
-                                                                                                                                                                                                                    <<bool
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::OutputTypeInfo>::indirection_level(),
-                                                                                                                                                                                                                direction:
-                                                                                                                                                                                                                    intercom::typelib::Direction::Retval,}]),}),
-                                                                                                                intercom::ComBox::new(intercom::typelib::Method{name:
-                                                                                                                                                                    "string_method".into(),
-                                                                                                                                                                return_type:
-                                                                                                                                                                    intercom::typelib::Arg{name:
-                                                                                                                                                                                               "".into(),
-                                                                                                                                                                                           ty:
-                                                                                                                                                                                               <<String
-                                                                                                                                                                                                as
-                                                                                                                                                                                                intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                   as
-                                                                                                                                                                                                   intercom::type_system::OutputTypeInfo>::type_name().into(),
-                                                                                                                                                                                           indirection_level:
-                                                                                                                                                                                               <<String
-                                                                                                                                                                                                as
-                                                                                                                                                                                                intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                   as
-                                                                                                                                                                                                   intercom::type_system::OutputTypeInfo>::indirection_level(),
-                                                                                                                                                                                           direction:
-                                                                                                                                                                                               intercom::typelib::Direction::Return,},
-                                                                                                                                                                parameters:
-                                                                                                                                                                    <[_]>::into_vec(box
-                                                                                                                                                                                        [intercom::typelib::Arg{name:
-                                                                                                                                                                                                                    "msg".into(),
-                                                                                                                                                                                                                ty:
-                                                                                                                                                                                                                    <<String
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::InputTypeInfo>::type_name().into(),
-                                                                                                                                                                                                                indirection_level:
-                                                                                                                                                                                                                    <<String
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::InputTypeInfo>::indirection_level(),
-                                                                                                                                                                                                                direction:
-                                                                                                                                                                                                                    intercom::typelib::Direction::In,}]),}),
-                                                                                                                intercom::ComBox::new(intercom::typelib::Method{name:
-                                                                                                                                                                    "comitf_method".into(),
-                                                                                                                                                                return_type:
-                                                                                                                                                                    intercom::typelib::Arg{name:
-                                                                                                                                                                                               "".into(),
-                                                                                                                                                                                           ty:
-                                                                                                                                                                                               <<intercom::raw::HRESULT
-                                                                                                                                                                                                as
-                                                                                                                                                                                                intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                   as
-                                                                                                                                                                                                   intercom::type_system::OutputTypeInfo>::type_name().into(),
-                                                                                                                                                                                           indirection_level:
-                                                                                                                                                                                               <<intercom::raw::HRESULT
-                                                                                                                                                                                                as
-                                                                                                                                                                                                intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                   as
-                                                                                                                                                                                                   intercom::type_system::OutputTypeInfo>::indirection_level(),
-                                                                                                                                                                                           direction:
-                                                                                                                                                                                               intercom::typelib::Direction::Return,},
-                                                                                                                                                                parameters:
-                                                                                                                                                                    <[_]>::into_vec(box
-                                                                                                                                                                                        [intercom::typelib::Arg{name:
-                                                                                                                                                                                                                    "itf".into(),
-                                                                                                                                                                                                                ty:
-                                                                                                                                                                                                                    <<ComItf<dyn Foo>
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::InputTypeInfo>::type_name().into(),
-                                                                                                                                                                                                                indirection_level:
-                                                                                                                                                                                                                    <<ComItf<dyn Foo>
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::InputTypeInfo>::indirection_level(),
-                                                                                                                                                                                                                direction:
-                                                                                                                                                                                                                    intercom::typelib::Direction::In,},
-                                                                                                                                                                                         intercom::typelib::Arg{name:
-                                                                                                                                                                                                                    "__out".into(),
-                                                                                                                                                                                                                ty:
-                                                                                                                                                                                                                    <<ComItf<dyn IUnknown>
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::OutputTypeInfo>::type_name().into(),
-                                                                                                                                                                                                                indirection_level:
-                                                                                                                                                                                                                    <<ComItf<dyn IUnknown>
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::OutputTypeInfo>::indirection_level(),
-                                                                                                                                                                                                                direction:
-                                                                                                                                                                                                                    intercom::typelib::Direction::Retval,}]),}),
-                                                                                                                intercom::ComBox::new(intercom::typelib::Method{name:
-                                                                                                                                                                    "bool_method".into(),
-                                                                                                                                                                return_type:
-                                                                                                                                                                    intercom::typelib::Arg{name:
-                                                                                                                                                                                               "".into(),
-                                                                                                                                                                                           ty:
-                                                                                                                                                                                               <<intercom::raw::HRESULT
-                                                                                                                                                                                                as
-                                                                                                                                                                                                intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                   as
-                                                                                                                                                                                                   intercom::type_system::OutputTypeInfo>::type_name().into(),
-                                                                                                                                                                                           indirection_level:
-                                                                                                                                                                                               <<intercom::raw::HRESULT
-                                                                                                                                                                                                as
-                                                                                                                                                                                                intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                   as
-                                                                                                                                                                                                   intercom::type_system::OutputTypeInfo>::indirection_level(),
-                                                                                                                                                                                           direction:
-                                                                                                                                                                                               intercom::typelib::Direction::Return,},
-                                                                                                                                                                parameters:
-                                                                                                                                                                    <[_]>::into_vec(box
-                                                                                                                                                                                        [intercom::typelib::Arg{name:
-                                                                                                                                                                                                                    "input".into(),
-                                                                                                                                                                                                                ty:
-                                                                                                                                                                                                                    <<bool
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::InputTypeInfo>::type_name().into(),
-                                                                                                                                                                                                                indirection_level:
-                                                                                                                                                                                                                    <<bool
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::InputTypeInfo>::indirection_level(),
-                                                                                                                                                                                                                direction:
-                                                                                                                                                                                                                    intercom::typelib::Direction::In,},
-                                                                                                                                                                                         intercom::typelib::Arg{name:
-                                                                                                                                                                                                                    "__out".into(),
-                                                                                                                                                                                                                ty:
-                                                                                                                                                                                                                    <<bool
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::OutputTypeInfo>::type_name().into(),
-                                                                                                                                                                                                                indirection_level:
-                                                                                                                                                                                                                    <<bool
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::OutputTypeInfo>::indirection_level(),
-                                                                                                                                                                                                                direction:
-                                                                                                                                                                                                                    intercom::typelib::Direction::Retval,}]),}),
-                                                                                                                intercom::ComBox::new(intercom::typelib::Method{name:
-                                                                                                                                                                    "variant_method".into(),
-                                                                                                                                                                return_type:
-                                                                                                                                                                    intercom::typelib::Arg{name:
-                                                                                                                                                                                               "".into(),
-                                                                                                                                                                                           ty:
-                                                                                                                                                                                               <<intercom::raw::HRESULT
-                                                                                                                                                                                                as
-                                                                                                                                                                                                intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                   as
-                                                                                                                                                                                                   intercom::type_system::OutputTypeInfo>::type_name().into(),
-                                                                                                                                                                                           indirection_level:
-                                                                                                                                                                                               <<intercom::raw::HRESULT
-                                                                                                                                                                                                as
-                                                                                                                                                                                                intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                   as
-                                                                                                                                                                                                   intercom::type_system::OutputTypeInfo>::indirection_level(),
-                                                                                                                                                                                           direction:
-                                                                                                                                                                                               intercom::typelib::Direction::Return,},
-                                                                                                                                                                parameters:
-                                                                                                                                                                    <[_]>::into_vec(box
-                                                                                                                                                                                        [intercom::typelib::Arg{name:
-                                                                                                                                                                                                                    "input".into(),
-                                                                                                                                                                                                                ty:
-                                                                                                                                                                                                                    <<Variant
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::InputTypeInfo>::type_name().into(),
-                                                                                                                                                                                                                indirection_level:
-                                                                                                                                                                                                                    <<Variant
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::InputTypeInfo>::indirection_level(),
-                                                                                                                                                                                                                direction:
-                                                                                                                                                                                                                    intercom::typelib::Direction::In,},
-                                                                                                                                                                                         intercom::typelib::Arg{name:
-                                                                                                                                                                                                                    "__out".into(),
-                                                                                                                                                                                                                ty:
-                                                                                                                                                                                                                    <<Variant
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::OutputTypeInfo>::type_name().into(),
-                                                                                                                                                                                                                indirection_level:
-                                                                                                                                                                                                                    <<Variant
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::OutputTypeInfo>::indirection_level(),
-                                                                                                                                                                                                                direction:
-                                                                                                                                                                                                                    intercom::typelib::Direction::Retval,}]),})]),}),
-                             intercom::ComBox::new(intercom::typelib::InterfaceVariant{ts:
-                                                                                           intercom::type_system::TypeSystemName::Raw,
-                                                                                       iid:
-                                                                                           intercom::GUID{data1:
-                                                                                                              0u32,
-                                                                                                          data2:
-                                                                                                              0u16,
-                                                                                                          data3:
-                                                                                                              0u16,
-                                                                                                          data4:
-                                                                                                              [0u8,
-                                                                                                               0u8,
-                                                                                                               0u8,
-                                                                                                               0u8,
-                                                                                                               0u8,
-                                                                                                               0u8,
-                                                                                                               0u8,
-                                                                                                               1u8],},
-                                                                                       methods:
-                                                                                           <[_]>::into_vec(box
-                                                                                                               [intercom::ComBox::new(intercom::typelib::Method{name:
-                                                                                                                                                                    "simple_method".into(),
-                                                                                                                                                                return_type:
-                                                                                                                                                                    intercom::typelib::Arg{name:
-                                                                                                                                                                                               "".into(),
-                                                                                                                                                                                           ty:
-                                                                                                                                                                                               "void".into(),
-                                                                                                                                                                                           indirection_level:
-                                                                                                                                                                                               0,
-                                                                                                                                                                                           direction:
-                                                                                                                                                                                               intercom::typelib::Direction::Return,},
-                                                                                                                                                                parameters:
-                                                                                                                                                                    <[_]>::into_vec(box
-                                                                                                                                                                                        []),}),
-                                                                                                                intercom::ComBox::new(intercom::typelib::Method{name:
-                                                                                                                                                                    "arg_method".into(),
-                                                                                                                                                                return_type:
-                                                                                                                                                                    intercom::typelib::Arg{name:
-                                                                                                                                                                                               "".into(),
-                                                                                                                                                                                           ty:
-                                                                                                                                                                                               "void".into(),
-                                                                                                                                                                                           indirection_level:
-                                                                                                                                                                                               0,
-                                                                                                                                                                                           direction:
-                                                                                                                                                                                               intercom::typelib::Direction::Return,},
-                                                                                                                                                                parameters:
-                                                                                                                                                                    <[_]>::into_vec(box
-                                                                                                                                                                                        [intercom::typelib::Arg{name:
-                                                                                                                                                                                                                    "a".into(),
-                                                                                                                                                                                                                ty:
-                                                                                                                                                                                                                    <<u16
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::InputTypeInfo>::type_name().into(),
-                                                                                                                                                                                                                indirection_level:
-                                                                                                                                                                                                                    <<u16
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::InputTypeInfo>::indirection_level(),
-                                                                                                                                                                                                                direction:
-                                                                                                                                                                                                                    intercom::typelib::Direction::In,}]),}),
-                                                                                                                intercom::ComBox::new(intercom::typelib::Method{name:
-                                                                                                                                                                    "simple_result_method".into(),
-                                                                                                                                                                return_type:
-                                                                                                                                                                    intercom::typelib::Arg{name:
-                                                                                                                                                                                               "".into(),
-                                                                                                                                                                                           ty:
-                                                                                                                                                                                               <<u16
-                                                                                                                                                                                                as
-                                                                                                                                                                                                intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                   as
-                                                                                                                                                                                                   intercom::type_system::OutputTypeInfo>::type_name().into(),
-                                                                                                                                                                                           indirection_level:
-                                                                                                                                                                                               <<u16
-                                                                                                                                                                                                as
-                                                                                                                                                                                                intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                   as
-                                                                                                                                                                                                   intercom::type_system::OutputTypeInfo>::indirection_level(),
-                                                                                                                                                                                           direction:
-                                                                                                                                                                                               intercom::typelib::Direction::Return,},
-                                                                                                                                                                parameters:
-                                                                                                                                                                    <[_]>::into_vec(box
-                                                                                                                                                                                        []),}),
-                                                                                                                intercom::ComBox::new(intercom::typelib::Method{name:
-                                                                                                                                                                    "com_result_method".into(),
-                                                                                                                                                                return_type:
-                                                                                                                                                                    intercom::typelib::Arg{name:
-                                                                                                                                                                                               "".into(),
-                                                                                                                                                                                           ty:
-                                                                                                                                                                                               <<intercom::raw::HRESULT
-                                                                                                                                                                                                as
-                                                                                                                                                                                                intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                   as
-                                                                                                                                                                                                   intercom::type_system::OutputTypeInfo>::type_name().into(),
-                                                                                                                                                                                           indirection_level:
-                                                                                                                                                                                               <<intercom::raw::HRESULT
-                                                                                                                                                                                                as
-                                                                                                                                                                                                intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                   as
-                                                                                                                                                                                                   intercom::type_system::OutputTypeInfo>::indirection_level(),
-                                                                                                                                                                                           direction:
-                                                                                                                                                                                               intercom::typelib::Direction::Return,},
-                                                                                                                                                                parameters:
-                                                                                                                                                                    <[_]>::into_vec(box
-                                                                                                                                                                                        [intercom::typelib::Arg{name:
-                                                                                                                                                                                                                    "__out".into(),
-                                                                                                                                                                                                                ty:
-                                                                                                                                                                                                                    <<u16
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::OutputTypeInfo>::type_name().into(),
-                                                                                                                                                                                                                indirection_level:
-                                                                                                                                                                                                                    <<u16
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::OutputTypeInfo>::indirection_level(),
-                                                                                                                                                                                                                direction:
-                                                                                                                                                                                                                    intercom::typelib::Direction::Retval,}]),}),
-                                                                                                                intercom::ComBox::new(intercom::typelib::Method{name:
-                                                                                                                                                                    "rust_result_method".into(),
-                                                                                                                                                                return_type:
-                                                                                                                                                                    intercom::typelib::Arg{name:
-                                                                                                                                                                                               "".into(),
-                                                                                                                                                                                           ty:
-                                                                                                                                                                                               <<i32
-                                                                                                                                                                                                as
-                                                                                                                                                                                                intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                   as
-                                                                                                                                                                                                   intercom::type_system::OutputTypeInfo>::type_name().into(),
-                                                                                                                                                                                           indirection_level:
-                                                                                                                                                                                               <<i32
-                                                                                                                                                                                                as
-                                                                                                                                                                                                intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                   as
-                                                                                                                                                                                                   intercom::type_system::OutputTypeInfo>::indirection_level(),
-                                                                                                                                                                                           direction:
-                                                                                                                                                                                               intercom::typelib::Direction::Return,},
-                                                                                                                                                                parameters:
-                                                                                                                                                                    <[_]>::into_vec(box
-                                                                                                                                                                                        [intercom::typelib::Arg{name:
-                                                                                                                                                                                                                    "__out".into(),
-                                                                                                                                                                                                                ty:
-                                                                                                                                                                                                                    <<u16
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::OutputTypeInfo>::type_name().into(),
-                                                                                                                                                                                                                indirection_level:
-                                                                                                                                                                                                                    <<u16
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::OutputTypeInfo>::indirection_level(),
-                                                                                                                                                                                                                direction:
-                                                                                                                                                                                                                    intercom::typelib::Direction::Retval,}]),}),
-                                                                                                                intercom::ComBox::new(intercom::typelib::Method{name:
-                                                                                                                                                                    "complete_method".into(),
-                                                                                                                                                                return_type:
-                                                                                                                                                                    intercom::typelib::Arg{name:
-                                                                                                                                                                                               "".into(),
-                                                                                                                                                                                           ty:
-                                                                                                                                                                                               <<intercom::raw::HRESULT
-                                                                                                                                                                                                as
-                                                                                                                                                                                                intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                   as
-                                                                                                                                                                                                   intercom::type_system::OutputTypeInfo>::type_name().into(),
-                                                                                                                                                                                           indirection_level:
-                                                                                                                                                                                               <<intercom::raw::HRESULT
-                                                                                                                                                                                                as
-                                                                                                                                                                                                intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                   as
-                                                                                                                                                                                                   intercom::type_system::OutputTypeInfo>::indirection_level(),
-                                                                                                                                                                                           direction:
-                                                                                                                                                                                               intercom::typelib::Direction::Return,},
-                                                                                                                                                                parameters:
-                                                                                                                                                                    <[_]>::into_vec(box
-                                                                                                                                                                                        [intercom::typelib::Arg{name:
-                                                                                                                                                                                                                    "a".into(),
-                                                                                                                                                                                                                ty:
-                                                                                                                                                                                                                    <<u16
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::InputTypeInfo>::type_name().into(),
-                                                                                                                                                                                                                indirection_level:
-                                                                                                                                                                                                                    <<u16
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::InputTypeInfo>::indirection_level(),
-                                                                                                                                                                                                                direction:
-                                                                                                                                                                                                                    intercom::typelib::Direction::In,},
-                                                                                                                                                                                         intercom::typelib::Arg{name:
-                                                                                                                                                                                                                    "b".into(),
-                                                                                                                                                                                                                ty:
-                                                                                                                                                                                                                    <<i16
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::InputTypeInfo>::type_name().into(),
-                                                                                                                                                                                                                indirection_level:
-                                                                                                                                                                                                                    <<i16
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::InputTypeInfo>::indirection_level(),
-                                                                                                                                                                                                                direction:
-                                                                                                                                                                                                                    intercom::typelib::Direction::In,},
-                                                                                                                                                                                         intercom::typelib::Arg{name:
-                                                                                                                                                                                                                    "__out".into(),
-                                                                                                                                                                                                                ty:
-                                                                                                                                                                                                                    <<bool
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::OutputTypeInfo>::type_name().into(),
-                                                                                                                                                                                                                indirection_level:
-                                                                                                                                                                                                                    <<bool
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::OutputTypeInfo>::indirection_level(),
-                                                                                                                                                                                                                direction:
-                                                                                                                                                                                                                    intercom::typelib::Direction::Retval,}]),}),
-                                                                                                                intercom::ComBox::new(intercom::typelib::Method{name:
-                                                                                                                                                                    "string_method".into(),
-                                                                                                                                                                return_type:
-                                                                                                                                                                    intercom::typelib::Arg{name:
-                                                                                                                                                                                               "".into(),
-                                                                                                                                                                                           ty:
-                                                                                                                                                                                               <<String
-                                                                                                                                                                                                as
-                                                                                                                                                                                                intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                   as
-                                                                                                                                                                                                   intercom::type_system::OutputTypeInfo>::type_name().into(),
-                                                                                                                                                                                           indirection_level:
-                                                                                                                                                                                               <<String
-                                                                                                                                                                                                as
-                                                                                                                                                                                                intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                   as
-                                                                                                                                                                                                   intercom::type_system::OutputTypeInfo>::indirection_level(),
-                                                                                                                                                                                           direction:
-                                                                                                                                                                                               intercom::typelib::Direction::Return,},
-                                                                                                                                                                parameters:
-                                                                                                                                                                    <[_]>::into_vec(box
-                                                                                                                                                                                        [intercom::typelib::Arg{name:
-                                                                                                                                                                                                                    "msg".into(),
-                                                                                                                                                                                                                ty:
-                                                                                                                                                                                                                    <<String
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::InputTypeInfo>::type_name().into(),
-                                                                                                                                                                                                                indirection_level:
-                                                                                                                                                                                                                    <<String
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::InputTypeInfo>::indirection_level(),
-                                                                                                                                                                                                                direction:
-                                                                                                                                                                                                                    intercom::typelib::Direction::In,}]),}),
-                                                                                                                intercom::ComBox::new(intercom::typelib::Method{name:
-                                                                                                                                                                    "comitf_method".into(),
-                                                                                                                                                                return_type:
-                                                                                                                                                                    intercom::typelib::Arg{name:
-                                                                                                                                                                                               "".into(),
-                                                                                                                                                                                           ty:
-                                                                                                                                                                                               <<intercom::raw::HRESULT
-                                                                                                                                                                                                as
-                                                                                                                                                                                                intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                   as
-                                                                                                                                                                                                   intercom::type_system::OutputTypeInfo>::type_name().into(),
-                                                                                                                                                                                           indirection_level:
-                                                                                                                                                                                               <<intercom::raw::HRESULT
-                                                                                                                                                                                                as
-                                                                                                                                                                                                intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                   as
-                                                                                                                                                                                                   intercom::type_system::OutputTypeInfo>::indirection_level(),
-                                                                                                                                                                                           direction:
-                                                                                                                                                                                               intercom::typelib::Direction::Return,},
-                                                                                                                                                                parameters:
-                                                                                                                                                                    <[_]>::into_vec(box
-                                                                                                                                                                                        [intercom::typelib::Arg{name:
-                                                                                                                                                                                                                    "itf".into(),
-                                                                                                                                                                                                                ty:
-                                                                                                                                                                                                                    <<ComItf<dyn Foo>
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::InputTypeInfo>::type_name().into(),
-                                                                                                                                                                                                                indirection_level:
-                                                                                                                                                                                                                    <<ComItf<dyn Foo>
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::InputTypeInfo>::indirection_level(),
-                                                                                                                                                                                                                direction:
-                                                                                                                                                                                                                    intercom::typelib::Direction::In,},
-                                                                                                                                                                                         intercom::typelib::Arg{name:
-                                                                                                                                                                                                                    "__out".into(),
-                                                                                                                                                                                                                ty:
-                                                                                                                                                                                                                    <<ComItf<dyn IUnknown>
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::OutputTypeInfo>::type_name().into(),
-                                                                                                                                                                                                                indirection_level:
-                                                                                                                                                                                                                    <<ComItf<dyn IUnknown>
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::OutputTypeInfo>::indirection_level(),
-                                                                                                                                                                                                                direction:
-                                                                                                                                                                                                                    intercom::typelib::Direction::Retval,}]),}),
-                                                                                                                intercom::ComBox::new(intercom::typelib::Method{name:
-                                                                                                                                                                    "bool_method".into(),
-                                                                                                                                                                return_type:
-                                                                                                                                                                    intercom::typelib::Arg{name:
-                                                                                                                                                                                               "".into(),
-                                                                                                                                                                                           ty:
-                                                                                                                                                                                               <<intercom::raw::HRESULT
-                                                                                                                                                                                                as
-                                                                                                                                                                                                intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                   as
-                                                                                                                                                                                                   intercom::type_system::OutputTypeInfo>::type_name().into(),
-                                                                                                                                                                                           indirection_level:
-                                                                                                                                                                                               <<intercom::raw::HRESULT
-                                                                                                                                                                                                as
-                                                                                                                                                                                                intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                   as
-                                                                                                                                                                                                   intercom::type_system::OutputTypeInfo>::indirection_level(),
-                                                                                                                                                                                           direction:
-                                                                                                                                                                                               intercom::typelib::Direction::Return,},
-                                                                                                                                                                parameters:
-                                                                                                                                                                    <[_]>::into_vec(box
-                                                                                                                                                                                        [intercom::typelib::Arg{name:
-                                                                                                                                                                                                                    "input".into(),
-                                                                                                                                                                                                                ty:
-                                                                                                                                                                                                                    <<bool
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::InputTypeInfo>::type_name().into(),
-                                                                                                                                                                                                                indirection_level:
-                                                                                                                                                                                                                    <<bool
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::InputTypeInfo>::indirection_level(),
-                                                                                                                                                                                                                direction:
-                                                                                                                                                                                                                    intercom::typelib::Direction::In,},
-                                                                                                                                                                                         intercom::typelib::Arg{name:
-                                                                                                                                                                                                                    "__out".into(),
-                                                                                                                                                                                                                ty:
-                                                                                                                                                                                                                    <<bool
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::OutputTypeInfo>::type_name().into(),
-                                                                                                                                                                                                                indirection_level:
-                                                                                                                                                                                                                    <<bool
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::OutputTypeInfo>::indirection_level(),
-                                                                                                                                                                                                                direction:
-                                                                                                                                                                                                                    intercom::typelib::Direction::Retval,}]),}),
-                                                                                                                intercom::ComBox::new(intercom::typelib::Method{name:
-                                                                                                                                                                    "variant_method".into(),
-                                                                                                                                                                return_type:
-                                                                                                                                                                    intercom::typelib::Arg{name:
-                                                                                                                                                                                               "".into(),
-                                                                                                                                                                                           ty:
-                                                                                                                                                                                               <<intercom::raw::HRESULT
-                                                                                                                                                                                                as
-                                                                                                                                                                                                intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                   as
-                                                                                                                                                                                                   intercom::type_system::OutputTypeInfo>::type_name().into(),
-                                                                                                                                                                                           indirection_level:
-                                                                                                                                                                                               <<intercom::raw::HRESULT
-                                                                                                                                                                                                as
-                                                                                                                                                                                                intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                   as
-                                                                                                                                                                                                   intercom::type_system::OutputTypeInfo>::indirection_level(),
-                                                                                                                                                                                           direction:
-                                                                                                                                                                                               intercom::typelib::Direction::Return,},
-                                                                                                                                                                parameters:
-                                                                                                                                                                    <[_]>::into_vec(box
-                                                                                                                                                                                        [intercom::typelib::Arg{name:
-                                                                                                                                                                                                                    "input".into(),
-                                                                                                                                                                                                                ty:
-                                                                                                                                                                                                                    <<Variant
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::InputTypeInfo>::type_name().into(),
-                                                                                                                                                                                                                indirection_level:
-                                                                                                                                                                                                                    <<Variant
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::InputTypeInfo>::indirection_level(),
-                                                                                                                                                                                                                direction:
-                                                                                                                                                                                                                    intercom::typelib::Direction::In,},
-                                                                                                                                                                                         intercom::typelib::Arg{name:
-                                                                                                                                                                                                                    "__out".into(),
-                                                                                                                                                                                                                ty:
-                                                                                                                                                                                                                    <<Variant
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::OutputTypeInfo>::type_name().into(),
-                                                                                                                                                                                                                indirection_level:
-                                                                                                                                                                                                                    <<Variant
-                                                                                                                                                                                                                     as
-                                                                                                                                                                                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
-                                                                                                                                                                                                                        as
-                                                                                                                                                                                                                        intercom::type_system::OutputTypeInfo>::indirection_level(),
-                                                                                                                                                                                                                direction:
-                                                                                                                                                                                                                    intercom::typelib::Direction::Retval,}]),})]),})]);
-    intercom::typelib::TypeInfo::Interface(intercom::ComBox::new(intercom::typelib::Interface {
-        name: "Foo".into(),
-        variants: variants,
-        options: intercom::typelib::InterfaceOptions {
-            class_impl_interface: false,
-            ..Default::default()
-        },
-    }))
+impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
+    fn gather_type_info() -> Vec<intercom::typelib::TypeInfo> {
+        let variants =
+            <[_]>::into_vec(box
+                                [intercom::ComBox::new(intercom::typelib::InterfaceVariant{ts:
+                                                                                               intercom::type_system::TypeSystemName::Automation,
+                                                                                           iid:
+                                                                                               intercom::GUID{data1:
+                                                                                                                  0u32,
+                                                                                                              data2:
+                                                                                                                  0u16,
+                                                                                                              data3:
+                                                                                                                  0u16,
+                                                                                                              data4:
+                                                                                                                  [0u8,
+                                                                                                                   0u8,
+                                                                                                                   0u8,
+                                                                                                                   0u8,
+                                                                                                                   0u8,
+                                                                                                                   0u8,
+                                                                                                                   0u8,
+                                                                                                                   0u8],},
+                                                                                           methods:
+                                                                                               <[_]>::into_vec(box
+                                                                                                                   [intercom::ComBox::new(intercom::typelib::Method{name:
+                                                                                                                                                                        "simple_method".into(),
+                                                                                                                                                                    return_type:
+                                                                                                                                                                        intercom::typelib::Arg{name:
+                                                                                                                                                                                                   "".into(),
+                                                                                                                                                                                               ty:
+                                                                                                                                                                                                   "void".into(),
+                                                                                                                                                                                               indirection_level:
+                                                                                                                                                                                                   0,
+                                                                                                                                                                                               direction:
+                                                                                                                                                                                                   intercom::typelib::Direction::Return,},
+                                                                                                                                                                    parameters:
+                                                                                                                                                                        <[_]>::into_vec(box
+                                                                                                                                                                                            []),}),
+                                                                                                                    intercom::ComBox::new(intercom::typelib::Method{name:
+                                                                                                                                                                        "arg_method".into(),
+                                                                                                                                                                    return_type:
+                                                                                                                                                                        intercom::typelib::Arg{name:
+                                                                                                                                                                                                   "".into(),
+                                                                                                                                                                                               ty:
+                                                                                                                                                                                                   "void".into(),
+                                                                                                                                                                                               indirection_level:
+                                                                                                                                                                                                   0,
+                                                                                                                                                                                               direction:
+                                                                                                                                                                                                   intercom::typelib::Direction::Return,},
+                                                                                                                                                                    parameters:
+                                                                                                                                                                        <[_]>::into_vec(box
+                                                                                                                                                                                            [intercom::typelib::Arg{name:
+                                                                                                                                                                                                                        "a".into(),
+                                                                                                                                                                                                                    ty:
+                                                                                                                                                                                                                        <<u16
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                    indirection_level:
+                                                                                                                                                                                                                        <<u16
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                    direction:
+                                                                                                                                                                                                                        intercom::typelib::Direction::In,}]),}),
+                                                                                                                    intercom::ComBox::new(intercom::typelib::Method{name:
+                                                                                                                                                                        "simple_result_method".into(),
+                                                                                                                                                                    return_type:
+                                                                                                                                                                        intercom::typelib::Arg{name:
+                                                                                                                                                                                                   "".into(),
+                                                                                                                                                                                               ty:
+                                                                                                                                                                                                   <<u16
+                                                                                                                                                                                                    as
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                       as
+                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                               indirection_level:
+                                                                                                                                                                                                   <<u16
+                                                                                                                                                                                                    as
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                       as
+                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                               direction:
+                                                                                                                                                                                                   intercom::typelib::Direction::Return,},
+                                                                                                                                                                    parameters:
+                                                                                                                                                                        <[_]>::into_vec(box
+                                                                                                                                                                                            []),}),
+                                                                                                                    intercom::ComBox::new(intercom::typelib::Method{name:
+                                                                                                                                                                        "com_result_method".into(),
+                                                                                                                                                                    return_type:
+                                                                                                                                                                        intercom::typelib::Arg{name:
+                                                                                                                                                                                                   "".into(),
+                                                                                                                                                                                               ty:
+                                                                                                                                                                                                   <<intercom::raw::HRESULT
+                                                                                                                                                                                                    as
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                       as
+                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                               indirection_level:
+                                                                                                                                                                                                   <<intercom::raw::HRESULT
+                                                                                                                                                                                                    as
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                       as
+                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                               direction:
+                                                                                                                                                                                                   intercom::typelib::Direction::Return,},
+                                                                                                                                                                    parameters:
+                                                                                                                                                                        <[_]>::into_vec(box
+                                                                                                                                                                                            [intercom::typelib::Arg{name:
+                                                                                                                                                                                                                        "__out".into(),
+                                                                                                                                                                                                                    ty:
+                                                                                                                                                                                                                        <<u16
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                    indirection_level:
+                                                                                                                                                                                                                        <<u16
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                    direction:
+                                                                                                                                                                                                                        intercom::typelib::Direction::Retval,}]),}),
+                                                                                                                    intercom::ComBox::new(intercom::typelib::Method{name:
+                                                                                                                                                                        "rust_result_method".into(),
+                                                                                                                                                                    return_type:
+                                                                                                                                                                        intercom::typelib::Arg{name:
+                                                                                                                                                                                                   "".into(),
+                                                                                                                                                                                               ty:
+                                                                                                                                                                                                   <<i32
+                                                                                                                                                                                                    as
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                       as
+                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                               indirection_level:
+                                                                                                                                                                                                   <<i32
+                                                                                                                                                                                                    as
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                       as
+                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                               direction:
+                                                                                                                                                                                                   intercom::typelib::Direction::Return,},
+                                                                                                                                                                    parameters:
+                                                                                                                                                                        <[_]>::into_vec(box
+                                                                                                                                                                                            [intercom::typelib::Arg{name:
+                                                                                                                                                                                                                        "__out".into(),
+                                                                                                                                                                                                                    ty:
+                                                                                                                                                                                                                        <<u16
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                    indirection_level:
+                                                                                                                                                                                                                        <<u16
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                    direction:
+                                                                                                                                                                                                                        intercom::typelib::Direction::Retval,}]),}),
+                                                                                                                    intercom::ComBox::new(intercom::typelib::Method{name:
+                                                                                                                                                                        "complete_method".into(),
+                                                                                                                                                                    return_type:
+                                                                                                                                                                        intercom::typelib::Arg{name:
+                                                                                                                                                                                                   "".into(),
+                                                                                                                                                                                               ty:
+                                                                                                                                                                                                   <<intercom::raw::HRESULT
+                                                                                                                                                                                                    as
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                       as
+                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                               indirection_level:
+                                                                                                                                                                                                   <<intercom::raw::HRESULT
+                                                                                                                                                                                                    as
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                       as
+                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                               direction:
+                                                                                                                                                                                                   intercom::typelib::Direction::Return,},
+                                                                                                                                                                    parameters:
+                                                                                                                                                                        <[_]>::into_vec(box
+                                                                                                                                                                                            [intercom::typelib::Arg{name:
+                                                                                                                                                                                                                        "a".into(),
+                                                                                                                                                                                                                    ty:
+                                                                                                                                                                                                                        <<u16
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                    indirection_level:
+                                                                                                                                                                                                                        <<u16
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                    direction:
+                                                                                                                                                                                                                        intercom::typelib::Direction::In,},
+                                                                                                                                                                                             intercom::typelib::Arg{name:
+                                                                                                                                                                                                                        "b".into(),
+                                                                                                                                                                                                                    ty:
+                                                                                                                                                                                                                        <<i16
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                    indirection_level:
+                                                                                                                                                                                                                        <<i16
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                    direction:
+                                                                                                                                                                                                                        intercom::typelib::Direction::In,},
+                                                                                                                                                                                             intercom::typelib::Arg{name:
+                                                                                                                                                                                                                        "__out".into(),
+                                                                                                                                                                                                                    ty:
+                                                                                                                                                                                                                        <<bool
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                    indirection_level:
+                                                                                                                                                                                                                        <<bool
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                    direction:
+                                                                                                                                                                                                                        intercom::typelib::Direction::Retval,}]),}),
+                                                                                                                    intercom::ComBox::new(intercom::typelib::Method{name:
+                                                                                                                                                                        "string_method".into(),
+                                                                                                                                                                    return_type:
+                                                                                                                                                                        intercom::typelib::Arg{name:
+                                                                                                                                                                                                   "".into(),
+                                                                                                                                                                                               ty:
+                                                                                                                                                                                                   <<String
+                                                                                                                                                                                                    as
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                       as
+                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                               indirection_level:
+                                                                                                                                                                                                   <<String
+                                                                                                                                                                                                    as
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                       as
+                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                               direction:
+                                                                                                                                                                                                   intercom::typelib::Direction::Return,},
+                                                                                                                                                                    parameters:
+                                                                                                                                                                        <[_]>::into_vec(box
+                                                                                                                                                                                            [intercom::typelib::Arg{name:
+                                                                                                                                                                                                                        "msg".into(),
+                                                                                                                                                                                                                    ty:
+                                                                                                                                                                                                                        <<String
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                    indirection_level:
+                                                                                                                                                                                                                        <<String
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                    direction:
+                                                                                                                                                                                                                        intercom::typelib::Direction::In,}]),}),
+                                                                                                                    intercom::ComBox::new(intercom::typelib::Method{name:
+                                                                                                                                                                        "comitf_method".into(),
+                                                                                                                                                                    return_type:
+                                                                                                                                                                        intercom::typelib::Arg{name:
+                                                                                                                                                                                                   "".into(),
+                                                                                                                                                                                               ty:
+                                                                                                                                                                                                   <<intercom::raw::HRESULT
+                                                                                                                                                                                                    as
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                       as
+                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                               indirection_level:
+                                                                                                                                                                                                   <<intercom::raw::HRESULT
+                                                                                                                                                                                                    as
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                       as
+                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                               direction:
+                                                                                                                                                                                                   intercom::typelib::Direction::Return,},
+                                                                                                                                                                    parameters:
+                                                                                                                                                                        <[_]>::into_vec(box
+                                                                                                                                                                                            [intercom::typelib::Arg{name:
+                                                                                                                                                                                                                        "itf".into(),
+                                                                                                                                                                                                                    ty:
+                                                                                                                                                                                                                        <<ComItf<dyn Foo>
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                    indirection_level:
+                                                                                                                                                                                                                        <<ComItf<dyn Foo>
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                    direction:
+                                                                                                                                                                                                                        intercom::typelib::Direction::In,},
+                                                                                                                                                                                             intercom::typelib::Arg{name:
+                                                                                                                                                                                                                        "__out".into(),
+                                                                                                                                                                                                                    ty:
+                                                                                                                                                                                                                        <<ComItf<dyn IUnknown>
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                    indirection_level:
+                                                                                                                                                                                                                        <<ComItf<dyn IUnknown>
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                    direction:
+                                                                                                                                                                                                                        intercom::typelib::Direction::Retval,}]),}),
+                                                                                                                    intercom::ComBox::new(intercom::typelib::Method{name:
+                                                                                                                                                                        "bool_method".into(),
+                                                                                                                                                                    return_type:
+                                                                                                                                                                        intercom::typelib::Arg{name:
+                                                                                                                                                                                                   "".into(),
+                                                                                                                                                                                               ty:
+                                                                                                                                                                                                   <<intercom::raw::HRESULT
+                                                                                                                                                                                                    as
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                       as
+                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                               indirection_level:
+                                                                                                                                                                                                   <<intercom::raw::HRESULT
+                                                                                                                                                                                                    as
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                       as
+                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                               direction:
+                                                                                                                                                                                                   intercom::typelib::Direction::Return,},
+                                                                                                                                                                    parameters:
+                                                                                                                                                                        <[_]>::into_vec(box
+                                                                                                                                                                                            [intercom::typelib::Arg{name:
+                                                                                                                                                                                                                        "input".into(),
+                                                                                                                                                                                                                    ty:
+                                                                                                                                                                                                                        <<bool
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                    indirection_level:
+                                                                                                                                                                                                                        <<bool
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                    direction:
+                                                                                                                                                                                                                        intercom::typelib::Direction::In,},
+                                                                                                                                                                                             intercom::typelib::Arg{name:
+                                                                                                                                                                                                                        "__out".into(),
+                                                                                                                                                                                                                    ty:
+                                                                                                                                                                                                                        <<bool
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                    indirection_level:
+                                                                                                                                                                                                                        <<bool
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                    direction:
+                                                                                                                                                                                                                        intercom::typelib::Direction::Retval,}]),}),
+                                                                                                                    intercom::ComBox::new(intercom::typelib::Method{name:
+                                                                                                                                                                        "variant_method".into(),
+                                                                                                                                                                    return_type:
+                                                                                                                                                                        intercom::typelib::Arg{name:
+                                                                                                                                                                                                   "".into(),
+                                                                                                                                                                                               ty:
+                                                                                                                                                                                                   <<intercom::raw::HRESULT
+                                                                                                                                                                                                    as
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                       as
+                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                               indirection_level:
+                                                                                                                                                                                                   <<intercom::raw::HRESULT
+                                                                                                                                                                                                    as
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                       as
+                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                               direction:
+                                                                                                                                                                                                   intercom::typelib::Direction::Return,},
+                                                                                                                                                                    parameters:
+                                                                                                                                                                        <[_]>::into_vec(box
+                                                                                                                                                                                            [intercom::typelib::Arg{name:
+                                                                                                                                                                                                                        "input".into(),
+                                                                                                                                                                                                                    ty:
+                                                                                                                                                                                                                        <<Variant
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                    indirection_level:
+                                                                                                                                                                                                                        <<Variant
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                    direction:
+                                                                                                                                                                                                                        intercom::typelib::Direction::In,},
+                                                                                                                                                                                             intercom::typelib::Arg{name:
+                                                                                                                                                                                                                        "__out".into(),
+                                                                                                                                                                                                                    ty:
+                                                                                                                                                                                                                        <<Variant
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                    indirection_level:
+                                                                                                                                                                                                                        <<Variant
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                    direction:
+                                                                                                                                                                                                                        intercom::typelib::Direction::Retval,}]),})]),}),
+                                 intercom::ComBox::new(intercom::typelib::InterfaceVariant{ts:
+                                                                                               intercom::type_system::TypeSystemName::Raw,
+                                                                                           iid:
+                                                                                               intercom::GUID{data1:
+                                                                                                                  0u32,
+                                                                                                              data2:
+                                                                                                                  0u16,
+                                                                                                              data3:
+                                                                                                                  0u16,
+                                                                                                              data4:
+                                                                                                                  [0u8,
+                                                                                                                   0u8,
+                                                                                                                   0u8,
+                                                                                                                   0u8,
+                                                                                                                   0u8,
+                                                                                                                   0u8,
+                                                                                                                   0u8,
+                                                                                                                   1u8],},
+                                                                                           methods:
+                                                                                               <[_]>::into_vec(box
+                                                                                                                   [intercom::ComBox::new(intercom::typelib::Method{name:
+                                                                                                                                                                        "simple_method".into(),
+                                                                                                                                                                    return_type:
+                                                                                                                                                                        intercom::typelib::Arg{name:
+                                                                                                                                                                                                   "".into(),
+                                                                                                                                                                                               ty:
+                                                                                                                                                                                                   "void".into(),
+                                                                                                                                                                                               indirection_level:
+                                                                                                                                                                                                   0,
+                                                                                                                                                                                               direction:
+                                                                                                                                                                                                   intercom::typelib::Direction::Return,},
+                                                                                                                                                                    parameters:
+                                                                                                                                                                        <[_]>::into_vec(box
+                                                                                                                                                                                            []),}),
+                                                                                                                    intercom::ComBox::new(intercom::typelib::Method{name:
+                                                                                                                                                                        "arg_method".into(),
+                                                                                                                                                                    return_type:
+                                                                                                                                                                        intercom::typelib::Arg{name:
+                                                                                                                                                                                                   "".into(),
+                                                                                                                                                                                               ty:
+                                                                                                                                                                                                   "void".into(),
+                                                                                                                                                                                               indirection_level:
+                                                                                                                                                                                                   0,
+                                                                                                                                                                                               direction:
+                                                                                                                                                                                                   intercom::typelib::Direction::Return,},
+                                                                                                                                                                    parameters:
+                                                                                                                                                                        <[_]>::into_vec(box
+                                                                                                                                                                                            [intercom::typelib::Arg{name:
+                                                                                                                                                                                                                        "a".into(),
+                                                                                                                                                                                                                    ty:
+                                                                                                                                                                                                                        <<u16
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                    indirection_level:
+                                                                                                                                                                                                                        <<u16
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                    direction:
+                                                                                                                                                                                                                        intercom::typelib::Direction::In,}]),}),
+                                                                                                                    intercom::ComBox::new(intercom::typelib::Method{name:
+                                                                                                                                                                        "simple_result_method".into(),
+                                                                                                                                                                    return_type:
+                                                                                                                                                                        intercom::typelib::Arg{name:
+                                                                                                                                                                                                   "".into(),
+                                                                                                                                                                                               ty:
+                                                                                                                                                                                                   <<u16
+                                                                                                                                                                                                    as
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                       as
+                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                               indirection_level:
+                                                                                                                                                                                                   <<u16
+                                                                                                                                                                                                    as
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                       as
+                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                               direction:
+                                                                                                                                                                                                   intercom::typelib::Direction::Return,},
+                                                                                                                                                                    parameters:
+                                                                                                                                                                        <[_]>::into_vec(box
+                                                                                                                                                                                            []),}),
+                                                                                                                    intercom::ComBox::new(intercom::typelib::Method{name:
+                                                                                                                                                                        "com_result_method".into(),
+                                                                                                                                                                    return_type:
+                                                                                                                                                                        intercom::typelib::Arg{name:
+                                                                                                                                                                                                   "".into(),
+                                                                                                                                                                                               ty:
+                                                                                                                                                                                                   <<intercom::raw::HRESULT
+                                                                                                                                                                                                    as
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                       as
+                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                               indirection_level:
+                                                                                                                                                                                                   <<intercom::raw::HRESULT
+                                                                                                                                                                                                    as
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                       as
+                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                               direction:
+                                                                                                                                                                                                   intercom::typelib::Direction::Return,},
+                                                                                                                                                                    parameters:
+                                                                                                                                                                        <[_]>::into_vec(box
+                                                                                                                                                                                            [intercom::typelib::Arg{name:
+                                                                                                                                                                                                                        "__out".into(),
+                                                                                                                                                                                                                    ty:
+                                                                                                                                                                                                                        <<u16
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                    indirection_level:
+                                                                                                                                                                                                                        <<u16
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                    direction:
+                                                                                                                                                                                                                        intercom::typelib::Direction::Retval,}]),}),
+                                                                                                                    intercom::ComBox::new(intercom::typelib::Method{name:
+                                                                                                                                                                        "rust_result_method".into(),
+                                                                                                                                                                    return_type:
+                                                                                                                                                                        intercom::typelib::Arg{name:
+                                                                                                                                                                                                   "".into(),
+                                                                                                                                                                                               ty:
+                                                                                                                                                                                                   <<i32
+                                                                                                                                                                                                    as
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                       as
+                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                               indirection_level:
+                                                                                                                                                                                                   <<i32
+                                                                                                                                                                                                    as
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                       as
+                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                               direction:
+                                                                                                                                                                                                   intercom::typelib::Direction::Return,},
+                                                                                                                                                                    parameters:
+                                                                                                                                                                        <[_]>::into_vec(box
+                                                                                                                                                                                            [intercom::typelib::Arg{name:
+                                                                                                                                                                                                                        "__out".into(),
+                                                                                                                                                                                                                    ty:
+                                                                                                                                                                                                                        <<u16
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                    indirection_level:
+                                                                                                                                                                                                                        <<u16
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                    direction:
+                                                                                                                                                                                                                        intercom::typelib::Direction::Retval,}]),}),
+                                                                                                                    intercom::ComBox::new(intercom::typelib::Method{name:
+                                                                                                                                                                        "complete_method".into(),
+                                                                                                                                                                    return_type:
+                                                                                                                                                                        intercom::typelib::Arg{name:
+                                                                                                                                                                                                   "".into(),
+                                                                                                                                                                                               ty:
+                                                                                                                                                                                                   <<intercom::raw::HRESULT
+                                                                                                                                                                                                    as
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                       as
+                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                               indirection_level:
+                                                                                                                                                                                                   <<intercom::raw::HRESULT
+                                                                                                                                                                                                    as
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                       as
+                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                               direction:
+                                                                                                                                                                                                   intercom::typelib::Direction::Return,},
+                                                                                                                                                                    parameters:
+                                                                                                                                                                        <[_]>::into_vec(box
+                                                                                                                                                                                            [intercom::typelib::Arg{name:
+                                                                                                                                                                                                                        "a".into(),
+                                                                                                                                                                                                                    ty:
+                                                                                                                                                                                                                        <<u16
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                    indirection_level:
+                                                                                                                                                                                                                        <<u16
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                    direction:
+                                                                                                                                                                                                                        intercom::typelib::Direction::In,},
+                                                                                                                                                                                             intercom::typelib::Arg{name:
+                                                                                                                                                                                                                        "b".into(),
+                                                                                                                                                                                                                    ty:
+                                                                                                                                                                                                                        <<i16
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                    indirection_level:
+                                                                                                                                                                                                                        <<i16
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                    direction:
+                                                                                                                                                                                                                        intercom::typelib::Direction::In,},
+                                                                                                                                                                                             intercom::typelib::Arg{name:
+                                                                                                                                                                                                                        "__out".into(),
+                                                                                                                                                                                                                    ty:
+                                                                                                                                                                                                                        <<bool
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                    indirection_level:
+                                                                                                                                                                                                                        <<bool
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                    direction:
+                                                                                                                                                                                                                        intercom::typelib::Direction::Retval,}]),}),
+                                                                                                                    intercom::ComBox::new(intercom::typelib::Method{name:
+                                                                                                                                                                        "string_method".into(),
+                                                                                                                                                                    return_type:
+                                                                                                                                                                        intercom::typelib::Arg{name:
+                                                                                                                                                                                                   "".into(),
+                                                                                                                                                                                               ty:
+                                                                                                                                                                                                   <<String
+                                                                                                                                                                                                    as
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                       as
+                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                               indirection_level:
+                                                                                                                                                                                                   <<String
+                                                                                                                                                                                                    as
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                       as
+                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                               direction:
+                                                                                                                                                                                                   intercom::typelib::Direction::Return,},
+                                                                                                                                                                    parameters:
+                                                                                                                                                                        <[_]>::into_vec(box
+                                                                                                                                                                                            [intercom::typelib::Arg{name:
+                                                                                                                                                                                                                        "msg".into(),
+                                                                                                                                                                                                                    ty:
+                                                                                                                                                                                                                        <<String
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                    indirection_level:
+                                                                                                                                                                                                                        <<String
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                    direction:
+                                                                                                                                                                                                                        intercom::typelib::Direction::In,}]),}),
+                                                                                                                    intercom::ComBox::new(intercom::typelib::Method{name:
+                                                                                                                                                                        "comitf_method".into(),
+                                                                                                                                                                    return_type:
+                                                                                                                                                                        intercom::typelib::Arg{name:
+                                                                                                                                                                                                   "".into(),
+                                                                                                                                                                                               ty:
+                                                                                                                                                                                                   <<intercom::raw::HRESULT
+                                                                                                                                                                                                    as
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                       as
+                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                               indirection_level:
+                                                                                                                                                                                                   <<intercom::raw::HRESULT
+                                                                                                                                                                                                    as
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                       as
+                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                               direction:
+                                                                                                                                                                                                   intercom::typelib::Direction::Return,},
+                                                                                                                                                                    parameters:
+                                                                                                                                                                        <[_]>::into_vec(box
+                                                                                                                                                                                            [intercom::typelib::Arg{name:
+                                                                                                                                                                                                                        "itf".into(),
+                                                                                                                                                                                                                    ty:
+                                                                                                                                                                                                                        <<ComItf<dyn Foo>
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                    indirection_level:
+                                                                                                                                                                                                                        <<ComItf<dyn Foo>
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                    direction:
+                                                                                                                                                                                                                        intercom::typelib::Direction::In,},
+                                                                                                                                                                                             intercom::typelib::Arg{name:
+                                                                                                                                                                                                                        "__out".into(),
+                                                                                                                                                                                                                    ty:
+                                                                                                                                                                                                                        <<ComItf<dyn IUnknown>
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                    indirection_level:
+                                                                                                                                                                                                                        <<ComItf<dyn IUnknown>
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                    direction:
+                                                                                                                                                                                                                        intercom::typelib::Direction::Retval,}]),}),
+                                                                                                                    intercom::ComBox::new(intercom::typelib::Method{name:
+                                                                                                                                                                        "bool_method".into(),
+                                                                                                                                                                    return_type:
+                                                                                                                                                                        intercom::typelib::Arg{name:
+                                                                                                                                                                                                   "".into(),
+                                                                                                                                                                                               ty:
+                                                                                                                                                                                                   <<intercom::raw::HRESULT
+                                                                                                                                                                                                    as
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                       as
+                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                               indirection_level:
+                                                                                                                                                                                                   <<intercom::raw::HRESULT
+                                                                                                                                                                                                    as
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                       as
+                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                               direction:
+                                                                                                                                                                                                   intercom::typelib::Direction::Return,},
+                                                                                                                                                                    parameters:
+                                                                                                                                                                        <[_]>::into_vec(box
+                                                                                                                                                                                            [intercom::typelib::Arg{name:
+                                                                                                                                                                                                                        "input".into(),
+                                                                                                                                                                                                                    ty:
+                                                                                                                                                                                                                        <<bool
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                    indirection_level:
+                                                                                                                                                                                                                        <<bool
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                    direction:
+                                                                                                                                                                                                                        intercom::typelib::Direction::In,},
+                                                                                                                                                                                             intercom::typelib::Arg{name:
+                                                                                                                                                                                                                        "__out".into(),
+                                                                                                                                                                                                                    ty:
+                                                                                                                                                                                                                        <<bool
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                    indirection_level:
+                                                                                                                                                                                                                        <<bool
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                    direction:
+                                                                                                                                                                                                                        intercom::typelib::Direction::Retval,}]),}),
+                                                                                                                    intercom::ComBox::new(intercom::typelib::Method{name:
+                                                                                                                                                                        "variant_method".into(),
+                                                                                                                                                                    return_type:
+                                                                                                                                                                        intercom::typelib::Arg{name:
+                                                                                                                                                                                                   "".into(),
+                                                                                                                                                                                               ty:
+                                                                                                                                                                                                   <<intercom::raw::HRESULT
+                                                                                                                                                                                                    as
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                       as
+                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                               indirection_level:
+                                                                                                                                                                                                   <<intercom::raw::HRESULT
+                                                                                                                                                                                                    as
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                       as
+                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                               direction:
+                                                                                                                                                                                                   intercom::typelib::Direction::Return,},
+                                                                                                                                                                    parameters:
+                                                                                                                                                                        <[_]>::into_vec(box
+                                                                                                                                                                                            [intercom::typelib::Arg{name:
+                                                                                                                                                                                                                        "input".into(),
+                                                                                                                                                                                                                    ty:
+                                                                                                                                                                                                                        <<Variant
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                    indirection_level:
+                                                                                                                                                                                                                        <<Variant
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                    direction:
+                                                                                                                                                                                                                        intercom::typelib::Direction::In,},
+                                                                                                                                                                                             intercom::typelib::Arg{name:
+                                                                                                                                                                                                                        "__out".into(),
+                                                                                                                                                                                                                    ty:
+                                                                                                                                                                                                                        <<Variant
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                    indirection_level:
+                                                                                                                                                                                                                        <<Variant
+                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                            as
+                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                    direction:
+                                                                                                                                                                                                                        intercom::typelib::Direction::Retval,}]),})]),})]);
+        <[_]>::into_vec(box [intercom::typelib::TypeInfo::Interface(
+            intercom::ComBox::new(intercom::typelib::Interface {
+                name: "Foo".into(),
+                variants: variants,
+                options: intercom::typelib::InterfaceOptions {
+                    class_impl_interface: false,
+                    ..Default::default()
+                },
+            }),
+        )])
+    }
 }

--- a/intercom-attributes/tests/data/macro/com_library.rs.stdout
+++ b/intercom-attributes/tests/data/macro/com_library.rs.stdout
@@ -55,10 +55,10 @@ pub unsafe extern "system" fn DllGetClassObject(
 }
 pub(crate) fn get_intercom_typelib() -> intercom::typelib::TypeLib {
     let types = <[_]>::into_vec(box [
-        intercom::alloc::get_intercom_coclass_info_for_Allocator(),
-        intercom::error::get_intercom_coclass_info_for_ErrorStore(),
-        some::path::get_intercom_coclass_info_for_Type(),
-        get_intercom_coclass_info_for_SimpleType(),
+        <intercom::alloc::Allocator as intercom::attributes::HasTypeInfo>::gather_type_info(),
+        <intercom::error::ErrorStore as intercom::attributes::HasTypeInfo>::gather_type_info(),
+        <some::path::Type as intercom::attributes::HasTypeInfo>::gather_type_info(),
+        <SimpleType as intercom::attributes::HasTypeInfo>::gather_type_info(),
     ])
     .into_iter()
     .flatten()

--- a/intercom-attributes/tests/data/macro/private_item.rs.stdout
+++ b/intercom-attributes/tests/data/macro/private_item.rs.stdout
@@ -10,49 +10,65 @@ use intercom::*;
 trait IFoo {
     fn trait_method(&self);
 }
-#[doc = "`IFoo` interface ID."]
-#[allow(non_upper_case_globals)]
-const IID_IFoo_Automation: intercom::IID = intercom::GUID {
-    data1: 0u32,
-    data2: 0u16,
-    data3: 0u16,
-    data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8],
-};
 #[allow(non_camel_case_types)]
 #[allow(non_snake_case)]
 #[allow(clippy::all)]
 #[repr(C)]
 #[doc(hidden)]
-struct __IFoo_AutomationVtbl {
-    pub __base: intercom::IUnknownVtbl,
-    pub trait_method_Automation:
-        unsafe extern "system" fn(
-            self_vtable: intercom::RawComPtr,
-        ) -> <() as intercom::type_system::ExternType<
-            intercom::type_system::AutomationTypeSystem,
-        >>::ExternOutputType,
-}
-#[doc = "`IFoo` interface ID."]
-#[allow(non_upper_case_globals)]
-const IID_IFoo_Raw: intercom::IID = intercom::GUID {
-    data1: 0u32,
-    data2: 0u16,
-    data3: 0u16,
-    data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8],
-};
-#[allow(non_camel_case_types)]
-#[allow(non_snake_case)]
-#[allow(clippy::all)]
-#[repr(C)]
-#[doc(hidden)]
-struct __IFoo_RawVtbl {
-    pub __base: intercom::IUnknownVtbl,
-    pub trait_method_Raw: unsafe extern "system" fn(
+struct __IntercomVtableForIFoo_Automation {
+    pub __base: <dyn intercom::IUnknown as intercom::attributes::ComInterface<
+        intercom::type_system::AutomationTypeSystem,
+    >>::VTable,
+    pub trait_method: unsafe extern "system" fn(
         self_vtable: intercom::RawComPtr,
-    )
-        -> <() as intercom::type_system::ExternType<
+    ) -> <() as intercom::type_system::ExternType<
         intercom::type_system::AutomationTypeSystem,
     >>::ExternOutputType,
+}
+#[allow(non_camel_case_types)]
+#[allow(non_snake_case)]
+#[allow(clippy::all)]
+#[doc(hidden)]
+impl intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem> for dyn IFoo {
+    type VTable = __IntercomVtableForIFoo_Automation;
+    fn iid() -> &'static intercom::IID {
+        &intercom::GUID {
+            data1: 0u32,
+            data2: 0u16,
+            data3: 0u16,
+            data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8],
+        }
+    }
+}
+#[allow(non_camel_case_types)]
+#[allow(non_snake_case)]
+#[allow(clippy::all)]
+#[repr(C)]
+#[doc(hidden)]
+struct __IntercomVtableForIFoo_Raw {
+    pub __base: <dyn intercom::IUnknown as intercom::attributes::ComInterface<
+        intercom::type_system::AutomationTypeSystem,
+    >>::VTable,
+    pub trait_method: unsafe extern "system" fn(
+        self_vtable: intercom::RawComPtr,
+    ) -> <() as intercom::type_system::ExternType<
+        intercom::type_system::AutomationTypeSystem,
+    >>::ExternOutputType,
+}
+#[allow(non_camel_case_types)]
+#[allow(non_snake_case)]
+#[allow(clippy::all)]
+#[doc(hidden)]
+impl intercom::attributes::ComInterface<intercom::type_system::RawTypeSystem> for dyn IFoo {
+    type VTable = __IntercomVtableForIFoo_Raw;
+    fn iid() -> &'static intercom::IID {
+        &intercom::GUID {
+            data1: 0u32,
+            data2: 0u16,
+            data3: 0u16,
+            data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8],
+        }
+    }
 }
 #[allow(clippy::all)]
 impl IFoo for intercom::ComItf<dyn IFoo> {
@@ -64,10 +80,13 @@ impl IFoo for intercom::ComItf<dyn IFoo> {
         {
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
-            let vtbl = comptr.ptr as *const *const __IFoo_AutomationVtbl;
+            let vtbl = comptr.ptr
+                as *const *const <dyn IFoo as intercom::attributes::ComInterface<
+                    intercom::type_system::AutomationTypeSystem,
+                >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<(), intercom::ComError> = (|| unsafe {
-                let __result = ((**vtbl).trait_method_Automation)(comptr.ptr);
+                let __result = ((**vtbl).trait_method)(comptr.ptr);
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
                     data2: 0u16,
@@ -86,10 +105,13 @@ impl IFoo for intercom::ComItf<dyn IFoo> {
         {
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
-            let vtbl = comptr.ptr as *const *const __IFoo_RawVtbl;
+            let vtbl = comptr.ptr
+                as *const *const <dyn IFoo as intercom::attributes::ComInterface<
+                    intercom::type_system::RawTypeSystem,
+                >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<(), intercom::ComError> = (|| unsafe {
-                let __result = ((**vtbl).trait_method_Raw)(comptr.ptr);
+                let __result = ((**vtbl).trait_method)(comptr.ptr);
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
                     data2: 0u16,
@@ -108,10 +130,24 @@ impl IFoo for intercom::ComItf<dyn IFoo> {
 }
 impl intercom::ComInterface for dyn IFoo {
     #[doc = "Returns the IID of the requested interface."]
+    fn iid_ts<TS: intercom::type_system::TypeSystem>() -> &'static intercom::IID
+    where
+        Self: intercom::attributes::ComInterface<TS>,
+    {
+        <Self as intercom::attributes::ComInterface<TS>>::iid()
+    }
     fn iid(ts: intercom::type_system::TypeSystemName) -> Option<&'static intercom::IID> {
         match ts {
-            intercom::type_system::TypeSystemName::Automation => Some(&IID_IFoo_Automation),
-            intercom::type_system::TypeSystemName::Raw => Some(&IID_IFoo_Raw),
+            intercom::type_system::TypeSystemName::Automation => {
+                Some(<Self as intercom::attributes::ComInterface<
+                    intercom::type_system::AutomationTypeSystem,
+                >>::iid())
+            }
+            intercom::type_system::TypeSystemName::Raw => {
+                Some(<Self as intercom::attributes::ComInterface<
+                    intercom::type_system::RawTypeSystem,
+                >>::iid())
+            }
         }
     }
     fn deref(com_itf: &intercom::ComItf<dyn IFoo>) -> &(dyn IFoo + 'static) {
@@ -126,107 +162,164 @@ impl intercom::type_system::BidirectionalTypeInfo for dyn IFoo {
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]
-pub(crate) fn get_intercom_interface_info_for_IFoo() -> intercom::typelib::TypeInfo {
-    let variants = <[_]>::into_vec(box [
-        intercom::ComBox::new(intercom::typelib::InterfaceVariant {
-            ts: intercom::type_system::TypeSystemName::Automation,
-            iid: intercom::GUID {
-                data1: 0u32,
-                data2: 0u16,
-                data3: 0u16,
-                data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8],
-            },
-            methods: <[_]>::into_vec(box [intercom::ComBox::new(intercom::typelib::Method {
-                name: "trait_method".into(),
-                return_type: intercom::typelib::Arg {
-                    name: "".into(),
-                    ty: "void".into(),
-                    indirection_level: 0,
-                    direction: intercom::typelib::Direction::Return,
+impl intercom::attributes::InterfaceHasTypeInfo for dyn IFoo {
+    fn gather_type_info() -> Vec<intercom::typelib::TypeInfo> {
+        let variants = <[_]>::into_vec(box [
+            intercom::ComBox::new(intercom::typelib::InterfaceVariant {
+                ts: intercom::type_system::TypeSystemName::Automation,
+                iid: intercom::GUID {
+                    data1: 0u32,
+                    data2: 0u16,
+                    data3: 0u16,
+                    data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8],
                 },
-                parameters: <[_]>::into_vec(box []),
-            })]),
-        }),
-        intercom::ComBox::new(intercom::typelib::InterfaceVariant {
-            ts: intercom::type_system::TypeSystemName::Raw,
-            iid: intercom::GUID {
-                data1: 0u32,
-                data2: 0u16,
-                data3: 0u16,
-                data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8],
-            },
-            methods: <[_]>::into_vec(box [intercom::ComBox::new(intercom::typelib::Method {
-                name: "trait_method".into(),
-                return_type: intercom::typelib::Arg {
-                    name: "".into(),
-                    ty: "void".into(),
-                    indirection_level: 0,
-                    direction: intercom::typelib::Direction::Return,
+                methods: <[_]>::into_vec(box [intercom::ComBox::new(intercom::typelib::Method {
+                    name: "trait_method".into(),
+                    return_type: intercom::typelib::Arg {
+                        name: "".into(),
+                        ty: "void".into(),
+                        indirection_level: 0,
+                        direction: intercom::typelib::Direction::Return,
+                    },
+                    parameters: <[_]>::into_vec(box []),
+                })]),
+            }),
+            intercom::ComBox::new(intercom::typelib::InterfaceVariant {
+                ts: intercom::type_system::TypeSystemName::Raw,
+                iid: intercom::GUID {
+                    data1: 0u32,
+                    data2: 0u16,
+                    data3: 0u16,
+                    data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8],
                 },
-                parameters: <[_]>::into_vec(box []),
-            })]),
-        }),
-    ]);
-    intercom::typelib::TypeInfo::Interface(intercom::ComBox::new(intercom::typelib::Interface {
-        name: "IFoo".into(),
-        variants: variants,
-        options: intercom::typelib::InterfaceOptions {
-            class_impl_interface: false,
-            ..Default::default()
-        },
-    }))
+                methods: <[_]>::into_vec(box [intercom::ComBox::new(intercom::typelib::Method {
+                    name: "trait_method".into(),
+                    return_type: intercom::typelib::Arg {
+                        name: "".into(),
+                        ty: "void".into(),
+                        indirection_level: 0,
+                        direction: intercom::typelib::Direction::Return,
+                    },
+                    parameters: <[_]>::into_vec(box []),
+                })]),
+            }),
+        ]);
+        <[_]>::into_vec(box [intercom::typelib::TypeInfo::Interface(
+            intercom::ComBox::new(intercom::typelib::Interface {
+                name: "IFoo".into(),
+                variants: variants,
+                options: intercom::typelib::InterfaceOptions {
+                    class_impl_interface: false,
+                    ..Default::default()
+                },
+            }),
+        )])
+    }
 }
 struct Foo;
-#[inline(always)]
 #[allow(non_snake_case)]
-fn __Foo_Foo_AutomationVtbl_offset() -> usize {
-    unsafe { &intercom::ComBoxData::<Foo>::null_vtable().Foo_Automation as *const _ as usize }
+impl intercom::attributes::ComClass<Foo, intercom::type_system::AutomationTypeSystem> for Foo {
+    #[inline(always)]
+    fn offset() -> usize {
+        unsafe { &intercom::ComBoxData::<Foo>::null_vtable().Foo_Automation as *const _ as usize }
+    }
 }
-#[inline(always)]
 #[allow(non_snake_case)]
-fn __Foo_Foo_RawVtbl_offset() -> usize {
-    unsafe { &intercom::ComBoxData::<Foo>::null_vtable().Foo_Raw as *const _ as usize }
+impl intercom::attributes::ComClass<Foo, intercom::type_system::RawTypeSystem> for Foo {
+    #[inline(always)]
+    fn offset() -> usize {
+        unsafe { &intercom::ComBoxData::<Foo>::null_vtable().Foo_Raw as *const _ as usize }
+    }
 }
-#[inline(always)]
 #[allow(non_snake_case)]
-fn __Foo_IFoo_AutomationVtbl_offset() -> usize {
-    unsafe { &intercom::ComBoxData::<Foo>::null_vtable().IFoo_Automation as *const _ as usize }
+impl intercom::attributes::ComClass<dyn IFoo, intercom::type_system::AutomationTypeSystem> for Foo {
+    #[inline(always)]
+    fn offset() -> usize {
+        unsafe { &intercom::ComBoxData::<Foo>::null_vtable().IFoo_Automation as *const _ as usize }
+    }
 }
-#[inline(always)]
 #[allow(non_snake_case)]
-fn __Foo_IFoo_RawVtbl_offset() -> usize {
-    unsafe { &intercom::ComBoxData::<Foo>::null_vtable().IFoo_Raw as *const _ as usize }
+impl intercom::attributes::ComClass<dyn IFoo, intercom::type_system::RawTypeSystem> for Foo {
+    #[inline(always)]
+    fn offset() -> usize {
+        unsafe { &intercom::ComBoxData::<Foo>::null_vtable().IFoo_Raw as *const _ as usize }
+    }
 }
 #[allow(non_upper_case_globals)]
-const __Foo_ISupportErrorInfoVtbl_INSTANCE: intercom::ISupportErrorInfoVtbl =
-    intercom::ISupportErrorInfoVtbl {
-        __base: intercom::IUnknownVtbl {
-            query_interface_Automation: intercom::ComBoxData::<Foo>::query_interface_ptr,
-            add_ref_Automation: intercom::ComBoxData::<Foo>::add_ref_ptr,
-            release_Automation: intercom::ComBoxData::<Foo>::release_ptr,
-        },
-        interface_supports_error_info_Automation:
-            intercom::ComBoxData::<Foo>::interface_supports_error_info_ptr,
-    };
+impl
+    intercom::attributes::ComImpl<
+        intercom::ISupportErrorInfo,
+        intercom::type_system::AutomationTypeSystem,
+    > for Foo
+{
+    fn vtable()
+     ->
+         &'static <dyn intercom::ISupportErrorInfo as
+intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::VTable{
+        type T = <dyn intercom::ISupportErrorInfo as intercom::attributes::ComInterface<
+            intercom::type_system::AutomationTypeSystem,
+        >>::VTable;
+        &T {
+            __base: {
+                type Vtbl = <dyn intercom::IUnknown as intercom::attributes::ComInterface<
+                    intercom::type_system::AutomationTypeSystem,
+                >>::VTable;
+                Vtbl {
+                    query_interface: intercom::ComBoxData::<Foo>::query_interface_ptr,
+                    add_ref: intercom::ComBoxData::<Foo>::add_ref_ptr,
+                    release: intercom::ComBoxData::<Foo>::release_ptr,
+                }
+            },
+            interface_supports_error_info:
+                intercom::ComBoxData::<Foo>::interface_supports_error_info_ptr,
+        }
+    }
+}
 impl intercom::HasInterface<intercom::IUnknown> for Foo {}
 #[allow(non_snake_case)]
 #[doc(hidden)]
-struct __FooVtblList {
-    _ISupportErrorInfo: &'static intercom::ISupportErrorInfoVtbl,
-    Foo_Automation: &'static __Foo_AutomationVtbl,
-    Foo_Raw: &'static __Foo_RawVtbl,
-    IFoo_Automation: &'static __IFoo_AutomationVtbl,
-    IFoo_Raw: &'static __IFoo_RawVtbl,
+struct __intercom_vtable_for_Foo {
+    _ISupportErrorInfo:
+        &'static <dyn intercom::ISupportErrorInfo as intercom::attributes::ComInterface<
+            intercom::type_system::AutomationTypeSystem,
+        >>::VTable,
+    Foo_Automation: &'static <Foo as intercom::attributes::ComInterface<
+        intercom::type_system::AutomationTypeSystem,
+    >>::VTable,
+    Foo_Raw: &'static <Foo as intercom::attributes::ComInterface<
+        intercom::type_system::RawTypeSystem,
+    >>::VTable,
+    IFoo_Automation: &'static <dyn IFoo as intercom::attributes::ComInterface<
+        intercom::type_system::AutomationTypeSystem,
+    >>::VTable,
+    IFoo_Raw: &'static <dyn IFoo as intercom::attributes::ComInterface<
+        intercom::type_system::RawTypeSystem,
+    >>::VTable,
 }
 impl intercom::CoClass for Foo {
-    type VTableList = __FooVtblList;
+    type VTableList = __intercom_vtable_for_Foo;
     fn create_vtable_list() -> Self::VTableList {
-        __FooVtblList {
-            _ISupportErrorInfo: &__Foo_ISupportErrorInfoVtbl_INSTANCE,
-            Foo_Automation: &__Foo_Foo_AutomationVtbl_INSTANCE,
-            Foo_Raw: &__Foo_Foo_RawVtbl_INSTANCE,
-            IFoo_Automation: &__Foo_IFoo_AutomationVtbl_INSTANCE,
-            IFoo_Raw: &__Foo_IFoo_RawVtbl_INSTANCE,
+        __intercom_vtable_for_Foo {
+            _ISupportErrorInfo: <Foo as intercom::attributes::ComImpl<
+                dyn intercom::ISupportErrorInfo,
+                intercom::type_system::AutomationTypeSystem,
+            >>::vtable(),
+            Foo_Automation: <Foo as intercom::attributes::ComImpl<
+                Foo,
+                intercom::type_system::AutomationTypeSystem,
+            >>::vtable(),
+            Foo_Raw: <Foo as intercom::attributes::ComImpl<
+                Foo,
+                intercom::type_system::RawTypeSystem,
+            >>::vtable(),
+            IFoo_Automation: <Foo as intercom::attributes::ComImpl<
+                dyn IFoo,
+                intercom::type_system::AutomationTypeSystem,
+            >>::vtable(),
+            IFoo_Raw: <Foo as intercom::attributes::ComImpl<
+                dyn IFoo,
+                intercom::type_system::RawTypeSystem,
+            >>::vtable(),
         }
     }
     fn query_interface(
@@ -236,41 +329,120 @@ impl intercom::CoClass for Foo {
         if riid.is_null() {
             return Err(intercom::raw::E_NOINTERFACE);
         }
-        Ok(match *unsafe { &*riid } {
-            intercom::IID_IUnknown => {
-                (&vtables._ISupportErrorInfo) as *const &intercom::ISupportErrorInfoVtbl
-                    as *mut &intercom::ISupportErrorInfoVtbl as intercom::RawComPtr
-            }
-            intercom::IID_ISupportErrorInfo => {
-                (&vtables._ISupportErrorInfo) as *const &intercom::ISupportErrorInfoVtbl
-                    as *mut &intercom::ISupportErrorInfoVtbl as intercom::RawComPtr
-            }
-            self::IID_Foo_Automation => {
-                &vtables.Foo_Automation as *const &__Foo_AutomationVtbl
-                    as *mut &__Foo_AutomationVtbl as intercom::RawComPtr
-            }
-            self::IID_Foo_Raw => {
-                &vtables.Foo_Raw as *const &__Foo_RawVtbl as *mut &__Foo_RawVtbl
-                    as intercom::RawComPtr
-            }
-            self::IID_IFoo_Automation => {
-                &vtables.IFoo_Automation as *const &__IFoo_AutomationVtbl
-                    as *mut &__IFoo_AutomationVtbl as intercom::RawComPtr
-            }
-            self::IID_IFoo_Raw => {
-                &vtables.IFoo_Raw as *const &__IFoo_RawVtbl as *mut &__IFoo_RawVtbl
-                    as intercom::RawComPtr
-            }
-            _ => return Err(intercom::raw::E_NOINTERFACE),
-        })
+        unsafe {
+            let riid = &*riid;
+            Ok(
+                if riid
+                    == <dyn intercom::IUnknown as intercom::attributes::ComInterface<
+                        intercom::type_system::AutomationTypeSystem,
+                    >>::iid()
+                {
+                    (&vtables._ISupportErrorInfo) as
+                       *const &<dyn intercom::ISupportErrorInfo as
+                               intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::VTable
+                       as
+                       *mut &<dyn intercom::ISupportErrorInfo as
+                             intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::VTable
+                       as intercom::RawComPtr
+                } else if riid
+                    == <dyn intercom::ISupportErrorInfo as intercom::attributes::ComInterface<
+                        intercom::type_system::AutomationTypeSystem,
+                    >>::iid()
+                {
+                    (&vtables._ISupportErrorInfo) as
+                       *const &<dyn intercom::ISupportErrorInfo as
+                               intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::VTable
+                       as
+                       *mut &<dyn intercom::ISupportErrorInfo as
+                             intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::VTable
+                       as intercom::RawComPtr
+                } else if riid
+                    == <Foo as intercom::attributes::ComInterface<
+                        intercom::type_system::AutomationTypeSystem,
+                    >>::iid()
+                {
+                    &vtables.Foo_Automation
+                        as *const &<Foo as intercom::attributes::ComInterface<
+                            intercom::type_system::AutomationTypeSystem,
+                        >>::VTable
+                        as *mut &<Foo as intercom::attributes::ComInterface<
+                            intercom::type_system::AutomationTypeSystem,
+                        >>::VTable as intercom::RawComPtr
+                } else if riid
+                    == <Foo as intercom::attributes::ComInterface<
+                        intercom::type_system::RawTypeSystem,
+                    >>::iid()
+                {
+                    &vtables.Foo_Raw
+                        as *const &<Foo as intercom::attributes::ComInterface<
+                            intercom::type_system::RawTypeSystem,
+                        >>::VTable
+                        as *mut &<Foo as intercom::attributes::ComInterface<
+                            intercom::type_system::RawTypeSystem,
+                        >>::VTable as intercom::RawComPtr
+                } else if riid
+                    == <dyn IFoo as intercom::attributes::ComInterface<
+                        intercom::type_system::AutomationTypeSystem,
+                    >>::iid()
+                {
+                    &vtables.IFoo_Automation
+                        as *const &<dyn IFoo as intercom::attributes::ComInterface<
+                            intercom::type_system::AutomationTypeSystem,
+                        >>::VTable
+                        as *mut &<dyn IFoo as intercom::attributes::ComInterface<
+                            intercom::type_system::AutomationTypeSystem,
+                        >>::VTable as intercom::RawComPtr
+                } else if riid
+                    == <dyn IFoo as intercom::attributes::ComInterface<
+                        intercom::type_system::RawTypeSystem,
+                    >>::iid()
+                {
+                    &vtables.IFoo_Raw
+                        as *const &<dyn IFoo as intercom::attributes::ComInterface<
+                            intercom::type_system::RawTypeSystem,
+                        >>::VTable
+                        as *mut &<dyn IFoo as intercom::attributes::ComInterface<
+                            intercom::type_system::RawTypeSystem,
+                        >>::VTable as intercom::RawComPtr
+                } else {
+                    return Err(intercom::raw::E_NOINTERFACE);
+                },
+            )
+        }
     }
     fn interface_supports_error_info(riid: intercom::REFIID) -> bool {
-        match *unsafe { &*riid } {
-            self::IID_Foo_Automation => true,
-            self::IID_Foo_Raw => true,
-            self::IID_IFoo_Automation => true,
-            self::IID_IFoo_Raw => true,
-            _ => false,
+        if riid.is_null() {
+            return false;
+        }
+        unsafe {
+            let riid = &*riid;
+            if riid
+                == <Foo as intercom::attributes::ComInterface<
+                    intercom::type_system::AutomationTypeSystem,
+                >>::iid()
+            {
+                true
+            } else if riid
+                == <Foo as intercom::attributes::ComInterface<
+                    intercom::type_system::RawTypeSystem,
+                >>::iid()
+            {
+                true
+            } else if riid
+                == <dyn IFoo as intercom::attributes::ComInterface<
+                    intercom::type_system::AutomationTypeSystem,
+                >>::iid()
+            {
+                true
+            } else if riid
+                == <dyn IFoo as intercom::attributes::ComInterface<
+                    intercom::type_system::RawTypeSystem,
+                >>::iid()
+            {
+                true
+            } else {
+                false
+            }
         }
     }
 }
@@ -282,10 +454,10 @@ pub const CLSID_Foo: intercom::CLSID = intercom::GUID {
     data3: 0u16,
     data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8],
 };
-pub fn get_intercom_coclass_info_for_Foo() -> Vec<intercom::typelib::TypeInfo> {
-    <[_]>::into_vec(box [
-        intercom::typelib::TypeInfo::Class(intercom::ComBox::new(
-            intercom::typelib::CoClass::__new(
+impl intercom::attributes::HasTypeInfo for Foo {
+    fn gather_type_info() -> Vec<intercom::typelib::TypeInfo> {
+        let mut r = <[_]>::into_vec(box [intercom::typelib::TypeInfo::Class(
+            intercom::ComBox::new(intercom::typelib::CoClass::__new(
                 "Foo".into(),
                 intercom::GUID {
                     data1: 0u32,
@@ -296,20 +468,33 @@ pub fn get_intercom_coclass_info_for_Foo() -> Vec<intercom::typelib::TypeInfo> {
                 <[_]>::into_vec(box [
                     intercom::typelib::InterfaceRef {
                         name: "Foo".into(),
-                        iid_automation: IID_Foo_Automation,
-                        iid_raw: IID_Foo_Raw,
+                        iid_automation: <Foo as intercom::attributes::ComInterface<
+                            intercom::type_system::AutomationTypeSystem,
+                        >>::iid()
+                        .clone(),
+                        iid_raw: <Foo as intercom::attributes::ComInterface<
+                            intercom::type_system::RawTypeSystem,
+                        >>::iid()
+                        .clone(),
                     },
                     intercom::typelib::InterfaceRef {
                         name: "IFoo".into(),
-                        iid_automation: IID_IFoo_Automation,
-                        iid_raw: IID_IFoo_Raw,
+                        iid_automation: <dyn IFoo as intercom::attributes::ComInterface<
+                            intercom::type_system::AutomationTypeSystem,
+                        >>::iid()
+                        .clone(),
+                        iid_raw: <dyn IFoo as intercom::attributes::ComInterface<
+                            intercom::type_system::RawTypeSystem,
+                        >>::iid()
+                        .clone(),
                     },
                 ]),
-            ),
-        )),
-        get_intercom_interface_info_for_Foo(),
-        get_intercom_interface_info_for_IFoo(),
-    ])
+            )),
+        )]);
+        r.extend(<Foo as intercom::attributes::InterfaceHasTypeInfo>::gather_type_info());
+        r.extend(<dyn IFoo as intercom::attributes::InterfaceHasTypeInfo>::gather_type_info());
+        r
+    }
 }
 impl Foo {
     pub fn struct_method(&self) {}
@@ -328,7 +513,11 @@ unsafe extern "system" fn __Foo_Foo_Automation_query_interface(
     intercom::type_system::AutomationTypeSystem,
 >>::ExternOutputType {
     intercom::ComBoxData::<Foo>::query_interface(
-        &mut *((self_vtable as usize - __Foo_Foo_AutomationVtbl_offset()) as *mut _),
+        &mut *((self_vtable as usize
+            - <Foo as intercom::attributes::ComClass<
+                Foo,
+                intercom::type_system::AutomationTypeSystem,
+            >>::offset()) as *mut _),
         riid,
         out,
     )
@@ -342,7 +531,11 @@ unsafe extern "system" fn __Foo_Foo_Automation_add_ref(self_vtable:
      <u32 as
 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
     intercom::ComBoxData::<Foo>::add_ref(
-        &mut *((self_vtable as usize - __Foo_Foo_AutomationVtbl_offset()) as *mut _),
+        &mut *((self_vtable as usize
+            - <Foo as intercom::attributes::ComClass<
+                Foo,
+                intercom::type_system::AutomationTypeSystem,
+            >>::offset()) as *mut _),
     )
 }
 #[allow(non_snake_case)]
@@ -354,7 +547,11 @@ unsafe extern "system" fn __Foo_Foo_Automation_release(self_vtable:
      <u32 as
 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
     intercom::ComBoxData::<Foo>::release_ptr(
-        (self_vtable as usize - __Foo_Foo_AutomationVtbl_offset()) as *mut _,
+        (self_vtable as usize
+            - <Foo as intercom::attributes::ComClass<
+                Foo,
+                intercom::type_system::AutomationTypeSystem,
+            >>::offset()) as *mut _,
     )
 }
 #[allow(non_snake_case)]
@@ -374,8 +571,10 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
              {
                  let self_combox =
                      (self_vtable as usize -
-                          __Foo_Foo_AutomationVtbl_offset()) as
-                         *mut intercom::ComBoxData<Foo>;
+                          <Foo as
+                              intercom::attributes::ComClass<Foo,
+                                                             intercom::type_system::AutomationTypeSystem>>::offset())
+                         as *mut intercom::ComBoxData<Foo>;
                  let self_struct: &Foo = &**self_combox;
                  let __result = self_struct.struct_method();
                  Ok({ })
@@ -391,14 +590,28 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
     }
 }
 #[allow(non_upper_case_globals)]
-const __Foo_Foo_AutomationVtbl_INSTANCE: __Foo_AutomationVtbl = __Foo_AutomationVtbl {
-    __base: intercom::IUnknownVtbl {
-        query_interface_Automation: __Foo_Foo_Automation_query_interface,
-        add_ref_Automation: __Foo_Foo_Automation_add_ref,
-        release_Automation: __Foo_Foo_Automation_release,
-    },
-    struct_method_Automation: __Foo_Foo_Automation_struct_method_Automation,
-};
+impl intercom::attributes::ComImpl<Foo, intercom::type_system::AutomationTypeSystem> for Foo {
+    fn vtable() -> &'static <Foo as intercom::attributes::ComInterface<
+        intercom::type_system::AutomationTypeSystem,
+    >>::VTable {
+        type T = <Foo as intercom::attributes::ComInterface<
+            intercom::type_system::AutomationTypeSystem,
+        >>::VTable;
+        &T {
+            __base: {
+                type TVtbl = <dyn intercom::IUnknown as intercom::attributes::ComInterface<
+                    intercom::type_system::AutomationTypeSystem,
+                >>::VTable;
+                TVtbl {
+                    query_interface: __Foo_Foo_Automation_query_interface,
+                    add_ref: __Foo_Foo_Automation_add_ref,
+                    release: __Foo_Foo_Automation_release,
+                }
+            },
+            struct_method: __Foo_Foo_Automation_struct_method_Automation,
+        }
+    }
+}
 #[allow(non_snake_case)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_Raw_query_interface(
@@ -412,11 +625,13 @@ unsafe extern "system" fn __Foo_Foo_Raw_query_interface(
 ) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
     intercom::type_system::AutomationTypeSystem,
 >>::ExternOutputType {
-    intercom::ComBoxData::<Foo>::query_interface(
-        &mut *((self_vtable as usize - __Foo_Foo_RawVtbl_offset()) as *mut _),
-        riid,
-        out,
-    )
+    intercom::ComBoxData::<Foo>::query_interface(&mut *((self_vtable as usize
+                                                             -
+                                                             <Foo as
+                                                                 intercom::attributes::ComClass<Foo,
+                                                                                                intercom::type_system::RawTypeSystem>>::offset())
+                                                            as *mut _), riid,
+                                                 out)
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]
@@ -426,9 +641,11 @@ unsafe extern "system" fn __Foo_Foo_Raw_add_ref(self_vtable:
  ->
      <u32 as
 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
-    intercom::ComBoxData::<Foo>::add_ref(
-        &mut *((self_vtable as usize - __Foo_Foo_RawVtbl_offset()) as *mut _),
-    )
+    intercom::ComBoxData::<Foo>::add_ref(&mut *((self_vtable as usize -
+                                                     <Foo as
+                                                         intercom::attributes::ComClass<Foo,
+                                                                                        intercom::type_system::RawTypeSystem>>::offset())
+                                                    as *mut _))
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]
@@ -438,9 +655,11 @@ unsafe extern "system" fn __Foo_Foo_Raw_release(self_vtable:
  ->
      <u32 as
 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
-    intercom::ComBoxData::<Foo>::release_ptr(
-        (self_vtable as usize - __Foo_Foo_RawVtbl_offset()) as *mut _,
-    )
+    intercom::ComBoxData::<Foo>::release_ptr((self_vtable as usize -
+                                                  <Foo as
+                                                      intercom::attributes::ComClass<Foo,
+                                                                                     intercom::type_system::RawTypeSystem>>::offset())
+                                                 as *mut _)
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]
@@ -458,8 +677,11 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
         (||
              {
                  let self_combox =
-                     (self_vtable as usize - __Foo_Foo_RawVtbl_offset()) as
-                         *mut intercom::ComBoxData<Foo>;
+                     (self_vtable as usize -
+                          <Foo as
+                              intercom::attributes::ComClass<Foo,
+                                                             intercom::type_system::RawTypeSystem>>::offset())
+                         as *mut intercom::ComBoxData<Foo>;
                  let self_struct: &Foo = &**self_combox;
                  let __result = self_struct.struct_method();
                  Ok({ })
@@ -475,65 +697,110 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
     }
 }
 #[allow(non_upper_case_globals)]
-const __Foo_Foo_RawVtbl_INSTANCE: __Foo_RawVtbl = __Foo_RawVtbl {
-    __base: intercom::IUnknownVtbl {
-        query_interface_Automation: __Foo_Foo_Raw_query_interface,
-        add_ref_Automation: __Foo_Foo_Raw_add_ref,
-        release_Automation: __Foo_Foo_Raw_release,
-    },
-    struct_method_Raw: __Foo_Foo_Raw_struct_method_Raw,
-};
-impl intercom::HasInterface<Foo> for Foo {}
-#[doc = "`Foo` interface ID."]
-#[allow(non_upper_case_globals)]
-pub const IID_Foo_Automation: intercom::IID = intercom::GUID {
-    data1: 0u32,
-    data2: 0u16,
-    data3: 0u16,
-    data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 2u8],
-};
-#[allow(non_camel_case_types)]
-#[allow(non_snake_case)]
-#[allow(clippy::all)]
-#[repr(C)]
-#[doc(hidden)]
-pub struct __Foo_AutomationVtbl {
-    pub __base: intercom::IUnknownVtbl,
-    pub struct_method_Automation:
-        unsafe extern "system" fn(
-            self_vtable: intercom::RawComPtr,
-        ) -> <() as intercom::type_system::ExternType<
-            intercom::type_system::AutomationTypeSystem,
-        >>::ExternOutputType,
+impl intercom::attributes::ComImpl<Foo, intercom::type_system::RawTypeSystem> for Foo {
+    fn vtable()
+     ->
+         &'static <Foo as
+intercom::attributes::ComInterface<intercom::type_system::RawTypeSystem>>::VTable{
+        type T = <Foo as intercom::attributes::ComInterface<
+            intercom::type_system::RawTypeSystem,
+        >>::VTable;
+        &T {
+            __base: {
+                type TVtbl = <dyn intercom::IUnknown as intercom::attributes::ComInterface<
+                    intercom::type_system::AutomationTypeSystem,
+                >>::VTable;
+                TVtbl {
+                    query_interface: __Foo_Foo_Raw_query_interface,
+                    add_ref: __Foo_Foo_Raw_add_ref,
+                    release: __Foo_Foo_Raw_release,
+                }
+            },
+            struct_method: __Foo_Foo_Raw_struct_method_Raw,
+        }
+    }
 }
-#[doc = "`Foo` interface ID."]
-#[allow(non_upper_case_globals)]
-pub const IID_Foo_Raw: intercom::IID = intercom::GUID {
-    data1: 0u32,
-    data2: 0u16,
-    data3: 0u16,
-    data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 3u8],
-};
+impl intercom::HasInterface<Foo> for Foo {}
 #[allow(non_camel_case_types)]
 #[allow(non_snake_case)]
 #[allow(clippy::all)]
 #[repr(C)]
 #[doc(hidden)]
-pub struct __Foo_RawVtbl {
-    pub __base: intercom::IUnknownVtbl,
-    pub struct_method_Raw: unsafe extern "system" fn(
+pub struct __IntercomVtableForFoo_Automation {
+    pub __base: <dyn intercom::IUnknown as intercom::attributes::ComInterface<
+        intercom::type_system::AutomationTypeSystem,
+    >>::VTable,
+    pub struct_method: unsafe extern "system" fn(
         self_vtable: intercom::RawComPtr,
-    )
-        -> <() as intercom::type_system::ExternType<
+    ) -> <() as intercom::type_system::ExternType<
         intercom::type_system::AutomationTypeSystem,
     >>::ExternOutputType,
 }
+#[allow(non_camel_case_types)]
+#[allow(non_snake_case)]
+#[allow(clippy::all)]
+#[doc(hidden)]
+impl intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem> for Foo {
+    type VTable = __IntercomVtableForFoo_Automation;
+    fn iid() -> &'static intercom::IID {
+        &intercom::GUID {
+            data1: 0u32,
+            data2: 0u16,
+            data3: 0u16,
+            data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 2u8],
+        }
+    }
+}
+#[allow(non_camel_case_types)]
+#[allow(non_snake_case)]
+#[allow(clippy::all)]
+#[repr(C)]
+#[doc(hidden)]
+pub struct __IntercomVtableForFoo_Raw {
+    pub __base: <dyn intercom::IUnknown as intercom::attributes::ComInterface<
+        intercom::type_system::AutomationTypeSystem,
+    >>::VTable,
+    pub struct_method: unsafe extern "system" fn(
+        self_vtable: intercom::RawComPtr,
+    ) -> <() as intercom::type_system::ExternType<
+        intercom::type_system::AutomationTypeSystem,
+    >>::ExternOutputType,
+}
+#[allow(non_camel_case_types)]
+#[allow(non_snake_case)]
+#[allow(clippy::all)]
+#[doc(hidden)]
+impl intercom::attributes::ComInterface<intercom::type_system::RawTypeSystem> for Foo {
+    type VTable = __IntercomVtableForFoo_Raw;
+    fn iid() -> &'static intercom::IID {
+        &intercom::GUID {
+            data1: 0u32,
+            data2: 0u16,
+            data3: 0u16,
+            data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 3u8],
+        }
+    }
+}
 impl intercom::ComInterface for Foo {
     #[doc = "Returns the IID of the requested interface."]
+    fn iid_ts<TS: intercom::type_system::TypeSystem>() -> &'static intercom::IID
+    where
+        Self: intercom::attributes::ComInterface<TS>,
+    {
+        <Self as intercom::attributes::ComInterface<TS>>::iid()
+    }
     fn iid(ts: intercom::type_system::TypeSystemName) -> Option<&'static intercom::IID> {
         match ts {
-            intercom::type_system::TypeSystemName::Automation => Some(&IID_Foo_Automation),
-            intercom::type_system::TypeSystemName::Raw => Some(&IID_Foo_Raw),
+            intercom::type_system::TypeSystemName::Automation => {
+                Some(<Self as intercom::attributes::ComInterface<
+                    intercom::type_system::AutomationTypeSystem,
+                >>::iid())
+            }
+            intercom::type_system::TypeSystemName::Raw => {
+                Some(<Self as intercom::attributes::ComInterface<
+                    intercom::type_system::RawTypeSystem,
+                >>::iid())
+            }
         }
     }
     fn deref(com_itf: &intercom::ComItf<Foo>) -> &Foo {
@@ -560,55 +827,59 @@ impl intercom::type_system::BidirectionalTypeInfo for Foo {
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]
-pub(crate) fn get_intercom_interface_info_for_Foo() -> intercom::typelib::TypeInfo {
-    let variants = <[_]>::into_vec(box [
-        intercom::ComBox::new(intercom::typelib::InterfaceVariant {
-            ts: intercom::type_system::TypeSystemName::Automation,
-            iid: intercom::GUID {
-                data1: 0u32,
-                data2: 0u16,
-                data3: 0u16,
-                data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 2u8],
-            },
-            methods: <[_]>::into_vec(box [intercom::ComBox::new(intercom::typelib::Method {
-                name: "struct_method".into(),
-                return_type: intercom::typelib::Arg {
-                    name: "".into(),
-                    ty: "void".into(),
-                    indirection_level: 0,
-                    direction: intercom::typelib::Direction::Return,
+impl intercom::attributes::InterfaceHasTypeInfo for Foo {
+    fn gather_type_info() -> Vec<intercom::typelib::TypeInfo> {
+        let variants = <[_]>::into_vec(box [
+            intercom::ComBox::new(intercom::typelib::InterfaceVariant {
+                ts: intercom::type_system::TypeSystemName::Automation,
+                iid: intercom::GUID {
+                    data1: 0u32,
+                    data2: 0u16,
+                    data3: 0u16,
+                    data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 2u8],
                 },
-                parameters: <[_]>::into_vec(box []),
-            })]),
-        }),
-        intercom::ComBox::new(intercom::typelib::InterfaceVariant {
-            ts: intercom::type_system::TypeSystemName::Raw,
-            iid: intercom::GUID {
-                data1: 0u32,
-                data2: 0u16,
-                data3: 0u16,
-                data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 3u8],
-            },
-            methods: <[_]>::into_vec(box [intercom::ComBox::new(intercom::typelib::Method {
-                name: "struct_method".into(),
-                return_type: intercom::typelib::Arg {
-                    name: "".into(),
-                    ty: "void".into(),
-                    indirection_level: 0,
-                    direction: intercom::typelib::Direction::Return,
+                methods: <[_]>::into_vec(box [intercom::ComBox::new(intercom::typelib::Method {
+                    name: "struct_method".into(),
+                    return_type: intercom::typelib::Arg {
+                        name: "".into(),
+                        ty: "void".into(),
+                        indirection_level: 0,
+                        direction: intercom::typelib::Direction::Return,
+                    },
+                    parameters: <[_]>::into_vec(box []),
+                })]),
+            }),
+            intercom::ComBox::new(intercom::typelib::InterfaceVariant {
+                ts: intercom::type_system::TypeSystemName::Raw,
+                iid: intercom::GUID {
+                    data1: 0u32,
+                    data2: 0u16,
+                    data3: 0u16,
+                    data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 3u8],
                 },
-                parameters: <[_]>::into_vec(box []),
-            })]),
-        }),
-    ]);
-    intercom::typelib::TypeInfo::Interface(intercom::ComBox::new(intercom::typelib::Interface {
-        name: "Foo".into(),
-        variants: variants,
-        options: intercom::typelib::InterfaceOptions {
-            class_impl_interface: true,
-            ..Default::default()
-        },
-    }))
+                methods: <[_]>::into_vec(box [intercom::ComBox::new(intercom::typelib::Method {
+                    name: "struct_method".into(),
+                    return_type: intercom::typelib::Arg {
+                        name: "".into(),
+                        ty: "void".into(),
+                        indirection_level: 0,
+                        direction: intercom::typelib::Direction::Return,
+                    },
+                    parameters: <[_]>::into_vec(box []),
+                })]),
+            }),
+        ]);
+        <[_]>::into_vec(box [intercom::typelib::TypeInfo::Interface(
+            intercom::ComBox::new(intercom::typelib::Interface {
+                name: "Foo".into(),
+                variants: variants,
+                options: intercom::typelib::InterfaceOptions {
+                    class_impl_interface: true,
+                    ..Default::default()
+                },
+            }),
+        )])
+    }
 }
 impl IFoo for Foo {
     fn trait_method(&self) {}
@@ -627,7 +898,11 @@ unsafe extern "system" fn __Foo_IFoo_Automation_query_interface(
     intercom::type_system::AutomationTypeSystem,
 >>::ExternOutputType {
     intercom::ComBoxData::<Foo>::query_interface(
-        &mut *((self_vtable as usize - __Foo_IFoo_AutomationVtbl_offset()) as *mut _),
+        &mut *((self_vtable as usize
+            - <Foo as intercom::attributes::ComClass<
+                dyn IFoo,
+                intercom::type_system::AutomationTypeSystem,
+            >>::offset()) as *mut _),
         riid,
         out,
     )
@@ -641,7 +916,11 @@ unsafe extern "system" fn __Foo_IFoo_Automation_add_ref(self_vtable:
      <u32 as
 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
     intercom::ComBoxData::<Foo>::add_ref(
-        &mut *((self_vtable as usize - __Foo_IFoo_AutomationVtbl_offset()) as *mut _),
+        &mut *((self_vtable as usize
+            - <Foo as intercom::attributes::ComClass<
+                dyn IFoo,
+                intercom::type_system::AutomationTypeSystem,
+            >>::offset()) as *mut _),
     )
 }
 #[allow(non_snake_case)]
@@ -653,7 +932,11 @@ unsafe extern "system" fn __Foo_IFoo_Automation_release(self_vtable:
      <u32 as
 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
     intercom::ComBoxData::<Foo>::release_ptr(
-        (self_vtable as usize - __Foo_IFoo_AutomationVtbl_offset()) as *mut _,
+        (self_vtable as usize
+            - <Foo as intercom::attributes::ComClass<
+                dyn IFoo,
+                intercom::type_system::AutomationTypeSystem,
+            >>::offset()) as *mut _,
     )
 }
 #[allow(non_snake_case)]
@@ -673,8 +956,10 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
              {
                  let self_combox =
                      (self_vtable as usize -
-                          __Foo_IFoo_AutomationVtbl_offset()) as
-                         *mut intercom::ComBoxData<Foo>;
+                          <Foo as
+                              intercom::attributes::ComClass<dyn IFoo,
+                                                             intercom::type_system::AutomationTypeSystem>>::offset())
+                         as *mut intercom::ComBoxData<Foo>;
                  let self_struct: &dyn IFoo = &**self_combox;
                  let __result = self_struct.trait_method();
                  Ok({ })
@@ -690,14 +975,28 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
     }
 }
 #[allow(non_upper_case_globals)]
-const __Foo_IFoo_AutomationVtbl_INSTANCE: __IFoo_AutomationVtbl = __IFoo_AutomationVtbl {
-    __base: intercom::IUnknownVtbl {
-        query_interface_Automation: __Foo_IFoo_Automation_query_interface,
-        add_ref_Automation: __Foo_IFoo_Automation_add_ref,
-        release_Automation: __Foo_IFoo_Automation_release,
-    },
-    trait_method_Automation: __Foo_IFoo_Automation_trait_method_Automation,
-};
+impl intercom::attributes::ComImpl<dyn IFoo, intercom::type_system::AutomationTypeSystem> for Foo {
+    fn vtable() -> &'static <dyn IFoo as intercom::attributes::ComInterface<
+        intercom::type_system::AutomationTypeSystem,
+    >>::VTable {
+        type T = <dyn IFoo as intercom::attributes::ComInterface<
+            intercom::type_system::AutomationTypeSystem,
+        >>::VTable;
+        &T {
+            __base: {
+                type TVtbl = <dyn intercom::IUnknown as intercom::attributes::ComInterface<
+                    intercom::type_system::AutomationTypeSystem,
+                >>::VTable;
+                TVtbl {
+                    query_interface: __Foo_IFoo_Automation_query_interface,
+                    add_ref: __Foo_IFoo_Automation_add_ref,
+                    release: __Foo_IFoo_Automation_release,
+                }
+            },
+            trait_method: __Foo_IFoo_Automation_trait_method_Automation,
+        }
+    }
+}
 #[allow(non_snake_case)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_IFoo_Raw_query_interface(
@@ -712,7 +1011,11 @@ unsafe extern "system" fn __Foo_IFoo_Raw_query_interface(
     intercom::type_system::AutomationTypeSystem,
 >>::ExternOutputType {
     intercom::ComBoxData::<Foo>::query_interface(
-        &mut *((self_vtable as usize - __Foo_IFoo_RawVtbl_offset()) as *mut _),
+        &mut *((self_vtable as usize
+            - <Foo as intercom::attributes::ComClass<
+                dyn IFoo,
+                intercom::type_system::RawTypeSystem,
+            >>::offset()) as *mut _),
         riid,
         out,
     )
@@ -726,7 +1029,11 @@ unsafe extern "system" fn __Foo_IFoo_Raw_add_ref(self_vtable:
      <u32 as
 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
     intercom::ComBoxData::<Foo>::add_ref(
-        &mut *((self_vtable as usize - __Foo_IFoo_RawVtbl_offset()) as *mut _),
+        &mut *((self_vtable as usize
+            - <Foo as intercom::attributes::ComClass<
+                dyn IFoo,
+                intercom::type_system::RawTypeSystem,
+            >>::offset()) as *mut _),
     )
 }
 #[allow(non_snake_case)]
@@ -738,7 +1045,11 @@ unsafe extern "system" fn __Foo_IFoo_Raw_release(self_vtable:
      <u32 as
 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
     intercom::ComBoxData::<Foo>::release_ptr(
-        (self_vtable as usize - __Foo_IFoo_RawVtbl_offset()) as *mut _,
+        (self_vtable as usize
+            - <Foo as intercom::attributes::ComClass<
+                dyn IFoo,
+                intercom::type_system::RawTypeSystem,
+            >>::offset()) as *mut _,
     )
 }
 #[allow(non_snake_case)]
@@ -757,8 +1068,11 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
         (||
              {
                  let self_combox =
-                     (self_vtable as usize - __Foo_IFoo_RawVtbl_offset()) as
-                         *mut intercom::ComBoxData<Foo>;
+                     (self_vtable as usize -
+                          <Foo as
+                              intercom::attributes::ComClass<dyn IFoo,
+                                                             intercom::type_system::RawTypeSystem>>::offset())
+                         as *mut intercom::ComBoxData<Foo>;
                  let self_struct: &dyn IFoo = &**self_combox;
                  let __result = self_struct.trait_method();
                  Ok({ })
@@ -774,12 +1088,26 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
     }
 }
 #[allow(non_upper_case_globals)]
-const __Foo_IFoo_RawVtbl_INSTANCE: __IFoo_RawVtbl = __IFoo_RawVtbl {
-    __base: intercom::IUnknownVtbl {
-        query_interface_Automation: __Foo_IFoo_Raw_query_interface,
-        add_ref_Automation: __Foo_IFoo_Raw_add_ref,
-        release_Automation: __Foo_IFoo_Raw_release,
-    },
-    trait_method_Raw: __Foo_IFoo_Raw_trait_method_Raw,
-};
+impl intercom::attributes::ComImpl<dyn IFoo, intercom::type_system::RawTypeSystem> for Foo {
+    fn vtable() -> &'static <dyn IFoo as intercom::attributes::ComInterface<
+        intercom::type_system::RawTypeSystem,
+    >>::VTable {
+        type T = <dyn IFoo as intercom::attributes::ComInterface<
+            intercom::type_system::RawTypeSystem,
+        >>::VTable;
+        &T {
+            __base: {
+                type TVtbl = <dyn intercom::IUnknown as intercom::attributes::ComInterface<
+                    intercom::type_system::AutomationTypeSystem,
+                >>::VTable;
+                TVtbl {
+                    query_interface: __Foo_IFoo_Raw_query_interface,
+                    add_ref: __Foo_IFoo_Raw_add_ref,
+                    release: __Foo_IFoo_Raw_release,
+                }
+            },
+            trait_method: __Foo_IFoo_Raw_trait_method_Raw,
+        }
+    }
+}
 impl intercom::HasInterface<dyn IFoo> for Foo {}

--- a/intercom-attributes/tests/data/macro/private_item.rs.stdout
+++ b/intercom-attributes/tests/data/macro/private_item.rs.stdout
@@ -296,6 +296,7 @@ struct __intercom_vtable_for_Foo {
         intercom::type_system::RawTypeSystem,
     >>::VTable,
 }
+#[allow(clippy::all)]
 impl intercom::CoClass for Foo {
     type VTableList = __intercom_vtable_for_Foo;
     fn create_vtable_list() -> Self::VTableList {

--- a/intercom-attributes/tests/data/ui/span-comclass-unknown-interface.rs.stderr
+++ b/intercom-attributes/tests/data/ui/span-comclass-unknown-interface.rs.stderr
@@ -1,58 +1,9 @@
-error[E0412]: cannot find type `__IDoesNotExist_AutomationVtbl` in this scope
+error[E0405]: cannot find trait `IDoesNotExist` in this scope
  --> span-comclass-unknown-interface.rs:5:13
   |
 5 | #[com_class(IDoesNotExist)]
   |             ^^^^^^^^^^^^^ not found in this scope
 
-error[E0412]: cannot find type `__IDoesNotExist_RawVtbl` in this scope
- --> span-comclass-unknown-interface.rs:5:13
-  |
-5 | #[com_class(IDoesNotExist)]
-  |             ^^^^^^^^^^^^^ not found in this scope
+error: aborting due to previous error
 
-error[E0425]: cannot find value `__S_IDoesNotExist_AutomationVtbl_INSTANCE` in this scope
- --> span-comclass-unknown-interface.rs:5:13
-  |
-5 | #[com_class(IDoesNotExist)]
-  |             ^^^^^^^^^^^^^ help: a function with a similar name exists: `__S_IDoesNotExist_AutomationVtbl_offset`
-
-error[E0425]: cannot find value `__S_IDoesNotExist_RawVtbl_INSTANCE` in this scope
- --> span-comclass-unknown-interface.rs:5:13
-  |
-5 | #[com_class(IDoesNotExist)]
-  |             ^^^^^^^^^^^^^ help: a function with a similar name exists: `__S_IDoesNotExist_RawVtbl_offset`
-
-error[E0531]: cannot find unit struct/variant or constant `IID_IDoesNotExist_Automation` in module `self`
- --> span-comclass-unknown-interface.rs:5:13
-  |
-5 | #[com_class(IDoesNotExist)]
-  |             ^^^^^^^^^^^^^ not found in `self`
-
-error[E0531]: cannot find unit struct/variant or constant `IID_IDoesNotExist_Raw` in module `self`
- --> span-comclass-unknown-interface.rs:5:13
-  |
-5 | #[com_class(IDoesNotExist)]
-  |             ^^^^^^^^^^^^^ not found in `self`
-
-error[E0425]: cannot find value `IID_IDoesNotExist_Automation` in this scope
- --> span-comclass-unknown-interface.rs:5:13
-  |
-5 | #[com_class(IDoesNotExist)]
-  |             ^^^^^^^^^^^^^ not found in this scope
-
-error[E0425]: cannot find value `IID_IDoesNotExist_Raw` in this scope
- --> span-comclass-unknown-interface.rs:5:13
-  |
-5 | #[com_class(IDoesNotExist)]
-  |             ^^^^^^^^^^^^^ not found in this scope
-
-error[E0425]: cannot find function `get_intercom_interface_info_for_IDoesNotExist` in this scope
- --> span-comclass-unknown-interface.rs:5:13
-  |
-5 | #[com_class(IDoesNotExist)]
-  |             ^^^^^^^^^^^^^ not found in this scope
-
-error: aborting due to 9 previous errors
-
-Some errors have detailed explanations: E0412, E0425, E0531.
-For more information about an error, try `rustc --explain E0412`.
+For more information about this error, try `rustc --explain E0405`.

--- a/intercom-attributes/tests/data/ui/span-comimpl-for-non-comclass.rs
+++ b/intercom-attributes/tests/data/ui/span-comimpl-for-non-comclass.rs
@@ -2,9 +2,9 @@
 extern crate intercom;
 use intercom::*;
 
+#[com_interface]
 trait NotComInterface {}
 
-#[com_class(NotComInterface)]
 struct S;
 
 #[com_impl]

--- a/intercom-attributes/tests/data/ui/span-comimpl-for-non-comclass.rs.stderr
+++ b/intercom-attributes/tests/data/ui/span-comimpl-for-non-comclass.rs.stderr
@@ -1,0 +1,9 @@
+error[E0277]: the trait bound `S: intercom::CoClass` is not satisfied
+  --> span-comimpl-for-non-comclass.rs:11:1
+   |
+11 | impl NotComInterface for S {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `intercom::CoClass` is not implemented for `S`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/intercom-attributes/tests/data/ui/span-comimpl-no-interface.rs.stderr
+++ b/intercom-attributes/tests/data/ui/span-comimpl-no-interface.rs.stderr
@@ -1,52 +1,33 @@
-error[E0425]: cannot find function `__S_NotComTrait_AutomationVtbl_offset` in this scope
-  --> span-comimpl-no-interface.rs:10:6
+error[E0277]: the trait bound `(dyn NotComInterface + 'static): intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>` is not satisfied
+ --> span-comimpl-no-interface.rs:7:1
+  |
+7 | #[com_class(NotComInterface)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>` is not implemented for `(dyn NotComInterface + 'static)`
+
+error[E0277]: the trait bound `(dyn NotComInterface + 'static): intercom::attributes::ComInterface<intercom::type_system::RawTypeSystem>` is not satisfied
+ --> span-comimpl-no-interface.rs:7:1
+  |
+7 | #[com_class(NotComInterface)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `intercom::attributes::ComInterface<intercom::type_system::RawTypeSystem>` is not implemented for `(dyn NotComInterface + 'static)`
+
+error[E0277]: the trait bound `(dyn NotComInterface + 'static): intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>` is not satisfied
+  --> span-comimpl-no-interface.rs:11:6
    |
-10 | impl NotComTrait for S {}
-   |      ^^^^^^^^^^^ help: a constant with a similar name exists: `__S_NotComTrait_AutomationVtbl_INSTANCE`
+11 | impl NotComInterface for S {}
+   |      ^^^^^^^^^^^^^^^ the trait `intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>` is not implemented for `(dyn NotComInterface + 'static)`
 
-error[E0412]: cannot find type `__NotComTrait_AutomationVtbl` in this scope
-  --> span-comimpl-no-interface.rs:10:6
+error[E0277]: the trait bound `(dyn NotComInterface + 'static): intercom::attributes::ComInterface<intercom::type_system::RawTypeSystem>` is not satisfied
+  --> span-comimpl-no-interface.rs:11:6
    |
-10 | impl NotComTrait for S {}
-   |      ^^^^^^^^^^^ not found in this scope
+11 | impl NotComInterface for S {}
+   |      ^^^^^^^^^^^^^^^ the trait `intercom::attributes::ComInterface<intercom::type_system::RawTypeSystem>` is not implemented for `(dyn NotComInterface + 'static)`
 
-error[E0422]: cannot find struct, variant or union type `__NotComTrait_AutomationVtbl` in this scope
-  --> span-comimpl-no-interface.rs:10:6
+error[E0277]: the trait bound `(dyn NotComInterface + 'static): intercom::ComInterface` is not satisfied
+  --> span-comimpl-no-interface.rs:11:1
    |
-10 | impl NotComTrait for S {}
-   |      ^^^^^^^^^^^ not found in this scope
+11 | impl NotComInterface for S {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `intercom::ComInterface` is not implemented for `(dyn NotComInterface + 'static)`
 
-error[E0425]: cannot find function `__S_NotComTrait_RawVtbl_offset` in this scope
-  --> span-comimpl-no-interface.rs:10:6
-   |
-10 | impl NotComTrait for S {}
-   |      ^^^^^^^^^^^ help: a constant with a similar name exists: `__S_NotComTrait_RawVtbl_INSTANCE`
+error: aborting due to 5 previous errors
 
-error[E0412]: cannot find type `__NotComTrait_RawVtbl` in this scope
-  --> span-comimpl-no-interface.rs:10:6
-   |
-10 | impl NotComTrait for S {}
-   |      ^^^^^^^^^^^ not found in this scope
-
-error[E0422]: cannot find struct, variant or union type `__NotComTrait_RawVtbl` in this scope
-  --> span-comimpl-no-interface.rs:10:6
-   |
-10 | impl NotComTrait for S {}
-   |      ^^^^^^^^^^^ not found in this scope
-
-error[E0277]: the trait bound `(dyn NotComTrait + 'static): intercom::ComInterface` is not satisfied
-  --> span-comimpl-no-interface.rs:10:1
-   |
-10 | impl NotComTrait for S {}
-   | ^^^^^^^^^^^^^^^^^^^^^^ the trait `intercom::ComInterface` is not implemented for `(dyn NotComTrait + 'static)`
-
-error[E0277]: the trait bound `S: intercom::CoClass` is not satisfied
-  --> span-comimpl-no-interface.rs:10:1
-   |
-10 | impl NotComTrait for S {}
-   | ^^^^^^^^^^^^^^^^^^^^^^ the trait `intercom::CoClass` is not implemented for `S`
-
-error: aborting due to 8 previous errors
-
-Some errors have detailed explanations: E0277, E0412, E0422, E0425.
-For more information about an error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0277`.

--- a/intercom-common/src/attributes/com_class.rs
+++ b/intercom-common/src/attributes/com_class.rs
@@ -204,6 +204,7 @@ pub fn expand_com_class(
 
     // The actual CoClass implementation.
     output.push(quote!(
+        #[allow(clippy::all)]
         impl intercom::CoClass for #struct_ident {
             type VTableList = #vtable_list_ident;
             fn create_vtable_list() -> Self::VTableList {

--- a/intercom-common/src/idents.rs
+++ b/intercom-common/src/idents.rs
@@ -31,29 +31,6 @@ pub fn method_impl(struct_ident: &Ident, itf_ident: &Ident, method_name: &str) -
     new_ident(&format!("__{}_{}_{}", struct_ident, itf_ident, method_name))
 }
 
-pub fn vtable_struct(itf_ident: &Ident, span: Span) -> Ident
-{
-    Ident::new(&format!("__{}Vtbl", itf_ident), span)
-}
-
-pub fn vtable_instance(struct_name: &Ident, itf_ident: &Ident, span: Span) -> Ident
-{
-    Ident::new(
-        &format!("__{}_{}Vtbl_INSTANCE", struct_name, itf_ident),
-        span,
-    )
-}
-
-pub fn vtable_list(struct_ident: &Ident) -> Ident
-{
-    new_ident(&format!("__{}VtblList", struct_ident))
-}
-
-pub fn vtable_offset(s: &Ident, i: &Ident, span: Span) -> Ident
-{
-    Ident::new(&format!("__{}_{}Vtbl_offset", s, i), span)
-}
-
 fn new_ident(s: &str) -> Ident
 {
     Ident::new(s, Span::call_site())

--- a/intercom-common/src/lib.rs
+++ b/intercom-common/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(non_exhaustive)]
 #![recursion_limit = "128"]
 #![allow(clippy::match_bool)]
 

--- a/intercom/src/attributes.rs
+++ b/intercom/src/attributes.rs
@@ -1,0 +1,30 @@
+use intercom::{type_system::TypeSystem, IID};
+
+pub trait ComImpl<TInterface: ?Sized, TS: TypeSystem>
+where
+    TInterface: ComInterface<TS>,
+{
+    fn vtable() -> &'static TInterface::VTable;
+}
+
+pub trait ComClass<TInterface: ?Sized, TS: TypeSystem>
+{
+    #[inline(always)]
+    fn offset() -> usize;
+}
+
+pub trait ComInterface<TS: TypeSystem>
+{
+    type VTable;
+    fn iid() -> &'static IID;
+}
+
+pub trait HasTypeInfo
+{
+    fn gather_type_info() -> Vec<crate::typelib::TypeInfo>;
+}
+
+pub trait InterfaceHasTypeInfo
+{
+    fn gather_type_info() -> Vec<crate::typelib::TypeInfo>;
+}

--- a/intercom/src/attributes.rs
+++ b/intercom/src/attributes.rs
@@ -9,7 +9,6 @@ where
 
 pub trait ComClass<TInterface: ?Sized, TS: TypeSystem>
 {
-    #[inline(always)]
     fn offset() -> usize;
 }
 

--- a/intercom/src/error.rs
+++ b/intercom/src/error.rs
@@ -3,7 +3,9 @@ use std::error::Error;
 
 use super::*;
 use crate::attributes;
-use crate::type_system::{AutomationTypeSystem, ExternType, IntercomFrom, TypeSystem};
+use crate::type_system::{
+    AutomationTypeSystem, ExternType, IntercomFrom, RawTypeSystem, TypeSystem,
+};
 
 /// Error structure containing the available information on a COM error.
 #[derive(Debug)]
@@ -455,7 +457,9 @@ pub fn load_error(iunk: &ComItf<dyn IUnknown>, iid: &GUID, err: raw::HRESULT) ->
     // Do not try to load error if this is IUnknown or ISupportErrorInfo.
     // Both of these are used during error handling and may fail.
     if iid == <dyn IUnknown as attributes::ComInterface<AutomationTypeSystem>>::iid()
+        || iid == <dyn IUnknown as attributes::ComInterface<RawTypeSystem>>::iid()
         || iid == <dyn ISupportErrorInfo as attributes::ComInterface<AutomationTypeSystem>>::iid()
+        || iid == <dyn ISupportErrorInfo as attributes::ComInterface<RawTypeSystem>>::iid()
     {
         return ComError {
             hresult: err,

--- a/intercom/src/error.rs
+++ b/intercom/src/error.rs
@@ -2,6 +2,7 @@ use std::convert::TryFrom;
 use std::error::Error;
 
 use super::*;
+use crate::attributes;
 use crate::type_system::{AutomationTypeSystem, ExternType, IntercomFrom, TypeSystem};
 
 /// Error structure containing the available information on a COM error.
@@ -453,10 +454,8 @@ pub fn load_error(iunk: &ComItf<dyn IUnknown>, iid: &GUID, err: raw::HRESULT) ->
 {
     // Do not try to load error if this is IUnknown or ISupportErrorInfo.
     // Both of these are used during error handling and may fail.
-    if *iid == IID_IUnknown
-        || *iid == intercom::interfaces::IID_IUnknown_Raw
-        || *iid == IID_ISupportErrorInfo
-        || *iid == intercom::interfaces::IID_ISupportErrorInfo_Raw
+    if iid == <dyn IUnknown as attributes::ComInterface<AutomationTypeSystem>>::iid()
+        || iid == <dyn ISupportErrorInfo as attributes::ComInterface<AutomationTypeSystem>>::iid()
     {
         return ComError {
             hresult: err,

--- a/intercom/src/lib.rs
+++ b/intercom/src/lib.rs
@@ -103,6 +103,7 @@ pub use crate::variant::{Variant, VariantError};
 pub mod type_system;
 pub mod typelib;
 pub use type_system::{BidirectionalTypeInfo, InputTypeInfo, OutputTypeInfo};
+pub mod attributes;
 
 /// The `ComInterface` trait defines the COM interface details for a COM
 /// interface trait.
@@ -110,6 +111,10 @@ pub trait ComInterface
 {
     /// IID of the COM interface.
     fn iid(ts: type_system::TypeSystemName) -> Option<&'static IID>;
+
+    fn iid_ts<TS: intercom::type_system::TypeSystem>() -> &'static intercom::IID
+    where
+        Self: intercom::attributes::ComInterface<TS>;
 
     /// Dereferences a `ComItf<T>` into a `&T`.
     ///
@@ -233,13 +238,11 @@ pub const IID_IErrorInfo: GUID = GUID {
     data4: [0x8E, 0x65, 0x08, 0x00, 0x2B, 0x2B, 0xD1, 0x19],
 };
 
-pub use crate::interfaces::IID_IUnknown_Automation as IID_IUnknown;
 pub use crate::interfaces::IUnknown;
-pub use crate::interfaces::__IUnknown_AutomationVtbl as IUnknownVtbl;
+// pub use crate::interfaces::__IUnknown_AutomationVtbl as IUnknownVtbl;
 
-pub use crate::interfaces::IID_ISupportErrorInfo_Automation as IID_ISupportErrorInfo;
 pub use crate::interfaces::ISupportErrorInfo;
-pub use crate::interfaces::__ISupportErrorInfo_AutomationVtbl as ISupportErrorInfoVtbl;
+// pub use crate::interfaces::__ISupportErrorInfo_AutomationVtbl as ISupportErrorInfoVtbl;
 
 // Do we need this? Would rather not export this through an extern crate
 // for another dll.

--- a/intercom/src/lib.rs
+++ b/intercom/src/lib.rs
@@ -58,12 +58,7 @@
 //! ```
 
 #![crate_type = "dylib"]
-#![feature(
-    specialization,
-    non_exhaustive,
-    integer_atomics,
-    associated_type_defaults
-)]
+#![feature(specialization, integer_atomics, associated_type_defaults)]
 #![allow(clippy::match_bool)]
 
 extern crate self as intercom;


### PR DESCRIPTION
Attributes define many items, such as `IID`, virtual tables, etc. These items were previously defined as global items with unique names that could then be referenced by other attributes. This causes problems if the user wants to implement a trait from a different module as these global items would need to be `use`'d by the user to access them by name.

Moving all of those into traits that can be accessed through `<dyn [trait] as OurInternalTraut>::Item` allows accessing them without relying on global items.

True path support still needs handling the items through `syn::Path` instead of the current `syn::Ident`.