### PR TITLE
Make CI fail on valgrind leaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,6 @@ script:
     - cargo test
     - mkdir build
     - ( cd build && cmake .. && make )
-    - ( cd build/bin && ldd ./cpp-raw && valgrind --error-exitcode=1 ./cpp-raw )
-    - ( cd build/bin && ldd ./cpp-wrapper && valgrind --error-exitcode=1 ./cpp-wrapper )
-    - ( cd build/bin && ldd ./cpp-dl && valgrind --error-exitcode=1 ./cpp-dl )
+    - ( cd build/bin && ldd ./cpp-raw && valgrind --error-exitcode=1 --leak-check=full ./cpp-raw )
+    - ( cd build/bin && ldd ./cpp-wrapper && valgrind --error-exitcode=1 --leak-check=full ./cpp-wrapper )
+    - ( cd build/bin && ldd ./cpp-dl && valgrind --error-exitcode=1 --leak-check=full ./cpp-dl )

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,9 +6,11 @@ strategy:
         Linux:
             imageName: "ubuntu-16.04"
             cmake_generator_opts:
+            memcheck: valgrind --error-exitcode=1 --leak-check=full
         Windows:
             imageName: "vs2017-win2016"
             cmake_generator_opts: -DCMAKE_GENERATOR_PLATFORM=x64
+            memcheck:
 
 pool:
   vmImage: $(imageName)
@@ -49,7 +51,7 @@ steps:
   displayName: "Build integration tests"
 
 - bash: |
-    build/bin/cpp-raw
-    build/bin/cpp-dl
-    build/bin/cpp-wrapper
+    $(memcheck) build/bin/cpp-raw
+    $(memcheck) build/bin/cpp-dl
+    $(memcheck) build/bin/cpp-wrapper
   displayName: "Run integration tests"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,8 +19,13 @@ steps:
 - script: |
     curl -sSf -o rustup-init.exe https://win.rustup.rs
     rustup-init.exe --default-toolchain nightly -y
-  displayName: 'Update Rustup (Windows)'
+  displayName: 'Update environment (Windows)'
   condition: and(succeeded(), eq( variables['Agent.OS'], 'Windows_NT' ))
+
+- script: |
+    sudo apt-get install valgrind -y
+  displayName: 'Update environment (Linux)'
+  condition: and(succeeded(), eq( variables['Agent.OS'], 'Linux' ))
 
 - script: |
     rustup -V

--- a/intercom-cpp/src/posix/memory.hpp
+++ b/intercom-cpp/src/posix/memory.hpp
@@ -121,6 +121,22 @@ namespace intercom
     }
 
     /**
+     * @brief Allocates memory for a string.
+     *
+     * @return intercom::OLECHAR Returns an uninitialized string with null-terminator.
+     */
+    template< typename TCharType >
+    inline void free_string(
+            TCharType* string
+    )
+    {
+        // Allocate enough memory to hold the string and null terminator.
+        if( string == nullptr )
+            return;
+        std::free( string );
+    }
+
+    /**
      * @brief Reallocates a strng.
      *
      * @param string

--- a/test/cpp-raw/error_info.cpp
+++ b/test/cpp-raw/error_info.cpp
@@ -36,6 +36,8 @@ namespace
             if( hr2 != intercom::SC_OK )
                 return hr2;
 
+            pErrorStore->Release();
+
             // Return the hresult.
             return hr;
 		}
@@ -59,6 +61,8 @@ namespace
             if( hr2 != intercom::SC_OK )
                 return hr2;
 
+            pErrorStore->Release();
+
             // Return the hresult.
             return hr;
 		}
@@ -81,6 +85,8 @@ namespace
             hr2 = pErrorStore->SetErrorMessage( bstr );
             if( hr2 != intercom::SC_OK )
                 return hr2;
+
+            pErrorStore->Release();
 
             // Return the hresult.
             return hr;
@@ -220,6 +226,9 @@ namespace
                 REQUIRE( text[ i ] == right[ i ] );  // This failed above.
             }
         }
+
+        pAllocator->Release();
+        pConverter->Release();
     }
 }
 
@@ -310,6 +319,7 @@ TEST_CASE( "Interfaces support error info" )
             check_equal( u"Error message", bstrOut );
             pAllocator->FreeBstr( bstrOut );
             pAllocator->FreeBstr( bstrError );
+            pErrorInfo->Release();
         }
 
         SECTION( "Returning custom error" )
@@ -328,6 +338,7 @@ TEST_CASE( "Interfaces support error info" )
             check_equal( u"Error message", bstrOut );
             pAllocator->FreeBstr( bstrOut );
             pAllocator->FreeBstr( bstrError );
+            pErrorInfo->Release();
         }
 
         SECTION( "Returning std::io::Error" )
@@ -344,6 +355,7 @@ TEST_CASE( "Interfaces support error info" )
             hr = pErrorInfo->GetDescription( &bstrOut );
             check_equal( u"permission denied", bstrOut );
             pAllocator->FreeBstr( bstrOut );
+            pErrorInfo->Release();
         }
 
         SECTION( "Returning ComError from COM callback" )

--- a/test/cpp-wrapper/strings.cpp
+++ b/test/cpp-wrapper/strings.cpp
@@ -54,6 +54,8 @@ TEST_CASE( "Manipulating BSTR succeeds" )
             REQUIRE( intercom::get_characters_in_bstr( converted ) == utf16_len );
 
             REQUIRE( memcmp( converted, utf16_text, utf16_len * 2 ) == 0 );
+
+            intercom::free_bstr( converted );
         }
 
         SECTION( std::string( "Converting BSTR to UTF-8 works: " ) + description )
@@ -74,6 +76,9 @@ TEST_CASE( "Manipulating BSTR succeeds" )
                 expected = "";
 
             REQUIRE( memcmp( converted, expected, utf8_len ) == 0 );
+
+            intercom::free_bstr( bstr );
+            intercom::free_string( converted );
         }
     }
 


### PR DESCRIPTION
Valgrind won't report error status unless --leak-check is something more than the default. This has resulted in some leaks in our test code.

This PR makes sure that CI fails on leaks and fixes the few leaks we had.

Fixes #99 