### PR TITLE
Add logging support into code generated from macro expansion

### DIFF
--- a/intercom-attributes/Cargo.toml
+++ b/intercom-attributes/Cargo.toml
@@ -20,5 +20,7 @@ quote = { version = "1.0" }
 difference = "2"
 term = "0.5"
 intercom-fmt = { version = "0.3.0", path = "../intercom-fmt" }
-intercom = { version = "0.3", path = "../intercom" }
+intercom = { version = "0.3", path = "../intercom", features = [ "log" ] }
 regex = "0.2"
+log = "0.4"
+simple_logger = { version = "1.0", default-features = false }

--- a/intercom-attributes/Cargo.toml
+++ b/intercom-attributes/Cargo.toml
@@ -20,7 +20,7 @@ quote = { version = "1.0" }
 difference = "2"
 term = "0.5"
 intercom-fmt = { version = "0.3.0", path = "../intercom-fmt" }
-intercom = { version = "0.3", path = "../intercom", features = [ "log" ] }
+intercom = { version = "0.3", path = "../intercom" }
 regex = "0.2"
 log = "0.4"
 simple_logger = { version = "1.0", default-features = false }

--- a/intercom-attributes/tests/data/macro/com_impl.rs.stdout
+++ b/intercom-attributes/tests/data/macro/com_impl.rs.stdout
@@ -117,60 +117,525 @@ impl intercom::CoClass for Foo {
         riid: intercom::REFIID,
     ) -> intercom::RawComResult<intercom::RawComPtr> {
         if riid.is_null() {
+            intercom::logging::error(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", "] ", "::query_interface(NULL)"],
+                        &match (&vtables, &"Foo") {
+                            (arg0, arg1) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             return Err(intercom::raw::E_NOINTERFACE);
         }
         unsafe {
             let riid = &*riid;
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1_formatted(
+                        &["[", "] ", "::query_interface(", ")"],
+                        &match (&vtables, &"Foo", &riid) {
+                            (arg0, arg1, arg2) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::UpperHex::fmt),
+                            ],
+                        },
+                        &[
+                            ::core::fmt::rt::v1::Argument {
+                                position: ::core::fmt::rt::v1::Position::At(0usize),
+                                format: ::core::fmt::rt::v1::FormatSpec {
+                                    fill: ' ',
+                                    align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                    flags: 0u32,
+                                    precision: ::core::fmt::rt::v1::Count::Implied,
+                                    width: ::core::fmt::rt::v1::Count::Implied,
+                                },
+                            },
+                            ::core::fmt::rt::v1::Argument {
+                                position: ::core::fmt::rt::v1::Position::At(1usize),
+                                format: ::core::fmt::rt::v1::FormatSpec {
+                                    fill: ' ',
+                                    align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                    flags: 0u32,
+                                    precision: ::core::fmt::rt::v1::Count::Implied,
+                                    width: ::core::fmt::rt::v1::Count::Implied,
+                                },
+                            },
+                            ::core::fmt::rt::v1::Argument {
+                                position: ::core::fmt::rt::v1::Position::At(2usize),
+                                format: ::core::fmt::rt::v1::FormatSpec {
+                                    fill: ' ',
+                                    align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                    flags: 2u32,
+                                    precision: ::core::fmt::rt::v1::Count::Implied,
+                                    width: ::core::fmt::rt::v1::Count::Implied,
+                                },
+                            },
+                        ],
+                    ),
+                )
+            });
             Ok(
                 if riid
                     == <dyn intercom::IUnknown as intercom::attributes::ComInterface<
                         intercom::type_system::AutomationTypeSystem,
                     >>::iid()
                 {
-                    (&vtables._ISupportErrorInfo) as
-                       *const &<dyn intercom::ISupportErrorInfo as
-                               intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::VTable
-                       as
-                       *mut &<dyn intercom::ISupportErrorInfo as
-                             intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::VTable
-                       as intercom::RawComPtr
+                    let ptr =
+                       (&vtables._ISupportErrorInfo) as
+                           *const &<dyn intercom::ISupportErrorInfo as
+                                   intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::VTable
+                           as
+                           *mut &<dyn intercom::ISupportErrorInfo as
+                                 intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::VTable
+                           as intercom::RawComPtr;
+                    intercom::logging::trace(|l| {
+                        l(
+                            "testcrate",
+                            ::core::fmt::Arguments::new_v1_formatted(
+                                &["[", "] ", "::query_interface(", ") -> IUnknown [", "]"],
+                                &match (&vtables, &"Foo", &riid, &ptr) {
+                                    (arg0, arg1, arg2, arg3) => [
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg0,
+                                            ::core::fmt::Pointer::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg1,
+                                            ::core::fmt::Display::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg2,
+                                            ::core::fmt::UpperHex::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg3,
+                                            ::core::fmt::Pointer::fmt,
+                                        ),
+                                    ],
+                                },
+                                &[
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(0usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(1usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(2usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 2u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(3usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                ],
+                            ),
+                        )
+                    });
+                    ptr
                 } else if riid
                     == <dyn intercom::ISupportErrorInfo as intercom::attributes::ComInterface<
                         intercom::type_system::AutomationTypeSystem,
                     >>::iid()
                 {
-                    (&vtables._ISupportErrorInfo) as
-                       *const &<dyn intercom::ISupportErrorInfo as
-                               intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::VTable
-                       as
-                       *mut &<dyn intercom::ISupportErrorInfo as
-                             intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::VTable
-                       as intercom::RawComPtr
+                    let ptr =
+                       (&vtables._ISupportErrorInfo) as
+                           *const &<dyn intercom::ISupportErrorInfo as
+                                   intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::VTable
+                           as
+                           *mut &<dyn intercom::ISupportErrorInfo as
+                                 intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::VTable
+                           as intercom::RawComPtr;
+                    intercom::logging::trace(|l| {
+                        l(
+                            "testcrate",
+                            ::core::fmt::Arguments::new_v1_formatted(
+                                &[
+                                    "[",
+                                    "] ",
+                                    "::query_interface(",
+                                    ") -> ISupportErrorInfo [",
+                                    "]",
+                                ],
+                                &match (&vtables, &"Foo", &riid, &ptr) {
+                                    (arg0, arg1, arg2, arg3) => [
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg0,
+                                            ::core::fmt::Pointer::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg1,
+                                            ::core::fmt::Display::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg2,
+                                            ::core::fmt::UpperHex::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg3,
+                                            ::core::fmt::Pointer::fmt,
+                                        ),
+                                    ],
+                                },
+                                &[
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(0usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(1usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(2usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 2u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(3usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                ],
+                            ),
+                        )
+                    });
+                    ptr
                 } else if riid
                     == <Foo as intercom::attributes::ComInterface<
                         intercom::type_system::AutomationTypeSystem,
                     >>::iid()
                 {
-                    &vtables.Foo_Automation
+                    let ptr = &vtables.Foo_Automation
                         as *const &<Foo as intercom::attributes::ComInterface<
                             intercom::type_system::AutomationTypeSystem,
                         >>::VTable
                         as *mut &<Foo as intercom::attributes::ComInterface<
                             intercom::type_system::AutomationTypeSystem,
-                        >>::VTable as intercom::RawComPtr
+                        >>::VTable as intercom::RawComPtr;
+                    intercom::logging::trace(|l| {
+                        l(
+                            "testcrate",
+                            ::core::fmt::Arguments::new_v1_formatted(
+                                &["[", "] ", "::query_interface(", ") -> ", " (", ") [", "]"],
+                                &match (&vtables, &"Foo", &riid, &"Foo", &"Automation", &ptr) {
+                                    (arg0, arg1, arg2, arg3, arg4, arg5) => [
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg0,
+                                            ::core::fmt::Pointer::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg1,
+                                            ::core::fmt::Display::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg2,
+                                            ::core::fmt::UpperHex::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg3,
+                                            ::core::fmt::Display::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg4,
+                                            ::core::fmt::Display::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg5,
+                                            ::core::fmt::Pointer::fmt,
+                                        ),
+                                    ],
+                                },
+                                &[
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(0usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(1usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(2usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 2u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(3usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(4usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(5usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                ],
+                            ),
+                        )
+                    });
+                    ptr
                 } else if riid
                     == <Foo as intercom::attributes::ComInterface<
                         intercom::type_system::RawTypeSystem,
                     >>::iid()
                 {
-                    &vtables.Foo_Raw
+                    let ptr = &vtables.Foo_Raw
                         as *const &<Foo as intercom::attributes::ComInterface<
                             intercom::type_system::RawTypeSystem,
                         >>::VTable
                         as *mut &<Foo as intercom::attributes::ComInterface<
                             intercom::type_system::RawTypeSystem,
-                        >>::VTable as intercom::RawComPtr
+                        >>::VTable as intercom::RawComPtr;
+                    intercom::logging::trace(|l| {
+                        l(
+                            "testcrate",
+                            ::core::fmt::Arguments::new_v1_formatted(
+                                &["[", "] ", "::query_interface(", ") -> ", " (", ") [", "]"],
+                                &match (&vtables, &"Foo", &riid, &"Foo", &"Raw", &ptr) {
+                                    (arg0, arg1, arg2, arg3, arg4, arg5) => [
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg0,
+                                            ::core::fmt::Pointer::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg1,
+                                            ::core::fmt::Display::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg2,
+                                            ::core::fmt::UpperHex::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg3,
+                                            ::core::fmt::Display::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg4,
+                                            ::core::fmt::Display::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg5,
+                                            ::core::fmt::Pointer::fmt,
+                                        ),
+                                    ],
+                                },
+                                &[
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(0usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(1usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(2usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 2u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(3usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(4usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(5usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                ],
+                            ),
+                        )
+                    });
+                    ptr
                 } else {
+                    intercom::logging::trace(|l| {
+                        l(
+                            "testcrate",
+                            ::core::fmt::Arguments::new_v1_formatted(
+                                &["[", "] ", "::query_interface(", ") -> E_NOINTERFACE"],
+                                &match (&vtables, &"Foo", &riid) {
+                                    (arg0, arg1, arg2) => [
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg0,
+                                            ::core::fmt::Pointer::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg1,
+                                            ::core::fmt::Display::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg2,
+                                            ::core::fmt::UpperHex::fmt,
+                                        ),
+                                    ],
+                                },
+                                &[
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(0usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(1usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(2usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 2u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                ],
+                            ),
+                        )
+                    });
                     return Err(intercom::raw::E_NOINTERFACE);
                 },
             )
@@ -294,15 +759,27 @@ unsafe extern "system" fn __Foo_Foo_Automation_query_interface(
 ) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
     intercom::type_system::AutomationTypeSystem,
 >>::ExternOutputType {
-    intercom::ComBoxData::<Foo>::query_interface(
-        &mut *((self_vtable as usize
-            - <Foo as intercom::attributes::ComClass<
-                Foo,
-                intercom::type_system::AutomationTypeSystem,
-            >>::offset()) as *mut _),
-        riid,
-        out,
-    )
+    let self_ptr = (self_vtable as usize
+        - <Foo as intercom::attributes::ComClass<
+            Foo,
+            intercom::type_system::AutomationTypeSystem,
+        >>::offset()) as *mut _;
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::query_interface"],
+                &match (&self_ptr, &self_vtable, &"Foo") {
+                    (arg0, arg1, arg2) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
+    intercom::ComBoxData::<Foo>::query_interface(&mut *self_ptr, riid, out)
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]
@@ -312,13 +789,27 @@ unsafe extern "system" fn __Foo_Foo_Automation_add_ref(self_vtable:
  ->
      <u32 as
 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
-    intercom::ComBoxData::<Foo>::add_ref(
-        &mut *((self_vtable as usize
-            - <Foo as intercom::attributes::ComClass<
-                Foo,
-                intercom::type_system::AutomationTypeSystem,
-            >>::offset()) as *mut _),
-    )
+    let self_ptr = (self_vtable as usize
+        - <Foo as intercom::attributes::ComClass<
+            Foo,
+            intercom::type_system::AutomationTypeSystem,
+        >>::offset()) as *mut _;
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::add_ref"],
+                &match (&self_ptr, &self_vtable, &"Foo") {
+                    (arg0, arg1, arg2) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
+    intercom::ComBoxData::<Foo>::add_ref_ptr(self_ptr)
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]
@@ -328,13 +819,27 @@ unsafe extern "system" fn __Foo_Foo_Automation_release(self_vtable:
  ->
      <u32 as
 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
-    intercom::ComBoxData::<Foo>::release_ptr(
-        (self_vtable as usize
-            - <Foo as intercom::attributes::ComClass<
-                Foo,
-                intercom::type_system::AutomationTypeSystem,
-            >>::offset()) as *mut _,
-    )
+    let self_ptr = (self_vtable as usize
+        - <Foo as intercom::attributes::ComClass<
+            Foo,
+            intercom::type_system::AutomationTypeSystem,
+        >>::offset()) as *mut _;
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::release_ptr"],
+                &match (&self_ptr, &self_vtable, &"Foo") {
+                    (arg0, arg1, arg2) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
+    intercom::ComBoxData::<Foo>::release_ptr(self_ptr)
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]
@@ -344,6 +849,11 @@ unsafe extern "system" fn __Foo_Foo_Automation_simple_method_Automation(self_vta
  ->
      <() as
 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
+    let self_combox = (self_vtable as usize
+        - <Foo as intercom::attributes::ComClass<
+            Foo,
+            intercom::type_system::AutomationTypeSystem,
+        >>::offset()) as *mut intercom::ComBoxData<Foo>;
     use intercom::type_system::{IntercomFrom, IntercomInto};
     let result:
             Result<<() as
@@ -351,24 +861,77 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
                    intercom::ComError> =
         (||
              {
-                 let self_combox =
-                     (self_vtable as usize -
-                          <Foo as
-                              intercom::attributes::ComClass<Foo,
-                                                             intercom::type_system::AutomationTypeSystem>>::offset())
-                         as *mut intercom::ComBoxData<Foo>;
+                 intercom::logging::trace(|l|
+                                              l("testcrate",
+                                                ::core::fmt::Arguments::new_v1(&["[",
+                                                                                 ", through ",
+                                                                                 "] Serving ",
+                                                                                 "::"],
+                                                                               &match (&self_combox,
+                                                                                       &self_vtable,
+                                                                                       &"Foo",
+                                                                                       &"simple_method")
+                                                                                    {
+                                                                                    (arg0,
+                                                                                     arg1,
+                                                                                     arg2,
+                                                                                     arg3)
+                                                                                    =>
+                                                                                    [::core::fmt::ArgumentV1::new(arg0,
+                                                                                                                  ::core::fmt::Pointer::fmt),
+                                                                                     ::core::fmt::ArgumentV1::new(arg1,
+                                                                                                                  ::core::fmt::Pointer::fmt),
+                                                                                     ::core::fmt::ArgumentV1::new(arg2,
+                                                                                                                  ::core::fmt::Display::fmt),
+                                                                                     ::core::fmt::ArgumentV1::new(arg3,
+                                                                                                                  ::core::fmt::Display::fmt)],
+                                                                                })));
                  let self_struct: &Foo = &**self_combox;
                  let __result = self_struct.simple_method();
                  Ok({ })
              })();
     use intercom::ErrorValue;
     match result {
-        Ok(v) => v,
-        Err(err) => <<() as intercom::type_system::ExternType<
-            intercom::type_system::AutomationTypeSystem,
-        >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(
-            err,
-        )),
+        Ok(v) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", OK"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"simple_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            v
+        }
+        Err(err) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"simple_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            <<() as
+             intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                as ErrorValue>::from_error(intercom::store_error(err))
+        }
     }
 }
 #[allow(non_snake_case)]
@@ -383,6 +946,11 @@ unsafe extern "system" fn __Foo_Foo_Automation_arg_method_Automation(self_vtable
  ->
      <() as
 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
+    let self_combox = (self_vtable as usize
+        - <Foo as intercom::attributes::ComClass<
+            Foo,
+            intercom::type_system::AutomationTypeSystem,
+        >>::offset()) as *mut intercom::ComBoxData<Foo>;
     use intercom::type_system::{IntercomFrom, IntercomInto};
     let result:
             Result<<() as
@@ -390,12 +958,31 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
                    intercom::ComError> =
         (||
              {
-                 let self_combox =
-                     (self_vtable as usize -
-                          <Foo as
-                              intercom::attributes::ComClass<Foo,
-                                                             intercom::type_system::AutomationTypeSystem>>::offset())
-                         as *mut intercom::ComBoxData<Foo>;
+                 intercom::logging::trace(|l|
+                                              l("testcrate",
+                                                ::core::fmt::Arguments::new_v1(&["[",
+                                                                                 ", through ",
+                                                                                 "] Serving ",
+                                                                                 "::"],
+                                                                               &match (&self_combox,
+                                                                                       &self_vtable,
+                                                                                       &"Foo",
+                                                                                       &"arg_method")
+                                                                                    {
+                                                                                    (arg0,
+                                                                                     arg1,
+                                                                                     arg2,
+                                                                                     arg3)
+                                                                                    =>
+                                                                                    [::core::fmt::ArgumentV1::new(arg0,
+                                                                                                                  ::core::fmt::Pointer::fmt),
+                                                                                     ::core::fmt::ArgumentV1::new(arg1,
+                                                                                                                  ::core::fmt::Pointer::fmt),
+                                                                                     ::core::fmt::ArgumentV1::new(arg2,
+                                                                                                                  ::core::fmt::Display::fmt),
+                                                                                     ::core::fmt::ArgumentV1::new(arg3,
+                                                                                                                  ::core::fmt::Display::fmt)],
+                                                                                })));
                  let self_struct: &Foo = &**self_combox;
                  let __result =
                      self_struct.arg_method((&<u16 as
@@ -404,12 +991,46 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
              })();
     use intercom::ErrorValue;
     match result {
-        Ok(v) => v,
-        Err(err) => <<() as intercom::type_system::ExternType<
-            intercom::type_system::AutomationTypeSystem,
-        >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(
-            err,
-        )),
+        Ok(v) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", OK"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"arg_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            v
+        }
+        Err(err) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"arg_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            <<() as
+             intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                as ErrorValue>::from_error(intercom::store_error(err))
+        }
     }
 }
 #[allow(non_snake_case)]
@@ -420,6 +1041,11 @@ unsafe extern "system" fn __Foo_Foo_Automation_simple_result_method_Automation(s
  ->
      <u16 as
 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
+    let self_combox = (self_vtable as usize
+        - <Foo as intercom::attributes::ComClass<
+            Foo,
+            intercom::type_system::AutomationTypeSystem,
+        >>::offset()) as *mut intercom::ComBoxData<Foo>;
     use intercom::type_system::{IntercomFrom, IntercomInto};
     let result:
             Result<<u16 as
@@ -427,20 +1053,73 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
                    intercom::ComError> =
         (||
              {
-                 let self_combox =
-                     (self_vtable as usize -
-                          <Foo as
-                              intercom::attributes::ComClass<Foo,
-                                                             intercom::type_system::AutomationTypeSystem>>::offset())
-                         as *mut intercom::ComBoxData<Foo>;
+                 intercom::logging::trace(|l|
+                                              l("testcrate",
+                                                ::core::fmt::Arguments::new_v1(&["[",
+                                                                                 ", through ",
+                                                                                 "] Serving ",
+                                                                                 "::"],
+                                                                               &match (&self_combox,
+                                                                                       &self_vtable,
+                                                                                       &"Foo",
+                                                                                       &"simple_result_method")
+                                                                                    {
+                                                                                    (arg0,
+                                                                                     arg1,
+                                                                                     arg2,
+                                                                                     arg3)
+                                                                                    =>
+                                                                                    [::core::fmt::ArgumentV1::new(arg0,
+                                                                                                                  ::core::fmt::Pointer::fmt),
+                                                                                     ::core::fmt::ArgumentV1::new(arg1,
+                                                                                                                  ::core::fmt::Pointer::fmt),
+                                                                                     ::core::fmt::ArgumentV1::new(arg2,
+                                                                                                                  ::core::fmt::Display::fmt),
+                                                                                     ::core::fmt::ArgumentV1::new(arg3,
+                                                                                                                  ::core::fmt::Display::fmt)],
+                                                                                })));
                  let self_struct: &Foo = &**self_combox;
                  let __result = self_struct.simple_result_method();
                  Ok({ __result.intercom_into()? })
              })();
     use intercom::ErrorValue;
     match result {
-        Ok(v) => v,
+        Ok(v) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", OK"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"simple_result_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            v
+        }
         Err(err) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"simple_result_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             <<u16 as intercom::type_system::ExternType<
                 intercom::type_system::AutomationTypeSystem,
             >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(err))
@@ -458,6 +1137,11 @@ unsafe extern "system" fn __Foo_Foo_Automation_com_result_method_Automation(
 ) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
     intercom::type_system::AutomationTypeSystem,
 >>::ExternOutputType {
+    let self_combox = (self_vtable as usize
+        - <Foo as intercom::attributes::ComClass<
+            Foo,
+            intercom::type_system::AutomationTypeSystem,
+        >>::offset()) as *mut intercom::ComBoxData<Foo>;
     use intercom::type_system::{IntercomFrom, IntercomInto};
     let result: Result<
         <intercom::raw::HRESULT as intercom::type_system::ExternType<
@@ -465,11 +1149,22 @@ unsafe extern "system" fn __Foo_Foo_Automation_com_result_method_Automation(
         >>::ExternOutputType,
         intercom::ComError,
     > = (|| {
-        let self_combox = (self_vtable as usize
-            - <Foo as intercom::attributes::ComClass<
-                Foo,
-                intercom::type_system::AutomationTypeSystem,
-            >>::offset()) as *mut intercom::ComBoxData<Foo>;
+        intercom::logging::trace(|l| {
+            l(
+                "testcrate",
+                ::core::fmt::Arguments::new_v1(
+                    &["[", ", through ", "] Serving ", "::"],
+                    &match (&self_combox, &self_vtable, &"Foo", &"com_result_method") {
+                        (arg0, arg1, arg2, arg3) => [
+                            ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                            ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                        ],
+                    },
+                ),
+            )
+        });
         let self_struct: &Foo = &**self_combox;
         let __result = self_struct.com_result_method();
         Ok({
@@ -487,8 +1182,42 @@ unsafe extern "system" fn __Foo_Foo_Automation_com_result_method_Automation(
     })();
     use intercom::ErrorValue;
     match result {
-        Ok(v) => v,
+        Ok(v) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", OK"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"com_result_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            v
+        }
         Err(err) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"com_result_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             <<intercom::raw::HRESULT as intercom::type_system::ExternType<
                 intercom::type_system::AutomationTypeSystem,
             >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(err))
@@ -506,6 +1235,11 @@ unsafe extern "system" fn __Foo_Foo_Automation_rust_result_method_Automation(
 ) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
     intercom::type_system::AutomationTypeSystem,
 >>::ExternOutputType {
+    let self_combox = (self_vtable as usize
+        - <Foo as intercom::attributes::ComClass<
+            Foo,
+            intercom::type_system::AutomationTypeSystem,
+        >>::offset()) as *mut intercom::ComBoxData<Foo>;
     use intercom::type_system::{IntercomFrom, IntercomInto};
     let result: Result<
         <intercom::raw::HRESULT as intercom::type_system::ExternType<
@@ -513,11 +1247,22 @@ unsafe extern "system" fn __Foo_Foo_Automation_rust_result_method_Automation(
         >>::ExternOutputType,
         intercom::ComError,
     > = (|| {
-        let self_combox = (self_vtable as usize
-            - <Foo as intercom::attributes::ComClass<
-                Foo,
-                intercom::type_system::AutomationTypeSystem,
-            >>::offset()) as *mut intercom::ComBoxData<Foo>;
+        intercom::logging::trace(|l| {
+            l(
+                "testcrate",
+                ::core::fmt::Arguments::new_v1(
+                    &["[", ", through ", "] Serving ", "::"],
+                    &match (&self_combox, &self_vtable, &"Foo", &"rust_result_method") {
+                        (arg0, arg1, arg2, arg3) => [
+                            ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                            ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                        ],
+                    },
+                ),
+            )
+        });
         let self_struct: &Foo = &**self_combox;
         let __result = self_struct.rust_result_method();
         Ok({
@@ -535,8 +1280,42 @@ unsafe extern "system" fn __Foo_Foo_Automation_rust_result_method_Automation(
     })();
     use intercom::ErrorValue;
     match result {
-        Ok(v) => v,
+        Ok(v) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", OK"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"rust_result_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            v
+        }
         Err(err) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"rust_result_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             <<intercom::raw::HRESULT as intercom::type_system::ExternType<
                 intercom::type_system::AutomationTypeSystem,
             >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(err))
@@ -560,6 +1339,11 @@ unsafe extern "system" fn __Foo_Foo_Automation_tuple_result_method_Automation(
 ) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
     intercom::type_system::AutomationTypeSystem,
 >>::ExternOutputType {
+    let self_combox = (self_vtable as usize
+        - <Foo as intercom::attributes::ComClass<
+            Foo,
+            intercom::type_system::AutomationTypeSystem,
+        >>::offset()) as *mut intercom::ComBoxData<Foo>;
     use intercom::type_system::{IntercomFrom, IntercomInto};
     let result: Result<
         <intercom::raw::HRESULT as intercom::type_system::ExternType<
@@ -567,11 +1351,22 @@ unsafe extern "system" fn __Foo_Foo_Automation_tuple_result_method_Automation(
         >>::ExternOutputType,
         intercom::ComError,
     > = (|| {
-        let self_combox = (self_vtable as usize
-            - <Foo as intercom::attributes::ComClass<
-                Foo,
-                intercom::type_system::AutomationTypeSystem,
-            >>::offset()) as *mut intercom::ComBoxData<Foo>;
+        intercom::logging::trace(|l| {
+            l(
+                "testcrate",
+                ::core::fmt::Arguments::new_v1(
+                    &["[", ", through ", "] Serving ", "::"],
+                    &match (&self_combox, &self_vtable, &"Foo", &"tuple_result_method") {
+                        (arg0, arg1, arg2, arg3) => [
+                            ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                            ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                        ],
+                    },
+                ),
+            )
+        });
         let self_struct: &Foo = &**self_combox;
         let __result = self_struct.tuple_result_method();
         Ok({
@@ -593,8 +1388,42 @@ unsafe extern "system" fn __Foo_Foo_Automation_tuple_result_method_Automation(
     })();
     use intercom::ErrorValue;
     match result {
-        Ok(v) => v,
+        Ok(v) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", OK"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"tuple_result_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            v
+        }
         Err(err) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"tuple_result_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             <<intercom::raw::HRESULT as intercom::type_system::ExternType<
                 intercom::type_system::AutomationTypeSystem,
             >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(err))
@@ -613,6 +1442,11 @@ unsafe extern "system" fn __Foo_Foo_Automation_string_method_Automation(self_vta
  ->
      <String as
 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
+    let self_combox = (self_vtable as usize
+        - <Foo as intercom::attributes::ComClass<
+            Foo,
+            intercom::type_system::AutomationTypeSystem,
+        >>::offset()) as *mut intercom::ComBoxData<Foo>;
     use intercom::type_system::{IntercomFrom, IntercomInto};
     let result: Result<
         <String as intercom::type_system::ExternType<
@@ -620,11 +1454,22 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
         >>::ExternOutputType,
         intercom::ComError,
     > = (|| {
-        let self_combox = (self_vtable as usize
-            - <Foo as intercom::attributes::ComClass<
-                Foo,
-                intercom::type_system::AutomationTypeSystem,
-            >>::offset()) as *mut intercom::ComBoxData<Foo>;
+        intercom::logging::trace(|l| {
+            l(
+                "testcrate",
+                ::core::fmt::Arguments::new_v1(
+                    &["[", ", through ", "] Serving ", "::"],
+                    &match (&self_combox, &self_vtable, &"Foo", &"string_method") {
+                        (arg0, arg1, arg2, arg3) => [
+                            ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                            ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                        ],
+                    },
+                ),
+            )
+        });
         let self_struct: &Foo = &**self_combox;
         let __result = self_struct.string_method(
             (&<String as intercom::type_system::ExternType<
@@ -636,8 +1481,42 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
     })();
     use intercom::ErrorValue;
     match result {
-        Ok(v) => v,
+        Ok(v) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", OK"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"string_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            v
+        }
         Err(err) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"string_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             <<String as intercom::type_system::ExternType<
                 intercom::type_system::AutomationTypeSystem,
             >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(err))
@@ -658,6 +1537,11 @@ unsafe extern "system" fn __Foo_Foo_Automation_string_result_method_Automation(
 ) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
     intercom::type_system::AutomationTypeSystem,
 >>::ExternOutputType {
+    let self_combox = (self_vtable as usize
+        - <Foo as intercom::attributes::ComClass<
+            Foo,
+            intercom::type_system::AutomationTypeSystem,
+        >>::offset()) as *mut intercom::ComBoxData<Foo>;
     use intercom::type_system::{IntercomFrom, IntercomInto};
     let result: Result<
         <intercom::raw::HRESULT as intercom::type_system::ExternType<
@@ -665,11 +1549,22 @@ unsafe extern "system" fn __Foo_Foo_Automation_string_result_method_Automation(
         >>::ExternOutputType,
         intercom::ComError,
     > = (|| {
-        let self_combox = (self_vtable as usize
-            - <Foo as intercom::attributes::ComClass<
-                Foo,
-                intercom::type_system::AutomationTypeSystem,
-            >>::offset()) as *mut intercom::ComBoxData<Foo>;
+        intercom::logging::trace(|l| {
+            l(
+                "testcrate",
+                ::core::fmt::Arguments::new_v1(
+                    &["[", ", through ", "] Serving ", "::"],
+                    &match (&self_combox, &self_vtable, &"Foo", &"string_result_method") {
+                        (arg0, arg1, arg2, arg3) => [
+                            ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                            ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                        ],
+                    },
+                ),
+            )
+        });
         let self_struct: &Foo = &**self_combox;
         let __result = self_struct.string_result_method(
             (&<String as intercom::type_system::ExternType<
@@ -692,8 +1587,42 @@ unsafe extern "system" fn __Foo_Foo_Automation_string_result_method_Automation(
     })();
     use intercom::ErrorValue;
     match result {
-        Ok(v) => v,
+        Ok(v) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", OK"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"string_result_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            v
+        }
         Err(err) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"string_result_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             <<intercom::raw::HRESULT as intercom::type_system::ExternType<
                 intercom::type_system::AutomationTypeSystem,
             >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(err))
@@ -719,6 +1648,11 @@ unsafe extern "system" fn __Foo_Foo_Automation_complete_method_Automation(
 ) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
     intercom::type_system::AutomationTypeSystem,
 >>::ExternOutputType {
+    let self_combox = (self_vtable as usize
+        - <Foo as intercom::attributes::ComClass<
+            Foo,
+            intercom::type_system::AutomationTypeSystem,
+        >>::offset()) as *mut intercom::ComBoxData<Foo>;
     use intercom::type_system::{IntercomFrom, IntercomInto};
     let result: Result<
         <intercom::raw::HRESULT as intercom::type_system::ExternType<
@@ -726,11 +1660,22 @@ unsafe extern "system" fn __Foo_Foo_Automation_complete_method_Automation(
         >>::ExternOutputType,
         intercom::ComError,
     > = (|| {
-        let self_combox = (self_vtable as usize
-            - <Foo as intercom::attributes::ComClass<
-                Foo,
-                intercom::type_system::AutomationTypeSystem,
-            >>::offset()) as *mut intercom::ComBoxData<Foo>;
+        intercom::logging::trace(|l| {
+            l(
+                "testcrate",
+                ::core::fmt::Arguments::new_v1(
+                    &["[", ", through ", "] Serving ", "::"],
+                    &match (&self_combox, &self_vtable, &"Foo", &"complete_method") {
+                        (arg0, arg1, arg2, arg3) => [
+                            ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                            ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                        ],
+                    },
+                ),
+            )
+        });
         let self_struct: &mut Foo = &mut **self_combox;
         let __result = self_struct.complete_method(
             (&<u16 as intercom::type_system::ExternType<
@@ -757,8 +1702,42 @@ unsafe extern "system" fn __Foo_Foo_Automation_complete_method_Automation(
     })();
     use intercom::ErrorValue;
     match result {
-        Ok(v) => v,
+        Ok(v) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", OK"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"complete_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            v
+        }
         Err(err) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"complete_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             <<intercom::raw::HRESULT as intercom::type_system::ExternType<
                 intercom::type_system::AutomationTypeSystem,
             >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(err))
@@ -779,6 +1758,11 @@ unsafe extern "system" fn __Foo_Foo_Automation_bool_method_Automation(
 ) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
     intercom::type_system::AutomationTypeSystem,
 >>::ExternOutputType {
+    let self_combox = (self_vtable as usize
+        - <Foo as intercom::attributes::ComClass<
+            Foo,
+            intercom::type_system::AutomationTypeSystem,
+        >>::offset()) as *mut intercom::ComBoxData<Foo>;
     use intercom::type_system::{IntercomFrom, IntercomInto};
     let result: Result<
         <intercom::raw::HRESULT as intercom::type_system::ExternType<
@@ -786,11 +1770,22 @@ unsafe extern "system" fn __Foo_Foo_Automation_bool_method_Automation(
         >>::ExternOutputType,
         intercom::ComError,
     > = (|| {
-        let self_combox = (self_vtable as usize
-            - <Foo as intercom::attributes::ComClass<
-                Foo,
-                intercom::type_system::AutomationTypeSystem,
-            >>::offset()) as *mut intercom::ComBoxData<Foo>;
+        intercom::logging::trace(|l| {
+            l(
+                "testcrate",
+                ::core::fmt::Arguments::new_v1(
+                    &["[", ", through ", "] Serving ", "::"],
+                    &match (&self_combox, &self_vtable, &"Foo", &"bool_method") {
+                        (arg0, arg1, arg2, arg3) => [
+                            ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                            ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                        ],
+                    },
+                ),
+            )
+        });
         let self_struct: &Foo = &**self_combox;
         let __result = self_struct.bool_method(
             (&<bool as intercom::type_system::ExternType<
@@ -813,8 +1808,42 @@ unsafe extern "system" fn __Foo_Foo_Automation_bool_method_Automation(
     })();
     use intercom::ErrorValue;
     match result {
-        Ok(v) => v,
+        Ok(v) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", OK"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"bool_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            v
+        }
         Err(err) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"bool_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             <<intercom::raw::HRESULT as intercom::type_system::ExternType<
                 intercom::type_system::AutomationTypeSystem,
             >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(err))
@@ -835,6 +1864,11 @@ unsafe extern "system" fn __Foo_Foo_Automation_variant_method_Automation(
 ) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
     intercom::type_system::AutomationTypeSystem,
 >>::ExternOutputType {
+    let self_combox = (self_vtable as usize
+        - <Foo as intercom::attributes::ComClass<
+            Foo,
+            intercom::type_system::AutomationTypeSystem,
+        >>::offset()) as *mut intercom::ComBoxData<Foo>;
     use intercom::type_system::{IntercomFrom, IntercomInto};
     let result: Result<
         <intercom::raw::HRESULT as intercom::type_system::ExternType<
@@ -842,11 +1876,22 @@ unsafe extern "system" fn __Foo_Foo_Automation_variant_method_Automation(
         >>::ExternOutputType,
         intercom::ComError,
     > = (|| {
-        let self_combox = (self_vtable as usize
-            - <Foo as intercom::attributes::ComClass<
-                Foo,
-                intercom::type_system::AutomationTypeSystem,
-            >>::offset()) as *mut intercom::ComBoxData<Foo>;
+        intercom::logging::trace(|l| {
+            l(
+                "testcrate",
+                ::core::fmt::Arguments::new_v1(
+                    &["[", ", through ", "] Serving ", "::"],
+                    &match (&self_combox, &self_vtable, &"Foo", &"variant_method") {
+                        (arg0, arg1, arg2, arg3) => [
+                            ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                            ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                        ],
+                    },
+                ),
+            )
+        });
         let self_struct: &Foo = &**self_combox;
         let __result = self_struct.variant_method(
             (&<Variant as intercom::type_system::ExternType<
@@ -869,8 +1914,42 @@ unsafe extern "system" fn __Foo_Foo_Automation_variant_method_Automation(
     })();
     use intercom::ErrorValue;
     match result {
-        Ok(v) => v,
+        Ok(v) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", OK"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"variant_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            v
+        }
         Err(err) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"variant_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             <<intercom::raw::HRESULT as intercom::type_system::ExternType<
                 intercom::type_system::AutomationTypeSystem,
             >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(err))
@@ -923,13 +2002,28 @@ unsafe extern "system" fn __Foo_Foo_Raw_query_interface(
 ) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
     intercom::type_system::AutomationTypeSystem,
 >>::ExternOutputType {
-    intercom::ComBoxData::<Foo>::query_interface(&mut *((self_vtable as usize
-                                                             -
-                                                             <Foo as
-                                                                 intercom::attributes::ComClass<Foo,
-                                                                                                intercom::type_system::RawTypeSystem>>::offset())
-                                                            as *mut _), riid,
-                                                 out)
+    let self_ptr =
+        (self_vtable as usize -
+             <Foo as
+                 intercom::attributes::ComClass<Foo,
+                                                intercom::type_system::RawTypeSystem>>::offset())
+            as *mut _;
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::query_interface"],
+                &match (&self_ptr, &self_vtable, &"Foo") {
+                    (arg0, arg1, arg2) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
+    intercom::ComBoxData::<Foo>::query_interface(&mut *self_ptr, riid, out)
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]
@@ -939,11 +2033,28 @@ unsafe extern "system" fn __Foo_Foo_Raw_add_ref(self_vtable:
  ->
      <u32 as
 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
-    intercom::ComBoxData::<Foo>::add_ref(&mut *((self_vtable as usize -
-                                                     <Foo as
-                                                         intercom::attributes::ComClass<Foo,
-                                                                                        intercom::type_system::RawTypeSystem>>::offset())
-                                                    as *mut _))
+    let self_ptr =
+        (self_vtable as usize -
+             <Foo as
+                 intercom::attributes::ComClass<Foo,
+                                                intercom::type_system::RawTypeSystem>>::offset())
+            as *mut _;
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::add_ref"],
+                &match (&self_ptr, &self_vtable, &"Foo") {
+                    (arg0, arg1, arg2) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
+    intercom::ComBoxData::<Foo>::add_ref_ptr(self_ptr)
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]
@@ -953,11 +2064,28 @@ unsafe extern "system" fn __Foo_Foo_Raw_release(self_vtable:
  ->
      <u32 as
 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
-    intercom::ComBoxData::<Foo>::release_ptr((self_vtable as usize -
-                                                  <Foo as
-                                                      intercom::attributes::ComClass<Foo,
-                                                                                     intercom::type_system::RawTypeSystem>>::offset())
-                                                 as *mut _)
+    let self_ptr =
+        (self_vtable as usize -
+             <Foo as
+                 intercom::attributes::ComClass<Foo,
+                                                intercom::type_system::RawTypeSystem>>::offset())
+            as *mut _;
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::release_ptr"],
+                &match (&self_ptr, &self_vtable, &"Foo") {
+                    (arg0, arg1, arg2) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
+    intercom::ComBoxData::<Foo>::release_ptr(self_ptr)
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]
@@ -967,6 +2095,12 @@ unsafe extern "system" fn __Foo_Foo_Raw_simple_method_Raw(self_vtable:
  ->
      <() as
 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
+    let self_combox =
+        (self_vtable as usize -
+             <Foo as
+                 intercom::attributes::ComClass<Foo,
+                                                intercom::type_system::RawTypeSystem>>::offset())
+            as *mut intercom::ComBoxData<Foo>;
     use intercom::type_system::{IntercomFrom, IntercomInto};
     let result:
             Result<<() as
@@ -974,24 +2108,77 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
                    intercom::ComError> =
         (||
              {
-                 let self_combox =
-                     (self_vtable as usize -
-                          <Foo as
-                              intercom::attributes::ComClass<Foo,
-                                                             intercom::type_system::RawTypeSystem>>::offset())
-                         as *mut intercom::ComBoxData<Foo>;
+                 intercom::logging::trace(|l|
+                                              l("testcrate",
+                                                ::core::fmt::Arguments::new_v1(&["[",
+                                                                                 ", through ",
+                                                                                 "] Serving ",
+                                                                                 "::"],
+                                                                               &match (&self_combox,
+                                                                                       &self_vtable,
+                                                                                       &"Foo",
+                                                                                       &"simple_method")
+                                                                                    {
+                                                                                    (arg0,
+                                                                                     arg1,
+                                                                                     arg2,
+                                                                                     arg3)
+                                                                                    =>
+                                                                                    [::core::fmt::ArgumentV1::new(arg0,
+                                                                                                                  ::core::fmt::Pointer::fmt),
+                                                                                     ::core::fmt::ArgumentV1::new(arg1,
+                                                                                                                  ::core::fmt::Pointer::fmt),
+                                                                                     ::core::fmt::ArgumentV1::new(arg2,
+                                                                                                                  ::core::fmt::Display::fmt),
+                                                                                     ::core::fmt::ArgumentV1::new(arg3,
+                                                                                                                  ::core::fmt::Display::fmt)],
+                                                                                })));
                  let self_struct: &Foo = &**self_combox;
                  let __result = self_struct.simple_method();
                  Ok({ })
              })();
     use intercom::ErrorValue;
     match result {
-        Ok(v) => v,
-        Err(err) => <<() as intercom::type_system::ExternType<
-            intercom::type_system::AutomationTypeSystem,
-        >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(
-            err,
-        )),
+        Ok(v) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", OK"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"simple_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            v
+        }
+        Err(err) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"simple_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            <<() as
+             intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                as ErrorValue>::from_error(intercom::store_error(err))
+        }
     }
 }
 #[allow(non_snake_case)]
@@ -1005,6 +2192,12 @@ unsafe extern "system" fn __Foo_Foo_Raw_arg_method_Raw(self_vtable:
  ->
      <() as
 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
+    let self_combox =
+        (self_vtable as usize -
+             <Foo as
+                 intercom::attributes::ComClass<Foo,
+                                                intercom::type_system::RawTypeSystem>>::offset())
+            as *mut intercom::ComBoxData<Foo>;
     use intercom::type_system::{IntercomFrom, IntercomInto};
     let result:
             Result<<() as
@@ -1012,12 +2205,31 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
                    intercom::ComError> =
         (||
              {
-                 let self_combox =
-                     (self_vtable as usize -
-                          <Foo as
-                              intercom::attributes::ComClass<Foo,
-                                                             intercom::type_system::RawTypeSystem>>::offset())
-                         as *mut intercom::ComBoxData<Foo>;
+                 intercom::logging::trace(|l|
+                                              l("testcrate",
+                                                ::core::fmt::Arguments::new_v1(&["[",
+                                                                                 ", through ",
+                                                                                 "] Serving ",
+                                                                                 "::"],
+                                                                               &match (&self_combox,
+                                                                                       &self_vtable,
+                                                                                       &"Foo",
+                                                                                       &"arg_method")
+                                                                                    {
+                                                                                    (arg0,
+                                                                                     arg1,
+                                                                                     arg2,
+                                                                                     arg3)
+                                                                                    =>
+                                                                                    [::core::fmt::ArgumentV1::new(arg0,
+                                                                                                                  ::core::fmt::Pointer::fmt),
+                                                                                     ::core::fmt::ArgumentV1::new(arg1,
+                                                                                                                  ::core::fmt::Pointer::fmt),
+                                                                                     ::core::fmt::ArgumentV1::new(arg2,
+                                                                                                                  ::core::fmt::Display::fmt),
+                                                                                     ::core::fmt::ArgumentV1::new(arg3,
+                                                                                                                  ::core::fmt::Display::fmt)],
+                                                                                })));
                  let self_struct: &Foo = &**self_combox;
                  let __result =
                      self_struct.arg_method((&<u16 as
@@ -1026,12 +2238,46 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
              })();
     use intercom::ErrorValue;
     match result {
-        Ok(v) => v,
-        Err(err) => <<() as intercom::type_system::ExternType<
-            intercom::type_system::AutomationTypeSystem,
-        >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(
-            err,
-        )),
+        Ok(v) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", OK"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"arg_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            v
+        }
+        Err(err) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"arg_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            <<() as
+             intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                as ErrorValue>::from_error(intercom::store_error(err))
+        }
     }
 }
 #[allow(non_snake_case)]
@@ -1042,6 +2288,12 @@ unsafe extern "system" fn __Foo_Foo_Raw_simple_result_method_Raw(self_vtable:
  ->
      <u16 as
 intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType{
+    let self_combox =
+        (self_vtable as usize -
+             <Foo as
+                 intercom::attributes::ComClass<Foo,
+                                                intercom::type_system::RawTypeSystem>>::offset())
+            as *mut intercom::ComBoxData<Foo>;
     use intercom::type_system::{IntercomFrom, IntercomInto};
     let result:
             Result<<u16 as
@@ -1049,24 +2301,77 @@ intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::Extern
                    intercom::ComError> =
         (||
              {
-                 let self_combox =
-                     (self_vtable as usize -
-                          <Foo as
-                              intercom::attributes::ComClass<Foo,
-                                                             intercom::type_system::RawTypeSystem>>::offset())
-                         as *mut intercom::ComBoxData<Foo>;
+                 intercom::logging::trace(|l|
+                                              l("testcrate",
+                                                ::core::fmt::Arguments::new_v1(&["[",
+                                                                                 ", through ",
+                                                                                 "] Serving ",
+                                                                                 "::"],
+                                                                               &match (&self_combox,
+                                                                                       &self_vtable,
+                                                                                       &"Foo",
+                                                                                       &"simple_result_method")
+                                                                                    {
+                                                                                    (arg0,
+                                                                                     arg1,
+                                                                                     arg2,
+                                                                                     arg3)
+                                                                                    =>
+                                                                                    [::core::fmt::ArgumentV1::new(arg0,
+                                                                                                                  ::core::fmt::Pointer::fmt),
+                                                                                     ::core::fmt::ArgumentV1::new(arg1,
+                                                                                                                  ::core::fmt::Pointer::fmt),
+                                                                                     ::core::fmt::ArgumentV1::new(arg2,
+                                                                                                                  ::core::fmt::Display::fmt),
+                                                                                     ::core::fmt::ArgumentV1::new(arg3,
+                                                                                                                  ::core::fmt::Display::fmt)],
+                                                                                })));
                  let self_struct: &Foo = &**self_combox;
                  let __result = self_struct.simple_result_method();
                  Ok({ __result.intercom_into()? })
              })();
     use intercom::ErrorValue;
     match result {
-        Ok(v) => v,
-        Err(err) => <<u16 as intercom::type_system::ExternType<
-            intercom::type_system::RawTypeSystem,
-        >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(
-            err,
-        )),
+        Ok(v) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", OK"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"simple_result_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            v
+        }
+        Err(err) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"simple_result_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            <<u16 as
+             intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                as ErrorValue>::from_error(intercom::store_error(err))
+        }
     }
 }
 #[allow(non_snake_case)]
@@ -1080,6 +2385,12 @@ unsafe extern "system" fn __Foo_Foo_Raw_com_result_method_Raw(
 ) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
     intercom::type_system::RawTypeSystem,
 >>::ExternOutputType {
+    let self_combox =
+        (self_vtable as usize -
+             <Foo as
+                 intercom::attributes::ComClass<Foo,
+                                                intercom::type_system::RawTypeSystem>>::offset())
+            as *mut intercom::ComBoxData<Foo>;
     use intercom::type_system::{IntercomFrom, IntercomInto};
     let result: Result<
         <intercom::raw::HRESULT as intercom::type_system::ExternType<
@@ -1087,12 +2398,22 @@ unsafe extern "system" fn __Foo_Foo_Raw_com_result_method_Raw(
         >>::ExternOutputType,
         intercom::ComError,
     > = (|| {
-        let self_combox =
-            (self_vtable as usize
-                - <Foo as intercom::attributes::ComClass<
-                    Foo,
-                    intercom::type_system::RawTypeSystem,
-                >>::offset()) as *mut intercom::ComBoxData<Foo>;
+        intercom::logging::trace(|l| {
+            l(
+                "testcrate",
+                ::core::fmt::Arguments::new_v1(
+                    &["[", ", through ", "] Serving ", "::"],
+                    &match (&self_combox, &self_vtable, &"Foo", &"com_result_method") {
+                        (arg0, arg1, arg2, arg3) => [
+                            ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                            ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                        ],
+                    },
+                ),
+            )
+        });
         let self_struct: &Foo = &**self_combox;
         let __result = self_struct.com_result_method();
         Ok({
@@ -1110,8 +2431,42 @@ unsafe extern "system" fn __Foo_Foo_Raw_com_result_method_Raw(
     })();
     use intercom::ErrorValue;
     match result {
-        Ok(v) => v,
+        Ok(v) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", OK"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"com_result_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            v
+        }
         Err(err) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"com_result_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             <<intercom::raw::HRESULT as intercom::type_system::ExternType<
                 intercom::type_system::RawTypeSystem,
             >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(err))
@@ -1130,6 +2485,12 @@ unsafe extern "system" fn __Foo_Foo_Raw_rust_result_method_Raw(
 ) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
     intercom::type_system::RawTypeSystem,
 >>::ExternOutputType {
+    let self_combox =
+        (self_vtable as usize -
+             <Foo as
+                 intercom::attributes::ComClass<Foo,
+                                                intercom::type_system::RawTypeSystem>>::offset())
+            as *mut intercom::ComBoxData<Foo>;
     use intercom::type_system::{IntercomFrom, IntercomInto};
     let result: Result<
         <intercom::raw::HRESULT as intercom::type_system::ExternType<
@@ -1137,12 +2498,22 @@ unsafe extern "system" fn __Foo_Foo_Raw_rust_result_method_Raw(
         >>::ExternOutputType,
         intercom::ComError,
     > = (|| {
-        let self_combox =
-            (self_vtable as usize
-                - <Foo as intercom::attributes::ComClass<
-                    Foo,
-                    intercom::type_system::RawTypeSystem,
-                >>::offset()) as *mut intercom::ComBoxData<Foo>;
+        intercom::logging::trace(|l| {
+            l(
+                "testcrate",
+                ::core::fmt::Arguments::new_v1(
+                    &["[", ", through ", "] Serving ", "::"],
+                    &match (&self_combox, &self_vtable, &"Foo", &"rust_result_method") {
+                        (arg0, arg1, arg2, arg3) => [
+                            ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                            ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                        ],
+                    },
+                ),
+            )
+        });
         let self_struct: &Foo = &**self_combox;
         let __result = self_struct.rust_result_method();
         Ok({
@@ -1160,8 +2531,42 @@ unsafe extern "system" fn __Foo_Foo_Raw_rust_result_method_Raw(
     })();
     use intercom::ErrorValue;
     match result {
-        Ok(v) => v,
+        Ok(v) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", OK"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"rust_result_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            v
+        }
         Err(err) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"rust_result_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             <<intercom::raw::HRESULT as intercom::type_system::ExternType<
                 intercom::type_system::RawTypeSystem,
             >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(err))
@@ -1188,6 +2593,12 @@ unsafe extern "system" fn __Foo_Foo_Raw_tuple_result_method_Raw(
 ) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
     intercom::type_system::RawTypeSystem,
 >>::ExternOutputType {
+    let self_combox =
+        (self_vtable as usize -
+             <Foo as
+                 intercom::attributes::ComClass<Foo,
+                                                intercom::type_system::RawTypeSystem>>::offset())
+            as *mut intercom::ComBoxData<Foo>;
     use intercom::type_system::{IntercomFrom, IntercomInto};
     let result: Result<
         <intercom::raw::HRESULT as intercom::type_system::ExternType<
@@ -1195,12 +2606,22 @@ unsafe extern "system" fn __Foo_Foo_Raw_tuple_result_method_Raw(
         >>::ExternOutputType,
         intercom::ComError,
     > = (|| {
-        let self_combox =
-            (self_vtable as usize
-                - <Foo as intercom::attributes::ComClass<
-                    Foo,
-                    intercom::type_system::RawTypeSystem,
-                >>::offset()) as *mut intercom::ComBoxData<Foo>;
+        intercom::logging::trace(|l| {
+            l(
+                "testcrate",
+                ::core::fmt::Arguments::new_v1(
+                    &["[", ", through ", "] Serving ", "::"],
+                    &match (&self_combox, &self_vtable, &"Foo", &"tuple_result_method") {
+                        (arg0, arg1, arg2, arg3) => [
+                            ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                            ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                        ],
+                    },
+                ),
+            )
+        });
         let self_struct: &Foo = &**self_combox;
         let __result = self_struct.tuple_result_method();
         Ok({
@@ -1222,8 +2643,42 @@ unsafe extern "system" fn __Foo_Foo_Raw_tuple_result_method_Raw(
     })();
     use intercom::ErrorValue;
     match result {
-        Ok(v) => v,
+        Ok(v) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", OK"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"tuple_result_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            v
+        }
         Err(err) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"tuple_result_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             <<intercom::raw::HRESULT as intercom::type_system::ExternType<
                 intercom::type_system::RawTypeSystem,
             >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(err))
@@ -1241,6 +2696,12 @@ unsafe extern "system" fn __Foo_Foo_Raw_string_method_Raw(self_vtable:
  ->
      <String as
 intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType{
+    let self_combox =
+        (self_vtable as usize -
+             <Foo as
+                 intercom::attributes::ComClass<Foo,
+                                                intercom::type_system::RawTypeSystem>>::offset())
+            as *mut intercom::ComBoxData<Foo>;
     use intercom::type_system::{IntercomFrom, IntercomInto};
     let result:
             Result<<String as
@@ -1248,12 +2709,31 @@ intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::Extern
                    intercom::ComError> =
         (||
              {
-                 let self_combox =
-                     (self_vtable as usize -
-                          <Foo as
-                              intercom::attributes::ComClass<Foo,
-                                                             intercom::type_system::RawTypeSystem>>::offset())
-                         as *mut intercom::ComBoxData<Foo>;
+                 intercom::logging::trace(|l|
+                                              l("testcrate",
+                                                ::core::fmt::Arguments::new_v1(&["[",
+                                                                                 ", through ",
+                                                                                 "] Serving ",
+                                                                                 "::"],
+                                                                               &match (&self_combox,
+                                                                                       &self_vtable,
+                                                                                       &"Foo",
+                                                                                       &"string_method")
+                                                                                    {
+                                                                                    (arg0,
+                                                                                     arg1,
+                                                                                     arg2,
+                                                                                     arg3)
+                                                                                    =>
+                                                                                    [::core::fmt::ArgumentV1::new(arg0,
+                                                                                                                  ::core::fmt::Pointer::fmt),
+                                                                                     ::core::fmt::ArgumentV1::new(arg1,
+                                                                                                                  ::core::fmt::Pointer::fmt),
+                                                                                     ::core::fmt::ArgumentV1::new(arg2,
+                                                                                                                  ::core::fmt::Display::fmt),
+                                                                                     ::core::fmt::ArgumentV1::new(arg3,
+                                                                                                                  ::core::fmt::Display::fmt)],
+                                                                                })));
                  let self_struct: &Foo = &**self_combox;
                  let __result =
                      self_struct.string_method((&<String as
@@ -1262,12 +2742,46 @@ intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::Extern
              })();
     use intercom::ErrorValue;
     match result {
-        Ok(v) => v,
-        Err(err) => <<String as intercom::type_system::ExternType<
-            intercom::type_system::RawTypeSystem,
-        >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(
-            err,
-        )),
+        Ok(v) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", OK"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"string_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            v
+        }
+        Err(err) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"string_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            <<String as
+             intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                as ErrorValue>::from_error(intercom::store_error(err))
+        }
     }
 }
 #[allow(non_snake_case)]
@@ -1285,6 +2799,12 @@ unsafe extern "system" fn __Foo_Foo_Raw_string_result_method_Raw(
 ) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
     intercom::type_system::RawTypeSystem,
 >>::ExternOutputType {
+    let self_combox =
+        (self_vtable as usize -
+             <Foo as
+                 intercom::attributes::ComClass<Foo,
+                                                intercom::type_system::RawTypeSystem>>::offset())
+            as *mut intercom::ComBoxData<Foo>;
     use intercom::type_system::{IntercomFrom, IntercomInto};
     let result: Result<
         <intercom::raw::HRESULT as intercom::type_system::ExternType<
@@ -1292,12 +2812,22 @@ unsafe extern "system" fn __Foo_Foo_Raw_string_result_method_Raw(
         >>::ExternOutputType,
         intercom::ComError,
     > = (|| {
-        let self_combox =
-            (self_vtable as usize
-                - <Foo as intercom::attributes::ComClass<
-                    Foo,
-                    intercom::type_system::RawTypeSystem,
-                >>::offset()) as *mut intercom::ComBoxData<Foo>;
+        intercom::logging::trace(|l| {
+            l(
+                "testcrate",
+                ::core::fmt::Arguments::new_v1(
+                    &["[", ", through ", "] Serving ", "::"],
+                    &match (&self_combox, &self_vtable, &"Foo", &"string_result_method") {
+                        (arg0, arg1, arg2, arg3) => [
+                            ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                            ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                        ],
+                    },
+                ),
+            )
+        });
         let self_struct: &Foo = &**self_combox;
         let __result = self_struct.string_result_method(
             (&<String as intercom::type_system::ExternType<
@@ -1320,8 +2850,42 @@ unsafe extern "system" fn __Foo_Foo_Raw_string_result_method_Raw(
     })();
     use intercom::ErrorValue;
     match result {
-        Ok(v) => v,
+        Ok(v) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", OK"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"string_result_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            v
+        }
         Err(err) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"string_result_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             <<intercom::raw::HRESULT as intercom::type_system::ExternType<
                 intercom::type_system::RawTypeSystem,
             >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(err))
@@ -1345,21 +2909,38 @@ unsafe extern "system" fn __Foo_Foo_Raw_complete_method_Raw(
 ) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
     intercom::type_system::RawTypeSystem,
 >>::ExternOutputType {
+    let self_combox =
+        (self_vtable as usize -
+             <Foo as
+                 intercom::attributes::ComClass<Foo,
+                                                intercom::type_system::RawTypeSystem>>::offset())
+            as *mut intercom::ComBoxData<Foo>;
     use intercom::type_system::{IntercomFrom, IntercomInto};
     let result: Result<
         <intercom::raw::HRESULT as intercom::type_system::ExternType<
             intercom::type_system::RawTypeSystem,
         >>::ExternOutputType,
         intercom::ComError,
-    > =
-        (|| {
-            let self_combox = (self_vtable as usize
-                - <Foo as intercom::attributes::ComClass<
-                    Foo,
-                    intercom::type_system::RawTypeSystem,
-                >>::offset()) as *mut intercom::ComBoxData<Foo>;
-            let self_struct: &mut Foo = &mut **self_combox;
-            let __result = self_struct.complete_method(
+    > = (|| {
+        intercom::logging::trace(|l| {
+            l(
+                "testcrate",
+                ::core::fmt::Arguments::new_v1(
+                    &["[", ", through ", "] Serving ", "::"],
+                    &match (&self_combox, &self_vtable, &"Foo", &"complete_method") {
+                        (arg0, arg1, arg2, arg3) => [
+                            ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                            ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                        ],
+                    },
+                ),
+            )
+        });
+        let self_struct: &mut Foo = &mut **self_combox;
+        let __result =
+            self_struct.complete_method(
                 (&<u16 as intercom::type_system::ExternType<
                     intercom::type_system::RawTypeSystem,
                 >>::intercom_from(a)?)
@@ -1369,23 +2950,57 @@ unsafe extern "system" fn __Foo_Foo_Raw_complete_method_Raw(
                 >>::intercom_from(b)?)
                     .intercom_into()?,
             );
-            Ok({
-                match __result {
-                    Ok(v1) => {
-                        *__out = v1.intercom_into()?;
-                        intercom::raw::S_OK
-                    }
-                    Err(e) => {
-                        *__out = intercom::type_system::ExternDefault::extern_default();
-                        intercom::store_error(e).hresult
-                    }
+        Ok({
+            match __result {
+                Ok(v1) => {
+                    *__out = v1.intercom_into()?;
+                    intercom::raw::S_OK
                 }
-            })
-        })();
+                Err(e) => {
+                    *__out = intercom::type_system::ExternDefault::extern_default();
+                    intercom::store_error(e).hresult
+                }
+            }
+        })
+    })();
     use intercom::ErrorValue;
     match result {
-        Ok(v) => v,
+        Ok(v) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", OK"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"complete_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            v
+        }
         Err(err) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"complete_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             <<intercom::raw::HRESULT as intercom::type_system::ExternType<
                 intercom::type_system::RawTypeSystem,
             >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(err))
@@ -1406,43 +3021,94 @@ unsafe extern "system" fn __Foo_Foo_Raw_bool_method_Raw(
 ) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
     intercom::type_system::RawTypeSystem,
 >>::ExternOutputType {
+    let self_combox =
+        (self_vtable as usize -
+             <Foo as
+                 intercom::attributes::ComClass<Foo,
+                                                intercom::type_system::RawTypeSystem>>::offset())
+            as *mut intercom::ComBoxData<Foo>;
     use intercom::type_system::{IntercomFrom, IntercomInto};
     let result: Result<
         <intercom::raw::HRESULT as intercom::type_system::ExternType<
             intercom::type_system::RawTypeSystem,
         >>::ExternOutputType,
         intercom::ComError,
-    > =
-        (|| {
-            let self_combox = (self_vtable as usize
-                - <Foo as intercom::attributes::ComClass<
-                    Foo,
-                    intercom::type_system::RawTypeSystem,
-                >>::offset()) as *mut intercom::ComBoxData<Foo>;
-            let self_struct: &Foo = &**self_combox;
-            let __result = self_struct.bool_method(
+    > = (|| {
+        intercom::logging::trace(|l| {
+            l(
+                "testcrate",
+                ::core::fmt::Arguments::new_v1(
+                    &["[", ", through ", "] Serving ", "::"],
+                    &match (&self_combox, &self_vtable, &"Foo", &"bool_method") {
+                        (arg0, arg1, arg2, arg3) => [
+                            ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                            ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                        ],
+                    },
+                ),
+            )
+        });
+        let self_struct: &Foo = &**self_combox;
+        let __result =
+            self_struct.bool_method(
                 (&<bool as intercom::type_system::ExternType<
                     intercom::type_system::RawTypeSystem,
                 >>::intercom_from(input)?)
                     .intercom_into()?,
             );
-            Ok({
-                match __result {
-                    Ok(v1) => {
-                        *__out = v1.intercom_into()?;
-                        intercom::raw::S_OK
-                    }
-                    Err(e) => {
-                        *__out = intercom::type_system::ExternDefault::extern_default();
-                        intercom::store_error(e).hresult
-                    }
+        Ok({
+            match __result {
+                Ok(v1) => {
+                    *__out = v1.intercom_into()?;
+                    intercom::raw::S_OK
                 }
-            })
-        })();
+                Err(e) => {
+                    *__out = intercom::type_system::ExternDefault::extern_default();
+                    intercom::store_error(e).hresult
+                }
+            }
+        })
+    })();
     use intercom::ErrorValue;
     match result {
-        Ok(v) => v,
+        Ok(v) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", OK"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"bool_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            v
+        }
         Err(err) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"bool_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             <<intercom::raw::HRESULT as intercom::type_system::ExternType<
                 intercom::type_system::RawTypeSystem,
             >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(err))
@@ -1463,6 +3129,12 @@ unsafe extern "system" fn __Foo_Foo_Raw_variant_method_Raw(
 ) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
     intercom::type_system::RawTypeSystem,
 >>::ExternOutputType {
+    let self_combox =
+        (self_vtable as usize -
+             <Foo as
+                 intercom::attributes::ComClass<Foo,
+                                                intercom::type_system::RawTypeSystem>>::offset())
+            as *mut intercom::ComBoxData<Foo>;
     use intercom::type_system::{IntercomFrom, IntercomInto};
     let result: Result<
         <intercom::raw::HRESULT as intercom::type_system::ExternType<
@@ -1470,12 +3142,22 @@ unsafe extern "system" fn __Foo_Foo_Raw_variant_method_Raw(
         >>::ExternOutputType,
         intercom::ComError,
     > = (|| {
-        let self_combox =
-            (self_vtable as usize
-                - <Foo as intercom::attributes::ComClass<
-                    Foo,
-                    intercom::type_system::RawTypeSystem,
-                >>::offset()) as *mut intercom::ComBoxData<Foo>;
+        intercom::logging::trace(|l| {
+            l(
+                "testcrate",
+                ::core::fmt::Arguments::new_v1(
+                    &["[", ", through ", "] Serving ", "::"],
+                    &match (&self_combox, &self_vtable, &"Foo", &"variant_method") {
+                        (arg0, arg1, arg2, arg3) => [
+                            ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                            ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                        ],
+                    },
+                ),
+            )
+        });
         let self_struct: &Foo = &**self_combox;
         let __result = self_struct.variant_method(
             (&<Variant as intercom::type_system::ExternType<
@@ -1498,8 +3180,42 @@ unsafe extern "system" fn __Foo_Foo_Raw_variant_method_Raw(
     })();
     use intercom::ErrorValue;
     match result {
-        Ok(v) => v,
+        Ok(v) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", OK"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"variant_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            v
+        }
         Err(err) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"variant_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             <<intercom::raw::HRESULT as intercom::type_system::ExternType<
                 intercom::type_system::RawTypeSystem,
             >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(err))

--- a/intercom-attributes/tests/data/macro/com_interface.rs.stdout
+++ b/intercom-attributes/tests/data/macro/com_interface.rs.stdout
@@ -259,11 +259,43 @@ impl intercom::attributes::ComInterface<intercom::type_system::RawTypeSystem> fo
 #[allow(clippy::all)]
 impl Foo for intercom::ComItf<dyn Foo> {
     fn arg_method(&self, a: u16) -> () {
+        intercom::logging::trace(|l| {
+            l(
+                "testcrate",
+                ::core::fmt::Arguments::new_v1(
+                    &["[", "] Calling ", "::"],
+                    &match (&self, &"Foo", &"arg_method") {
+                        (arg0, arg1, arg2) => [
+                            ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Display::fmt),
+                            ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                        ],
+                    },
+                ),
+            )
+        });
         #[allow(unused_imports)]
         use intercom::ErrorValue;
         if let Some(comptr) =
             intercom::ComItf::maybe_ptr::<intercom::type_system::AutomationTypeSystem>(self)
         {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", with ", "] Calling ", "::", ", type system: "],
+                        &match (&self, &comptr.ptr, &"Foo", &"arg_method", &"Automation") {
+                            (arg0, arg1, arg2, arg3, arg4) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg4, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
@@ -295,6 +327,23 @@ impl Foo for intercom::ComItf<dyn Foo> {
         if let Some(comptr) =
             intercom::ComItf::maybe_ptr::<intercom::type_system::RawTypeSystem>(self)
         {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", with ", "] Calling ", "::", ", type system: "],
+                        &match (&self, &comptr.ptr, &"Foo", &"arg_method", &"Raw") {
+                            (arg0, arg1, arg2, arg3, arg4) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg4, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
@@ -326,11 +375,43 @@ impl Foo for intercom::ComItf<dyn Foo> {
         <() as intercom::ErrorValue>::from_com_error(intercom::ComError::E_POINTER.into())
     }
     fn bool_method(&self, input: bool) -> ComResult<bool> {
+        intercom::logging::trace(|l| {
+            l(
+                "testcrate",
+                ::core::fmt::Arguments::new_v1(
+                    &["[", "] Calling ", "::"],
+                    &match (&self, &"Foo", &"bool_method") {
+                        (arg0, arg1, arg2) => [
+                            ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Display::fmt),
+                            ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                        ],
+                    },
+                ),
+            )
+        });
         #[allow(unused_imports)]
         use intercom::ErrorValue;
         if let Some(comptr) =
             intercom::ComItf::maybe_ptr::<intercom::type_system::AutomationTypeSystem>(self)
         {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", with ", "] Calling ", "::", ", type system: "],
+                        &match (&self, &comptr.ptr, &"Foo", &"bool_method", &"Automation") {
+                            (arg0, arg1, arg2, arg3, arg4) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg4, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
@@ -376,6 +457,23 @@ impl Foo for intercom::ComItf<dyn Foo> {
         if let Some(comptr) =
             intercom::ComItf::maybe_ptr::<intercom::type_system::RawTypeSystem>(self)
         {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", with ", "] Calling ", "::", ", type system: "],
+                        &match (&self, &comptr.ptr, &"Foo", &"bool_method", &"Raw") {
+                            (arg0, arg1, arg2, arg3, arg4) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg4, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
@@ -423,11 +521,49 @@ impl Foo for intercom::ComItf<dyn Foo> {
         )
     }
     fn com_result_method(&self) -> ComResult<u16> {
+        intercom::logging::trace(|l| {
+            l(
+                "testcrate",
+                ::core::fmt::Arguments::new_v1(
+                    &["[", "] Calling ", "::"],
+                    &match (&self, &"Foo", &"com_result_method") {
+                        (arg0, arg1, arg2) => [
+                            ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Display::fmt),
+                            ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                        ],
+                    },
+                ),
+            )
+        });
         #[allow(unused_imports)]
         use intercom::ErrorValue;
         if let Some(comptr) =
             intercom::ComItf::maybe_ptr::<intercom::type_system::AutomationTypeSystem>(self)
         {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", with ", "] Calling ", "::", ", type system: "],
+                        &match (
+                            &self,
+                            &comptr.ptr,
+                            &"Foo",
+                            &"com_result_method",
+                            &"Automation",
+                        ) {
+                            (arg0, arg1, arg2, arg3, arg4) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg4, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
@@ -466,6 +602,23 @@ impl Foo for intercom::ComItf<dyn Foo> {
         if let Some(comptr) =
             intercom::ComItf::maybe_ptr::<intercom::type_system::RawTypeSystem>(self)
         {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", with ", "] Calling ", "::", ", type system: "],
+                        &match (&self, &comptr.ptr, &"Foo", &"com_result_method", &"Raw") {
+                            (arg0, arg1, arg2, arg3, arg4) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg4, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
@@ -506,11 +659,43 @@ impl Foo for intercom::ComItf<dyn Foo> {
         )
     }
     fn comitf_method(&self, itf: ComItf<dyn Foo>) -> ComResult<ComItf<dyn IUnknown>> {
+        intercom::logging::trace(|l| {
+            l(
+                "testcrate",
+                ::core::fmt::Arguments::new_v1(
+                    &["[", "] Calling ", "::"],
+                    &match (&self, &"Foo", &"comitf_method") {
+                        (arg0, arg1, arg2) => [
+                            ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Display::fmt),
+                            ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                        ],
+                    },
+                ),
+            )
+        });
         #[allow(unused_imports)]
         use intercom::ErrorValue;
         if let Some(comptr) =
             intercom::ComItf::maybe_ptr::<intercom::type_system::AutomationTypeSystem>(self)
         {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", with ", "] Calling ", "::", ", type system: "],
+                        &match (&self, &comptr.ptr, &"Foo", &"comitf_method", &"Automation") {
+                            (arg0, arg1, arg2, arg3, arg4) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg4, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
@@ -561,6 +746,23 @@ impl Foo for intercom::ComItf<dyn Foo> {
         if let Some(comptr) =
             intercom::ComItf::maybe_ptr::<intercom::type_system::RawTypeSystem>(self)
         {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", with ", "] Calling ", "::", ", type system: "],
+                        &match (&self, &comptr.ptr, &"Foo", &"comitf_method", &"Raw") {
+                            (arg0, arg1, arg2, arg3, arg4) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg4, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
@@ -613,11 +815,49 @@ impl Foo for intercom::ComItf<dyn Foo> {
         )
     }
     fn complete_method(&mut self, a: u16, b: i16) -> ComResult<bool> {
+        intercom::logging::trace(|l| {
+            l(
+                "testcrate",
+                ::core::fmt::Arguments::new_v1(
+                    &["[", "] Calling ", "::"],
+                    &match (&self, &"Foo", &"complete_method") {
+                        (arg0, arg1, arg2) => [
+                            ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Display::fmt),
+                            ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                        ],
+                    },
+                ),
+            )
+        });
         #[allow(unused_imports)]
         use intercom::ErrorValue;
         if let Some(comptr) =
             intercom::ComItf::maybe_ptr::<intercom::type_system::AutomationTypeSystem>(self)
         {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", with ", "] Calling ", "::", ", type system: "],
+                        &match (
+                            &self,
+                            &comptr.ptr,
+                            &"Foo",
+                            &"complete_method",
+                            &"Automation",
+                        ) {
+                            (arg0, arg1, arg2, arg3, arg4) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg4, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
@@ -667,6 +907,23 @@ impl Foo for intercom::ComItf<dyn Foo> {
         if let Some(comptr) =
             intercom::ComItf::maybe_ptr::<intercom::type_system::RawTypeSystem>(self)
         {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", with ", "] Calling ", "::", ", type system: "],
+                        &match (&self, &comptr.ptr, &"Foo", &"complete_method", &"Raw") {
+                            (arg0, arg1, arg2, arg3, arg4) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg4, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
@@ -718,11 +975,49 @@ impl Foo for intercom::ComItf<dyn Foo> {
         )
     }
     fn rust_result_method(&self) -> Result<u16, i32> {
+        intercom::logging::trace(|l| {
+            l(
+                "testcrate",
+                ::core::fmt::Arguments::new_v1(
+                    &["[", "] Calling ", "::"],
+                    &match (&self, &"Foo", &"rust_result_method") {
+                        (arg0, arg1, arg2) => [
+                            ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Display::fmt),
+                            ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                        ],
+                    },
+                ),
+            )
+        });
         #[allow(unused_imports)]
         use intercom::ErrorValue;
         if let Some(comptr) =
             intercom::ComItf::maybe_ptr::<intercom::type_system::AutomationTypeSystem>(self)
         {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", with ", "] Calling ", "::", ", type system: "],
+                        &match (
+                            &self,
+                            &comptr.ptr,
+                            &"Foo",
+                            &"rust_result_method",
+                            &"Automation",
+                        ) {
+                            (arg0, arg1, arg2, arg3, arg4) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg4, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
@@ -761,6 +1056,23 @@ impl Foo for intercom::ComItf<dyn Foo> {
         if let Some(comptr) =
             intercom::ComItf::maybe_ptr::<intercom::type_system::RawTypeSystem>(self)
         {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", with ", "] Calling ", "::", ", type system: "],
+                        &match (&self, &comptr.ptr, &"Foo", &"rust_result_method", &"Raw") {
+                            (arg0, arg1, arg2, arg3, arg4) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg4, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
@@ -801,11 +1113,43 @@ impl Foo for intercom::ComItf<dyn Foo> {
         )
     }
     fn simple_method(&self) -> () {
+        intercom::logging::trace(|l| {
+            l(
+                "testcrate",
+                ::core::fmt::Arguments::new_v1(
+                    &["[", "] Calling ", "::"],
+                    &match (&self, &"Foo", &"simple_method") {
+                        (arg0, arg1, arg2) => [
+                            ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Display::fmt),
+                            ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                        ],
+                    },
+                ),
+            )
+        });
         #[allow(unused_imports)]
         use intercom::ErrorValue;
         if let Some(comptr) =
             intercom::ComItf::maybe_ptr::<intercom::type_system::AutomationTypeSystem>(self)
         {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", with ", "] Calling ", "::", ", type system: "],
+                        &match (&self, &comptr.ptr, &"Foo", &"simple_method", &"Automation") {
+                            (arg0, arg1, arg2, arg3, arg4) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg4, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
@@ -831,6 +1175,23 @@ impl Foo for intercom::ComItf<dyn Foo> {
         if let Some(comptr) =
             intercom::ComItf::maybe_ptr::<intercom::type_system::RawTypeSystem>(self)
         {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", with ", "] Calling ", "::", ", type system: "],
+                        &match (&self, &comptr.ptr, &"Foo", &"simple_method", &"Raw") {
+                            (arg0, arg1, arg2, arg3, arg4) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg4, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
@@ -856,11 +1217,49 @@ impl Foo for intercom::ComItf<dyn Foo> {
         <() as intercom::ErrorValue>::from_com_error(intercom::ComError::E_POINTER.into())
     }
     fn simple_result_method(&self) -> u16 {
+        intercom::logging::trace(|l| {
+            l(
+                "testcrate",
+                ::core::fmt::Arguments::new_v1(
+                    &["[", "] Calling ", "::"],
+                    &match (&self, &"Foo", &"simple_result_method") {
+                        (arg0, arg1, arg2) => [
+                            ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Display::fmt),
+                            ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                        ],
+                    },
+                ),
+            )
+        });
         #[allow(unused_imports)]
         use intercom::ErrorValue;
         if let Some(comptr) =
             intercom::ComItf::maybe_ptr::<intercom::type_system::AutomationTypeSystem>(self)
         {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", with ", "] Calling ", "::", ", type system: "],
+                        &match (
+                            &self,
+                            &comptr.ptr,
+                            &"Foo",
+                            &"simple_result_method",
+                            &"Automation",
+                        ) {
+                            (arg0, arg1, arg2, arg3, arg4) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg4, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
@@ -886,6 +1285,23 @@ impl Foo for intercom::ComItf<dyn Foo> {
         if let Some(comptr) =
             intercom::ComItf::maybe_ptr::<intercom::type_system::RawTypeSystem>(self)
         {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", with ", "] Calling ", "::", ", type system: "],
+                        &match (&self, &comptr.ptr, &"Foo", &"simple_result_method", &"Raw") {
+                            (arg0, arg1, arg2, arg3, arg4) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg4, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
@@ -911,11 +1327,43 @@ impl Foo for intercom::ComItf<dyn Foo> {
         <u16 as intercom::ErrorValue>::from_com_error(intercom::ComError::E_POINTER.into())
     }
     fn string_method(&self, msg: String) -> String {
+        intercom::logging::trace(|l| {
+            l(
+                "testcrate",
+                ::core::fmt::Arguments::new_v1(
+                    &["[", "] Calling ", "::"],
+                    &match (&self, &"Foo", &"string_method") {
+                        (arg0, arg1, arg2) => [
+                            ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Display::fmt),
+                            ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                        ],
+                    },
+                ),
+            )
+        });
         #[allow(unused_imports)]
         use intercom::ErrorValue;
         if let Some(comptr) =
             intercom::ComItf::maybe_ptr::<intercom::type_system::AutomationTypeSystem>(self)
         {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", with ", "] Calling ", "::", ", type system: "],
+                        &match (&self, &comptr.ptr, &"Foo", &"string_method", &"Automation") {
+                            (arg0, arg1, arg2, arg3, arg4) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg4, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
@@ -947,6 +1395,23 @@ impl Foo for intercom::ComItf<dyn Foo> {
         if let Some(comptr) =
             intercom::ComItf::maybe_ptr::<intercom::type_system::RawTypeSystem>(self)
         {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", with ", "] Calling ", "::", ", type system: "],
+                        &match (&self, &comptr.ptr, &"Foo", &"string_method", &"Raw") {
+                            (arg0, arg1, arg2, arg3, arg4) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg4, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
@@ -978,11 +1443,43 @@ impl Foo for intercom::ComItf<dyn Foo> {
         <String as intercom::ErrorValue>::from_com_error(intercom::ComError::E_POINTER.into())
     }
     fn variant_method(&self, input: Variant) -> ComResult<Variant> {
+        intercom::logging::trace(|l| {
+            l(
+                "testcrate",
+                ::core::fmt::Arguments::new_v1(
+                    &["[", "] Calling ", "::"],
+                    &match (&self, &"Foo", &"variant_method") {
+                        (arg0, arg1, arg2) => [
+                            ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Display::fmt),
+                            ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                        ],
+                    },
+                ),
+            )
+        });
         #[allow(unused_imports)]
         use intercom::ErrorValue;
         if let Some(comptr) =
             intercom::ComItf::maybe_ptr::<intercom::type_system::AutomationTypeSystem>(self)
         {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", with ", "] Calling ", "::", ", type system: "],
+                        &match (&self, &comptr.ptr, &"Foo", &"variant_method", &"Automation") {
+                            (arg0, arg1, arg2, arg3, arg4) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg4, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
@@ -1029,6 +1526,23 @@ impl Foo for intercom::ComItf<dyn Foo> {
         if let Some(comptr) =
             intercom::ComItf::maybe_ptr::<intercom::type_system::RawTypeSystem>(self)
         {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", with ", "] Calling ", "::", ", type system: "],
+                        &match (&self, &comptr.ptr, &"Foo", &"variant_method", &"Raw") {
+                            (arg0, arg1, arg2, arg3, arg4) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg4, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr

--- a/intercom-attributes/tests/data/macro/private_item.rs.stdout
+++ b/intercom-attributes/tests/data/macro/private_item.rs.stdout
@@ -73,11 +73,43 @@ impl intercom::attributes::ComInterface<intercom::type_system::RawTypeSystem> fo
 #[allow(clippy::all)]
 impl IFoo for intercom::ComItf<dyn IFoo> {
     fn trait_method(&self) -> () {
+        intercom::logging::trace(|l| {
+            l(
+                "testcrate",
+                ::core::fmt::Arguments::new_v1(
+                    &["[", "] Calling ", "::"],
+                    &match (&self, &"IFoo", &"trait_method") {
+                        (arg0, arg1, arg2) => [
+                            ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                            ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Display::fmt),
+                            ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                        ],
+                    },
+                ),
+            )
+        });
         #[allow(unused_imports)]
         use intercom::ErrorValue;
         if let Some(comptr) =
             intercom::ComItf::maybe_ptr::<intercom::type_system::AutomationTypeSystem>(self)
         {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", with ", "] Calling ", "::", ", type system: "],
+                        &match (&self, &comptr.ptr, &"IFoo", &"trait_method", &"Automation") {
+                            (arg0, arg1, arg2, arg3, arg4) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg4, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
@@ -103,6 +135,23 @@ impl IFoo for intercom::ComItf<dyn IFoo> {
         if let Some(comptr) =
             intercom::ComItf::maybe_ptr::<intercom::type_system::RawTypeSystem>(self)
         {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", with ", "] Calling ", "::", ", type system: "],
+                        &match (&self, &comptr.ptr, &"IFoo", &"trait_method", &"Raw") {
+                            (arg0, arg1, arg2, arg3, arg4) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg4, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             #[allow(unused_imports)]
             use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
@@ -328,84 +377,747 @@ impl intercom::CoClass for Foo {
         riid: intercom::REFIID,
     ) -> intercom::RawComResult<intercom::RawComPtr> {
         if riid.is_null() {
+            intercom::logging::error(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", "] ", "::query_interface(NULL)"],
+                        &match (&vtables, &"Foo") {
+                            (arg0, arg1) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
             return Err(intercom::raw::E_NOINTERFACE);
         }
         unsafe {
             let riid = &*riid;
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1_formatted(
+                        &["[", "] ", "::query_interface(", ")"],
+                        &match (&vtables, &"Foo", &riid) {
+                            (arg0, arg1, arg2) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::UpperHex::fmt),
+                            ],
+                        },
+                        &[
+                            ::core::fmt::rt::v1::Argument {
+                                position: ::core::fmt::rt::v1::Position::At(0usize),
+                                format: ::core::fmt::rt::v1::FormatSpec {
+                                    fill: ' ',
+                                    align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                    flags: 0u32,
+                                    precision: ::core::fmt::rt::v1::Count::Implied,
+                                    width: ::core::fmt::rt::v1::Count::Implied,
+                                },
+                            },
+                            ::core::fmt::rt::v1::Argument {
+                                position: ::core::fmt::rt::v1::Position::At(1usize),
+                                format: ::core::fmt::rt::v1::FormatSpec {
+                                    fill: ' ',
+                                    align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                    flags: 0u32,
+                                    precision: ::core::fmt::rt::v1::Count::Implied,
+                                    width: ::core::fmt::rt::v1::Count::Implied,
+                                },
+                            },
+                            ::core::fmt::rt::v1::Argument {
+                                position: ::core::fmt::rt::v1::Position::At(2usize),
+                                format: ::core::fmt::rt::v1::FormatSpec {
+                                    fill: ' ',
+                                    align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                    flags: 2u32,
+                                    precision: ::core::fmt::rt::v1::Count::Implied,
+                                    width: ::core::fmt::rt::v1::Count::Implied,
+                                },
+                            },
+                        ],
+                    ),
+                )
+            });
             Ok(
                 if riid
                     == <dyn intercom::IUnknown as intercom::attributes::ComInterface<
                         intercom::type_system::AutomationTypeSystem,
                     >>::iid()
                 {
-                    (&vtables._ISupportErrorInfo) as
-                       *const &<dyn intercom::ISupportErrorInfo as
-                               intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::VTable
-                       as
-                       *mut &<dyn intercom::ISupportErrorInfo as
-                             intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::VTable
-                       as intercom::RawComPtr
+                    let ptr =
+                       (&vtables._ISupportErrorInfo) as
+                           *const &<dyn intercom::ISupportErrorInfo as
+                                   intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::VTable
+                           as
+                           *mut &<dyn intercom::ISupportErrorInfo as
+                                 intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::VTable
+                           as intercom::RawComPtr;
+                    intercom::logging::trace(|l| {
+                        l(
+                            "testcrate",
+                            ::core::fmt::Arguments::new_v1_formatted(
+                                &["[", "] ", "::query_interface(", ") -> IUnknown [", "]"],
+                                &match (&vtables, &"Foo", &riid, &ptr) {
+                                    (arg0, arg1, arg2, arg3) => [
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg0,
+                                            ::core::fmt::Pointer::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg1,
+                                            ::core::fmt::Display::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg2,
+                                            ::core::fmt::UpperHex::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg3,
+                                            ::core::fmt::Pointer::fmt,
+                                        ),
+                                    ],
+                                },
+                                &[
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(0usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(1usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(2usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 2u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(3usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                ],
+                            ),
+                        )
+                    });
+                    ptr
                 } else if riid
                     == <dyn intercom::ISupportErrorInfo as intercom::attributes::ComInterface<
                         intercom::type_system::AutomationTypeSystem,
                     >>::iid()
                 {
-                    (&vtables._ISupportErrorInfo) as
-                       *const &<dyn intercom::ISupportErrorInfo as
-                               intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::VTable
-                       as
-                       *mut &<dyn intercom::ISupportErrorInfo as
-                             intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::VTable
-                       as intercom::RawComPtr
+                    let ptr =
+                       (&vtables._ISupportErrorInfo) as
+                           *const &<dyn intercom::ISupportErrorInfo as
+                                   intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::VTable
+                           as
+                           *mut &<dyn intercom::ISupportErrorInfo as
+                                 intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::VTable
+                           as intercom::RawComPtr;
+                    intercom::logging::trace(|l| {
+                        l(
+                            "testcrate",
+                            ::core::fmt::Arguments::new_v1_formatted(
+                                &[
+                                    "[",
+                                    "] ",
+                                    "::query_interface(",
+                                    ") -> ISupportErrorInfo [",
+                                    "]",
+                                ],
+                                &match (&vtables, &"Foo", &riid, &ptr) {
+                                    (arg0, arg1, arg2, arg3) => [
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg0,
+                                            ::core::fmt::Pointer::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg1,
+                                            ::core::fmt::Display::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg2,
+                                            ::core::fmt::UpperHex::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg3,
+                                            ::core::fmt::Pointer::fmt,
+                                        ),
+                                    ],
+                                },
+                                &[
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(0usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(1usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(2usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 2u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(3usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                ],
+                            ),
+                        )
+                    });
+                    ptr
                 } else if riid
                     == <Foo as intercom::attributes::ComInterface<
                         intercom::type_system::AutomationTypeSystem,
                     >>::iid()
                 {
-                    &vtables.Foo_Automation
+                    let ptr = &vtables.Foo_Automation
                         as *const &<Foo as intercom::attributes::ComInterface<
                             intercom::type_system::AutomationTypeSystem,
                         >>::VTable
                         as *mut &<Foo as intercom::attributes::ComInterface<
                             intercom::type_system::AutomationTypeSystem,
-                        >>::VTable as intercom::RawComPtr
+                        >>::VTable as intercom::RawComPtr;
+                    intercom::logging::trace(|l| {
+                        l(
+                            "testcrate",
+                            ::core::fmt::Arguments::new_v1_formatted(
+                                &["[", "] ", "::query_interface(", ") -> ", " (", ") [", "]"],
+                                &match (&vtables, &"Foo", &riid, &"Foo", &"Automation", &ptr) {
+                                    (arg0, arg1, arg2, arg3, arg4, arg5) => [
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg0,
+                                            ::core::fmt::Pointer::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg1,
+                                            ::core::fmt::Display::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg2,
+                                            ::core::fmt::UpperHex::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg3,
+                                            ::core::fmt::Display::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg4,
+                                            ::core::fmt::Display::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg5,
+                                            ::core::fmt::Pointer::fmt,
+                                        ),
+                                    ],
+                                },
+                                &[
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(0usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(1usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(2usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 2u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(3usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(4usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(5usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                ],
+                            ),
+                        )
+                    });
+                    ptr
                 } else if riid
                     == <Foo as intercom::attributes::ComInterface<
                         intercom::type_system::RawTypeSystem,
                     >>::iid()
                 {
-                    &vtables.Foo_Raw
+                    let ptr = &vtables.Foo_Raw
                         as *const &<Foo as intercom::attributes::ComInterface<
                             intercom::type_system::RawTypeSystem,
                         >>::VTable
                         as *mut &<Foo as intercom::attributes::ComInterface<
                             intercom::type_system::RawTypeSystem,
-                        >>::VTable as intercom::RawComPtr
+                        >>::VTable as intercom::RawComPtr;
+                    intercom::logging::trace(|l| {
+                        l(
+                            "testcrate",
+                            ::core::fmt::Arguments::new_v1_formatted(
+                                &["[", "] ", "::query_interface(", ") -> ", " (", ") [", "]"],
+                                &match (&vtables, &"Foo", &riid, &"Foo", &"Raw", &ptr) {
+                                    (arg0, arg1, arg2, arg3, arg4, arg5) => [
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg0,
+                                            ::core::fmt::Pointer::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg1,
+                                            ::core::fmt::Display::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg2,
+                                            ::core::fmt::UpperHex::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg3,
+                                            ::core::fmt::Display::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg4,
+                                            ::core::fmt::Display::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg5,
+                                            ::core::fmt::Pointer::fmt,
+                                        ),
+                                    ],
+                                },
+                                &[
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(0usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(1usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(2usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 2u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(3usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(4usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(5usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                ],
+                            ),
+                        )
+                    });
+                    ptr
                 } else if riid
                     == <dyn IFoo as intercom::attributes::ComInterface<
                         intercom::type_system::AutomationTypeSystem,
                     >>::iid()
                 {
-                    &vtables.IFoo_Automation
+                    let ptr = &vtables.IFoo_Automation
                         as *const &<dyn IFoo as intercom::attributes::ComInterface<
                             intercom::type_system::AutomationTypeSystem,
                         >>::VTable
                         as *mut &<dyn IFoo as intercom::attributes::ComInterface<
                             intercom::type_system::AutomationTypeSystem,
-                        >>::VTable as intercom::RawComPtr
+                        >>::VTable as intercom::RawComPtr;
+                    intercom::logging::trace(|l| {
+                        l(
+                            "testcrate",
+                            ::core::fmt::Arguments::new_v1_formatted(
+                                &["[", "] ", "::query_interface(", ") -> ", " (", ") [", "]"],
+                                &match (&vtables, &"Foo", &riid, &"IFoo", &"Automation", &ptr) {
+                                    (arg0, arg1, arg2, arg3, arg4, arg5) => [
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg0,
+                                            ::core::fmt::Pointer::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg1,
+                                            ::core::fmt::Display::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg2,
+                                            ::core::fmt::UpperHex::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg3,
+                                            ::core::fmt::Display::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg4,
+                                            ::core::fmt::Display::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg5,
+                                            ::core::fmt::Pointer::fmt,
+                                        ),
+                                    ],
+                                },
+                                &[
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(0usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(1usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(2usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 2u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(3usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(4usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(5usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                ],
+                            ),
+                        )
+                    });
+                    ptr
                 } else if riid
                     == <dyn IFoo as intercom::attributes::ComInterface<
                         intercom::type_system::RawTypeSystem,
                     >>::iid()
                 {
-                    &vtables.IFoo_Raw
+                    let ptr = &vtables.IFoo_Raw
                         as *const &<dyn IFoo as intercom::attributes::ComInterface<
                             intercom::type_system::RawTypeSystem,
                         >>::VTable
                         as *mut &<dyn IFoo as intercom::attributes::ComInterface<
                             intercom::type_system::RawTypeSystem,
-                        >>::VTable as intercom::RawComPtr
+                        >>::VTable as intercom::RawComPtr;
+                    intercom::logging::trace(|l| {
+                        l(
+                            "testcrate",
+                            ::core::fmt::Arguments::new_v1_formatted(
+                                &["[", "] ", "::query_interface(", ") -> ", " (", ") [", "]"],
+                                &match (&vtables, &"Foo", &riid, &"IFoo", &"Raw", &ptr) {
+                                    (arg0, arg1, arg2, arg3, arg4, arg5) => [
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg0,
+                                            ::core::fmt::Pointer::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg1,
+                                            ::core::fmt::Display::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg2,
+                                            ::core::fmt::UpperHex::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg3,
+                                            ::core::fmt::Display::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg4,
+                                            ::core::fmt::Display::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg5,
+                                            ::core::fmt::Pointer::fmt,
+                                        ),
+                                    ],
+                                },
+                                &[
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(0usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(1usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(2usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 2u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(3usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(4usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(5usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                ],
+                            ),
+                        )
+                    });
+                    ptr
                 } else {
+                    intercom::logging::trace(|l| {
+                        l(
+                            "testcrate",
+                            ::core::fmt::Arguments::new_v1_formatted(
+                                &["[", "] ", "::query_interface(", ") -> E_NOINTERFACE"],
+                                &match (&vtables, &"Foo", &riid) {
+                                    (arg0, arg1, arg2) => [
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg0,
+                                            ::core::fmt::Pointer::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg1,
+                                            ::core::fmt::Display::fmt,
+                                        ),
+                                        ::core::fmt::ArgumentV1::new(
+                                            arg2,
+                                            ::core::fmt::UpperHex::fmt,
+                                        ),
+                                    ],
+                                },
+                                &[
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(0usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(1usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 0u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                    ::core::fmt::rt::v1::Argument {
+                                        position: ::core::fmt::rt::v1::Position::At(2usize),
+                                        format: ::core::fmt::rt::v1::FormatSpec {
+                                            fill: ' ',
+                                            align: ::core::fmt::rt::v1::Alignment::Unknown,
+                                            flags: 2u32,
+                                            precision: ::core::fmt::rt::v1::Count::Implied,
+                                            width: ::core::fmt::rt::v1::Count::Implied,
+                                        },
+                                    },
+                                ],
+                            ),
+                        )
+                    });
                     return Err(intercom::raw::E_NOINTERFACE);
                 },
             )
@@ -513,15 +1225,27 @@ unsafe extern "system" fn __Foo_Foo_Automation_query_interface(
 ) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
     intercom::type_system::AutomationTypeSystem,
 >>::ExternOutputType {
-    intercom::ComBoxData::<Foo>::query_interface(
-        &mut *((self_vtable as usize
-            - <Foo as intercom::attributes::ComClass<
-                Foo,
-                intercom::type_system::AutomationTypeSystem,
-            >>::offset()) as *mut _),
-        riid,
-        out,
-    )
+    let self_ptr = (self_vtable as usize
+        - <Foo as intercom::attributes::ComClass<
+            Foo,
+            intercom::type_system::AutomationTypeSystem,
+        >>::offset()) as *mut _;
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::query_interface"],
+                &match (&self_ptr, &self_vtable, &"Foo") {
+                    (arg0, arg1, arg2) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
+    intercom::ComBoxData::<Foo>::query_interface(&mut *self_ptr, riid, out)
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]
@@ -531,13 +1255,27 @@ unsafe extern "system" fn __Foo_Foo_Automation_add_ref(self_vtable:
  ->
      <u32 as
 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
-    intercom::ComBoxData::<Foo>::add_ref(
-        &mut *((self_vtable as usize
-            - <Foo as intercom::attributes::ComClass<
-                Foo,
-                intercom::type_system::AutomationTypeSystem,
-            >>::offset()) as *mut _),
-    )
+    let self_ptr = (self_vtable as usize
+        - <Foo as intercom::attributes::ComClass<
+            Foo,
+            intercom::type_system::AutomationTypeSystem,
+        >>::offset()) as *mut _;
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::add_ref"],
+                &match (&self_ptr, &self_vtable, &"Foo") {
+                    (arg0, arg1, arg2) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
+    intercom::ComBoxData::<Foo>::add_ref_ptr(self_ptr)
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]
@@ -547,13 +1285,27 @@ unsafe extern "system" fn __Foo_Foo_Automation_release(self_vtable:
  ->
      <u32 as
 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
-    intercom::ComBoxData::<Foo>::release_ptr(
-        (self_vtable as usize
-            - <Foo as intercom::attributes::ComClass<
-                Foo,
-                intercom::type_system::AutomationTypeSystem,
-            >>::offset()) as *mut _,
-    )
+    let self_ptr = (self_vtable as usize
+        - <Foo as intercom::attributes::ComClass<
+            Foo,
+            intercom::type_system::AutomationTypeSystem,
+        >>::offset()) as *mut _;
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::release_ptr"],
+                &match (&self_ptr, &self_vtable, &"Foo") {
+                    (arg0, arg1, arg2) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
+    intercom::ComBoxData::<Foo>::release_ptr(self_ptr)
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]
@@ -563,6 +1315,11 @@ unsafe extern "system" fn __Foo_Foo_Automation_struct_method_Automation(self_vta
  ->
      <() as
 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
+    let self_combox = (self_vtable as usize
+        - <Foo as intercom::attributes::ComClass<
+            Foo,
+            intercom::type_system::AutomationTypeSystem,
+        >>::offset()) as *mut intercom::ComBoxData<Foo>;
     use intercom::type_system::{IntercomFrom, IntercomInto};
     let result:
             Result<<() as
@@ -570,24 +1327,77 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
                    intercom::ComError> =
         (||
              {
-                 let self_combox =
-                     (self_vtable as usize -
-                          <Foo as
-                              intercom::attributes::ComClass<Foo,
-                                                             intercom::type_system::AutomationTypeSystem>>::offset())
-                         as *mut intercom::ComBoxData<Foo>;
+                 intercom::logging::trace(|l|
+                                              l("testcrate",
+                                                ::core::fmt::Arguments::new_v1(&["[",
+                                                                                 ", through ",
+                                                                                 "] Serving ",
+                                                                                 "::"],
+                                                                               &match (&self_combox,
+                                                                                       &self_vtable,
+                                                                                       &"Foo",
+                                                                                       &"struct_method")
+                                                                                    {
+                                                                                    (arg0,
+                                                                                     arg1,
+                                                                                     arg2,
+                                                                                     arg3)
+                                                                                    =>
+                                                                                    [::core::fmt::ArgumentV1::new(arg0,
+                                                                                                                  ::core::fmt::Pointer::fmt),
+                                                                                     ::core::fmt::ArgumentV1::new(arg1,
+                                                                                                                  ::core::fmt::Pointer::fmt),
+                                                                                     ::core::fmt::ArgumentV1::new(arg2,
+                                                                                                                  ::core::fmt::Display::fmt),
+                                                                                     ::core::fmt::ArgumentV1::new(arg3,
+                                                                                                                  ::core::fmt::Display::fmt)],
+                                                                                })));
                  let self_struct: &Foo = &**self_combox;
                  let __result = self_struct.struct_method();
                  Ok({ })
              })();
     use intercom::ErrorValue;
     match result {
-        Ok(v) => v,
-        Err(err) => <<() as intercom::type_system::ExternType<
-            intercom::type_system::AutomationTypeSystem,
-        >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(
-            err,
-        )),
+        Ok(v) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", OK"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"struct_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            v
+        }
+        Err(err) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"struct_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            <<() as
+             intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                as ErrorValue>::from_error(intercom::store_error(err))
+        }
     }
 }
 #[allow(non_upper_case_globals)]
@@ -626,13 +1436,28 @@ unsafe extern "system" fn __Foo_Foo_Raw_query_interface(
 ) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
     intercom::type_system::AutomationTypeSystem,
 >>::ExternOutputType {
-    intercom::ComBoxData::<Foo>::query_interface(&mut *((self_vtable as usize
-                                                             -
-                                                             <Foo as
-                                                                 intercom::attributes::ComClass<Foo,
-                                                                                                intercom::type_system::RawTypeSystem>>::offset())
-                                                            as *mut _), riid,
-                                                 out)
+    let self_ptr =
+        (self_vtable as usize -
+             <Foo as
+                 intercom::attributes::ComClass<Foo,
+                                                intercom::type_system::RawTypeSystem>>::offset())
+            as *mut _;
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::query_interface"],
+                &match (&self_ptr, &self_vtable, &"Foo") {
+                    (arg0, arg1, arg2) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
+    intercom::ComBoxData::<Foo>::query_interface(&mut *self_ptr, riid, out)
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]
@@ -642,11 +1467,28 @@ unsafe extern "system" fn __Foo_Foo_Raw_add_ref(self_vtable:
  ->
      <u32 as
 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
-    intercom::ComBoxData::<Foo>::add_ref(&mut *((self_vtable as usize -
-                                                     <Foo as
-                                                         intercom::attributes::ComClass<Foo,
-                                                                                        intercom::type_system::RawTypeSystem>>::offset())
-                                                    as *mut _))
+    let self_ptr =
+        (self_vtable as usize -
+             <Foo as
+                 intercom::attributes::ComClass<Foo,
+                                                intercom::type_system::RawTypeSystem>>::offset())
+            as *mut _;
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::add_ref"],
+                &match (&self_ptr, &self_vtable, &"Foo") {
+                    (arg0, arg1, arg2) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
+    intercom::ComBoxData::<Foo>::add_ref_ptr(self_ptr)
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]
@@ -656,11 +1498,28 @@ unsafe extern "system" fn __Foo_Foo_Raw_release(self_vtable:
  ->
      <u32 as
 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
-    intercom::ComBoxData::<Foo>::release_ptr((self_vtable as usize -
-                                                  <Foo as
-                                                      intercom::attributes::ComClass<Foo,
-                                                                                     intercom::type_system::RawTypeSystem>>::offset())
-                                                 as *mut _)
+    let self_ptr =
+        (self_vtable as usize -
+             <Foo as
+                 intercom::attributes::ComClass<Foo,
+                                                intercom::type_system::RawTypeSystem>>::offset())
+            as *mut _;
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::release_ptr"],
+                &match (&self_ptr, &self_vtable, &"Foo") {
+                    (arg0, arg1, arg2) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
+    intercom::ComBoxData::<Foo>::release_ptr(self_ptr)
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]
@@ -670,6 +1529,12 @@ unsafe extern "system" fn __Foo_Foo_Raw_struct_method_Raw(self_vtable:
  ->
      <() as
 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
+    let self_combox =
+        (self_vtable as usize -
+             <Foo as
+                 intercom::attributes::ComClass<Foo,
+                                                intercom::type_system::RawTypeSystem>>::offset())
+            as *mut intercom::ComBoxData<Foo>;
     use intercom::type_system::{IntercomFrom, IntercomInto};
     let result:
             Result<<() as
@@ -677,24 +1542,77 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
                    intercom::ComError> =
         (||
              {
-                 let self_combox =
-                     (self_vtable as usize -
-                          <Foo as
-                              intercom::attributes::ComClass<Foo,
-                                                             intercom::type_system::RawTypeSystem>>::offset())
-                         as *mut intercom::ComBoxData<Foo>;
+                 intercom::logging::trace(|l|
+                                              l("testcrate",
+                                                ::core::fmt::Arguments::new_v1(&["[",
+                                                                                 ", through ",
+                                                                                 "] Serving ",
+                                                                                 "::"],
+                                                                               &match (&self_combox,
+                                                                                       &self_vtable,
+                                                                                       &"Foo",
+                                                                                       &"struct_method")
+                                                                                    {
+                                                                                    (arg0,
+                                                                                     arg1,
+                                                                                     arg2,
+                                                                                     arg3)
+                                                                                    =>
+                                                                                    [::core::fmt::ArgumentV1::new(arg0,
+                                                                                                                  ::core::fmt::Pointer::fmt),
+                                                                                     ::core::fmt::ArgumentV1::new(arg1,
+                                                                                                                  ::core::fmt::Pointer::fmt),
+                                                                                     ::core::fmt::ArgumentV1::new(arg2,
+                                                                                                                  ::core::fmt::Display::fmt),
+                                                                                     ::core::fmt::ArgumentV1::new(arg3,
+                                                                                                                  ::core::fmt::Display::fmt)],
+                                                                                })));
                  let self_struct: &Foo = &**self_combox;
                  let __result = self_struct.struct_method();
                  Ok({ })
              })();
     use intercom::ErrorValue;
     match result {
-        Ok(v) => v,
-        Err(err) => <<() as intercom::type_system::ExternType<
-            intercom::type_system::AutomationTypeSystem,
-        >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(
-            err,
-        )),
+        Ok(v) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", OK"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"struct_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            v
+        }
+        Err(err) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"struct_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            <<() as
+             intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                as ErrorValue>::from_error(intercom::store_error(err))
+        }
     }
 }
 #[allow(non_upper_case_globals)]
@@ -898,15 +1816,27 @@ unsafe extern "system" fn __Foo_IFoo_Automation_query_interface(
 ) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
     intercom::type_system::AutomationTypeSystem,
 >>::ExternOutputType {
-    intercom::ComBoxData::<Foo>::query_interface(
-        &mut *((self_vtable as usize
-            - <Foo as intercom::attributes::ComClass<
-                dyn IFoo,
-                intercom::type_system::AutomationTypeSystem,
-            >>::offset()) as *mut _),
-        riid,
-        out,
-    )
+    let self_ptr = (self_vtable as usize
+        - <Foo as intercom::attributes::ComClass<
+            dyn IFoo,
+            intercom::type_system::AutomationTypeSystem,
+        >>::offset()) as *mut _;
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::query_interface"],
+                &match (&self_ptr, &self_vtable, &"Foo") {
+                    (arg0, arg1, arg2) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
+    intercom::ComBoxData::<Foo>::query_interface(&mut *self_ptr, riid, out)
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]
@@ -916,13 +1846,27 @@ unsafe extern "system" fn __Foo_IFoo_Automation_add_ref(self_vtable:
  ->
      <u32 as
 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
-    intercom::ComBoxData::<Foo>::add_ref(
-        &mut *((self_vtable as usize
-            - <Foo as intercom::attributes::ComClass<
-                dyn IFoo,
-                intercom::type_system::AutomationTypeSystem,
-            >>::offset()) as *mut _),
-    )
+    let self_ptr = (self_vtable as usize
+        - <Foo as intercom::attributes::ComClass<
+            dyn IFoo,
+            intercom::type_system::AutomationTypeSystem,
+        >>::offset()) as *mut _;
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::add_ref"],
+                &match (&self_ptr, &self_vtable, &"Foo") {
+                    (arg0, arg1, arg2) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
+    intercom::ComBoxData::<Foo>::add_ref_ptr(self_ptr)
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]
@@ -932,13 +1876,27 @@ unsafe extern "system" fn __Foo_IFoo_Automation_release(self_vtable:
  ->
      <u32 as
 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
-    intercom::ComBoxData::<Foo>::release_ptr(
-        (self_vtable as usize
-            - <Foo as intercom::attributes::ComClass<
-                dyn IFoo,
-                intercom::type_system::AutomationTypeSystem,
-            >>::offset()) as *mut _,
-    )
+    let self_ptr = (self_vtable as usize
+        - <Foo as intercom::attributes::ComClass<
+            dyn IFoo,
+            intercom::type_system::AutomationTypeSystem,
+        >>::offset()) as *mut _;
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::release_ptr"],
+                &match (&self_ptr, &self_vtable, &"Foo") {
+                    (arg0, arg1, arg2) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
+    intercom::ComBoxData::<Foo>::release_ptr(self_ptr)
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]
@@ -948,6 +1906,11 @@ unsafe extern "system" fn __Foo_IFoo_Automation_trait_method_Automation(self_vta
  ->
      <() as
 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
+    let self_combox = (self_vtable as usize
+        - <Foo as intercom::attributes::ComClass<
+            dyn IFoo,
+            intercom::type_system::AutomationTypeSystem,
+        >>::offset()) as *mut intercom::ComBoxData<Foo>;
     use intercom::type_system::{IntercomFrom, IntercomInto};
     let result:
             Result<<() as
@@ -955,24 +1918,77 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
                    intercom::ComError> =
         (||
              {
-                 let self_combox =
-                     (self_vtable as usize -
-                          <Foo as
-                              intercom::attributes::ComClass<dyn IFoo,
-                                                             intercom::type_system::AutomationTypeSystem>>::offset())
-                         as *mut intercom::ComBoxData<Foo>;
+                 intercom::logging::trace(|l|
+                                              l("testcrate",
+                                                ::core::fmt::Arguments::new_v1(&["[",
+                                                                                 ", through ",
+                                                                                 "] Serving ",
+                                                                                 "::"],
+                                                                               &match (&self_combox,
+                                                                                       &self_vtable,
+                                                                                       &"Foo",
+                                                                                       &"trait_method")
+                                                                                    {
+                                                                                    (arg0,
+                                                                                     arg1,
+                                                                                     arg2,
+                                                                                     arg3)
+                                                                                    =>
+                                                                                    [::core::fmt::ArgumentV1::new(arg0,
+                                                                                                                  ::core::fmt::Pointer::fmt),
+                                                                                     ::core::fmt::ArgumentV1::new(arg1,
+                                                                                                                  ::core::fmt::Pointer::fmt),
+                                                                                     ::core::fmt::ArgumentV1::new(arg2,
+                                                                                                                  ::core::fmt::Display::fmt),
+                                                                                     ::core::fmt::ArgumentV1::new(arg3,
+                                                                                                                  ::core::fmt::Display::fmt)],
+                                                                                })));
                  let self_struct: &dyn IFoo = &**self_combox;
                  let __result = self_struct.trait_method();
                  Ok({ })
              })();
     use intercom::ErrorValue;
     match result {
-        Ok(v) => v,
-        Err(err) => <<() as intercom::type_system::ExternType<
-            intercom::type_system::AutomationTypeSystem,
-        >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(
-            err,
-        )),
+        Ok(v) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", OK"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"trait_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            v
+        }
+        Err(err) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"trait_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            <<() as
+             intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                as ErrorValue>::from_error(intercom::store_error(err))
+        }
     }
 }
 #[allow(non_upper_case_globals)]
@@ -1011,15 +2027,28 @@ unsafe extern "system" fn __Foo_IFoo_Raw_query_interface(
 ) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
     intercom::type_system::AutomationTypeSystem,
 >>::ExternOutputType {
-    intercom::ComBoxData::<Foo>::query_interface(
-        &mut *((self_vtable as usize
+    let self_ptr =
+        (self_vtable as usize
             - <Foo as intercom::attributes::ComClass<
                 dyn IFoo,
                 intercom::type_system::RawTypeSystem,
-            >>::offset()) as *mut _),
-        riid,
-        out,
-    )
+            >>::offset()) as *mut _;
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::query_interface"],
+                &match (&self_ptr, &self_vtable, &"Foo") {
+                    (arg0, arg1, arg2) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
+    intercom::ComBoxData::<Foo>::query_interface(&mut *self_ptr, riid, out)
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]
@@ -1029,13 +2058,28 @@ unsafe extern "system" fn __Foo_IFoo_Raw_add_ref(self_vtable:
  ->
      <u32 as
 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
-    intercom::ComBoxData::<Foo>::add_ref(
-        &mut *((self_vtable as usize
+    let self_ptr =
+        (self_vtable as usize
             - <Foo as intercom::attributes::ComClass<
                 dyn IFoo,
                 intercom::type_system::RawTypeSystem,
-            >>::offset()) as *mut _),
-    )
+            >>::offset()) as *mut _;
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::add_ref"],
+                &match (&self_ptr, &self_vtable, &"Foo") {
+                    (arg0, arg1, arg2) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
+    intercom::ComBoxData::<Foo>::add_ref_ptr(self_ptr)
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]
@@ -1045,13 +2089,28 @@ unsafe extern "system" fn __Foo_IFoo_Raw_release(self_vtable:
  ->
      <u32 as
 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
-    intercom::ComBoxData::<Foo>::release_ptr(
+    let self_ptr =
         (self_vtable as usize
             - <Foo as intercom::attributes::ComClass<
                 dyn IFoo,
                 intercom::type_system::RawTypeSystem,
-            >>::offset()) as *mut _,
-    )
+            >>::offset()) as *mut _;
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::release_ptr"],
+                &match (&self_ptr, &self_vtable, &"Foo") {
+                    (arg0, arg1, arg2) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
+    intercom::ComBoxData::<Foo>::release_ptr(self_ptr)
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]
@@ -1061,6 +2120,12 @@ unsafe extern "system" fn __Foo_IFoo_Raw_trait_method_Raw(self_vtable:
  ->
      <() as
 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
+    let self_combox =
+        (self_vtable as usize
+            - <Foo as intercom::attributes::ComClass<
+                dyn IFoo,
+                intercom::type_system::RawTypeSystem,
+            >>::offset()) as *mut intercom::ComBoxData<Foo>;
     use intercom::type_system::{IntercomFrom, IntercomInto};
     let result:
             Result<<() as
@@ -1068,24 +2133,77 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
                    intercom::ComError> =
         (||
              {
-                 let self_combox =
-                     (self_vtable as usize -
-                          <Foo as
-                              intercom::attributes::ComClass<dyn IFoo,
-                                                             intercom::type_system::RawTypeSystem>>::offset())
-                         as *mut intercom::ComBoxData<Foo>;
+                 intercom::logging::trace(|l|
+                                              l("testcrate",
+                                                ::core::fmt::Arguments::new_v1(&["[",
+                                                                                 ", through ",
+                                                                                 "] Serving ",
+                                                                                 "::"],
+                                                                               &match (&self_combox,
+                                                                                       &self_vtable,
+                                                                                       &"Foo",
+                                                                                       &"trait_method")
+                                                                                    {
+                                                                                    (arg0,
+                                                                                     arg1,
+                                                                                     arg2,
+                                                                                     arg3)
+                                                                                    =>
+                                                                                    [::core::fmt::ArgumentV1::new(arg0,
+                                                                                                                  ::core::fmt::Pointer::fmt),
+                                                                                     ::core::fmt::ArgumentV1::new(arg1,
+                                                                                                                  ::core::fmt::Pointer::fmt),
+                                                                                     ::core::fmt::ArgumentV1::new(arg2,
+                                                                                                                  ::core::fmt::Display::fmt),
+                                                                                     ::core::fmt::ArgumentV1::new(arg3,
+                                                                                                                  ::core::fmt::Display::fmt)],
+                                                                                })));
                  let self_struct: &dyn IFoo = &**self_combox;
                  let __result = self_struct.trait_method();
                  Ok({ })
              })();
     use intercom::ErrorValue;
     match result {
-        Ok(v) => v,
-        Err(err) => <<() as intercom::type_system::ExternType<
-            intercom::type_system::AutomationTypeSystem,
-        >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(
-            err,
-        )),
+        Ok(v) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", OK"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"trait_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            v
+        }
+        Err(err) => {
+            intercom::logging::trace(|l| {
+                l(
+                    "testcrate",
+                    ::core::fmt::Arguments::new_v1(
+                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
+                        &match (&self_combox, &self_vtable, &"Foo", &"trait_method") {
+                            (arg0, arg1, arg2, arg3) => [
+                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                            ],
+                        },
+                    ),
+                )
+            });
+            <<() as
+             intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                as ErrorValue>::from_error(intercom::store_error(err))
+        }
     }
 }
 #[allow(non_upper_case_globals)]

--- a/intercom-attributes/tests/data/run/basic-logging.rs
+++ b/intercom-attributes/tests/data/run/basic-logging.rs
@@ -1,0 +1,63 @@
+extern crate intercom;
+extern crate log;
+extern crate simple_logger;
+
+use submodule::ISubInterface;
+
+#[intercom::com_class(IInterface, ISubInterface)]
+struct S;
+
+#[intercom::com_interface]
+trait IInterface
+{
+    fn call(&self);
+}
+
+#[intercom::com_interface]
+trait IAnotherInterface
+{
+}
+
+#[intercom::com_impl]
+impl IInterface for S
+{
+    fn call(&self)
+    {
+        println!("Call");
+    }
+}
+
+mod submodule
+{
+    use super::*;
+
+    #[intercom::com_interface]
+    pub trait ISubInterface
+    {
+    }
+
+    #[intercom::com_impl]
+    impl ISubInterface for S {}
+}
+
+fn main()
+{
+    simple_logger::init().unwrap();
+
+    log::info!("Acquire S as IInterface");
+    let combox = intercom::ComBox::new(S);
+    let rc: intercom::ComRc<dyn IInterface> = intercom::ComRc::from(combox);
+
+    log::info!("Call IInterface::call");
+    rc.call();
+
+    log::info!("Query ISubInterface");
+    let _: intercom::ComRc<dyn submodule::ISubInterface> =
+        intercom::ComItf::query_interface(&rc).unwrap();
+
+    log::info!("Query IAnotherInterface");
+    let rc: intercom::ComResult<intercom::ComRc<dyn IAnotherInterface>> =
+        intercom::ComItf::query_interface(&rc);
+
+    log::info!("Cleanup");
+}

--- a/intercom-attributes/tests/data/run/basic-logging.rs.stdout
+++ b/intercom-attributes/tests/data/run/basic-logging.rs.stdout
@@ -1,0 +1,35 @@
+<TIMESTAMP> INFO  [testcrate] Acquire S as IInterface
+<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] S::query_interface(8846368B-18D7-3322-4DFB-1CE9E67F42A7)
+<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] S::query_interface(8846368B-18D7-3322-4DFB-1CE9E67F42A7) -> IInterface (Automation) [xxxxxxxx]
+<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] S::query_interface(9F4CFB79-0D16-30B4-6BD3-486DC541B7C4)
+<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] S::query_interface(9F4CFB79-0D16-30B4-6BD3-486DC541B7C4) -> IInterface (Raw) [xxxxxxxx]
+<TIMESTAMP> INFO  [testcrate] Call IInterface::call
+<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] Calling IInterface::call
+<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] Calling IInterface::call, type system: Automation
+<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] Serving S::call
+Call
+<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] Serving S::call, OK
+<TIMESTAMP> INFO  [testcrate] Query ISubInterface
+<TIMESTAMP> TRACE [generated::intercom::interfaces] [xxxxxxxx] Calling IUnknown::query_interface
+<TIMESTAMP> TRACE [generated::intercom::interfaces] [xxxxxxxx] Calling IUnknown::query_interface, type system: Automation
+<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] Serving S::query_interface
+<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] S::query_interface(8CEF9AA1-9CA1-3278-65DE-0DC2088FA5C0)
+<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] S::query_interface(8CEF9AA1-9CA1-3278-65DE-0DC2088FA5C0) -> ISubInterface (Raw) [xxxxxxxx]
+<TIMESTAMP> TRACE [generated::intercom::interfaces] [xxxxxxxx] Calling IUnknown::release
+<TIMESTAMP> TRACE [generated::intercom::interfaces] [xxxxxxxx] Calling IUnknown::release, type system: Raw
+<TIMESTAMP> TRACE [generated::testcrate::submodule] [xxxxxxxx] Serving S::release_ptr
+<TIMESTAMP> INFO  [testcrate] Query IAnotherInterface
+<TIMESTAMP> TRACE [generated::intercom::interfaces] [xxxxxxxx] Calling IUnknown::query_interface
+<TIMESTAMP> TRACE [generated::intercom::interfaces] [xxxxxxxx] Calling IUnknown::query_interface, type system: Automation
+<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] Serving S::query_interface
+<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] S::query_interface(3B049C4C-901B-3C27-7CD9-D8D0D5881325)
+<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] S::query_interface(3B049C4C-901B-3C27-7CD9-D8D0D5881325) -> E_NOINTERFACE
+<TIMESTAMP> TRACE [generated::intercom::interfaces] [xxxxxxxx] Calling IUnknown::query_interface
+<TIMESTAMP> TRACE [generated::intercom::interfaces] [xxxxxxxx] Calling IUnknown::query_interface, type system: Automation
+<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] Serving S::query_interface
+<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] S::query_interface(A082C6BF-6F0A-3C82-5954-86D506EB8662)
+<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] S::query_interface(A082C6BF-6F0A-3C82-5954-86D506EB8662) -> E_NOINTERFACE
+<TIMESTAMP> INFO  [testcrate] Cleanup
+<TIMESTAMP> TRACE [generated::intercom::interfaces] [xxxxxxxx] Calling IUnknown::release
+<TIMESTAMP> TRACE [generated::intercom::interfaces] [xxxxxxxx] Calling IUnknown::release, type system: Automation
+<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] Serving S::release_ptr

--- a/intercom-attributes/tests/data/run/confirm-run-tests.rs
+++ b/intercom-attributes/tests/data/run/confirm-run-tests.rs
@@ -1,0 +1,5 @@
+fn main()
+{
+    println!("stdout works");
+    eprintln!("stderr works");
+}

--- a/intercom-attributes/tests/data/run/confirm-run-tests.rs.stderr
+++ b/intercom-attributes/tests/data/run/confirm-run-tests.rs.stderr
@@ -1,0 +1,1 @@
+stderr works

--- a/intercom-attributes/tests/data/run/confirm-run-tests.rs.stdout
+++ b/intercom-attributes/tests/data/run/confirm-run-tests.rs.stdout
@@ -1,0 +1,1 @@
+stdout works

--- a/intercom-common/src/attributes/com_impl.rs
+++ b/intercom-common/src/attributes/com_impl.rs
@@ -75,9 +75,9 @@ pub fn expand_com_impl(
                 // self_vtable with the vtable offset. Once we have the primary
                 // pointer we can delegate the call to the primary implementation.
                 let self_ptr = ( self_vtable as usize - #vtable_offset ) as *mut _;
-                intercom::logging::trace(format_args!(
+                intercom::logging::trace(|l| l(module_path!(), format_args!(
                     "[{:p}, through {:p}] Serving {}::query_interface",
-                    self_ptr, self_vtable, #struct_name));
+                    self_ptr, self_vtable, #struct_name)));
                 intercom::ComBoxData::< #struct_ident >::query_interface(
                         &mut *self_ptr,
                         riid,
@@ -98,9 +98,9 @@ pub fn expand_com_impl(
                         ::ExternOutputType
             {
                 let self_ptr = ( self_vtable as usize - #vtable_offset ) as *mut _;
-                intercom::logging::trace(format_args!(
+                intercom::logging::trace(|l| l(module_path!(), format_args!(
                     "[{:p}, through {:p}] Serving {}::add_ref",
-                    self_ptr, self_vtable, #struct_name));
+                    self_ptr, self_vtable, #struct_name)));
                 intercom::ComBoxData::< #struct_ident >::add_ref_ptr(self_ptr)
             }
         ));
@@ -118,9 +118,9 @@ pub fn expand_com_impl(
                         ::ExternOutputType
             {
                 let self_ptr = ( self_vtable as usize - #vtable_offset ) as *mut _;
-                intercom::logging::trace(format_args!(
+                intercom::logging::trace(|l| l(module_path!(), format_args!(
                     "[{:p}, through {:p}] Serving {}::release_ptr",
-                    self_ptr, self_vtable, #struct_name));
+                    self_ptr, self_vtable, #struct_name)));
                 intercom::ComBoxData::< #struct_ident >::release_ptr(self_ptr)
             }
         ));
@@ -209,9 +209,9 @@ pub fn expand_com_impl(
 
                     use intercom::type_system::{IntercomFrom, IntercomInto};
                     let result : Result< #ret_ty, intercom::ComError > = ( || {
-                        intercom::logging::trace(format_args!(
+                        intercom::logging::trace(|l| l(module_path!(), format_args!(
                             "[{:p}, through {:p}] Serving {}::{}",
-                            self_combox, self_vtable, #struct_name, #method_name));
+                            self_combox, self_vtable, #struct_name, #method_name)));
 
                         #self_struct_stmt;
                         let #return_ident = self_struct.#method_rust_ident( #( #in_params ),* );
@@ -222,15 +222,15 @@ pub fn expand_com_impl(
                     use intercom::ErrorValue;
                     match result {
                         Ok( v ) => {
-                            intercom::logging::trace(format_args!(
+                            intercom::logging::trace(|l| l(module_path!(), format_args!(
                                 "[{:p}, through {:p}] Serving {}::{}, OK",
-                                self_combox, self_vtable, #struct_name, #method_name));
+                                self_combox, self_vtable, #struct_name, #method_name)));
                             v
                         },
                         Err( err ) => {
-                            intercom::logging::trace(format_args!(
+                            intercom::logging::trace(|l| l(module_path!(), format_args!(
                                 "[{:p}, through {:p}] Serving {}::{}, ERROR",
-                                self_combox, self_vtable, #struct_name, #method_name));
+                                self_combox, self_vtable, #struct_name, #method_name)));
                             <#ret_ty as ErrorValue>::from_error(
                                 intercom::store_error(err))
                         },

--- a/intercom-common/src/attributes/com_impl.rs
+++ b/intercom-common/src/attributes/com_impl.rs
@@ -55,6 +55,7 @@ pub fn expand_com_impl(
         // QueryInterface
         let query_interface_ident =
             idents::method_impl(&struct_ident, &itf_unique_ident, "query_interface");
+        let struct_name = struct_ident.to_string();
         output.push(quote_spanned!(struct_ident.span() =>
             #[allow(non_snake_case)]
             #[doc(hidden)]
@@ -73,8 +74,12 @@ pub fn expand_com_impl(
                 // Get the primary iunk interface by offsetting the current
                 // self_vtable with the vtable offset. Once we have the primary
                 // pointer we can delegate the call to the primary implementation.
+                let self_ptr = ( self_vtable as usize - #vtable_offset ) as *mut _;
+                intercom::logging::trace(format_args!(
+                    "[{:p}, through {:p}] Serving {}::query_interface",
+                    self_ptr, self_vtable, #struct_name));
                 intercom::ComBoxData::< #struct_ident >::query_interface(
-                        &mut *(( self_vtable as usize - #vtable_offset ) as *mut _ ),
+                        &mut *self_ptr,
                         riid,
                         out )
             }
@@ -92,8 +97,11 @@ pub fn expand_com_impl(
                     intercom::type_system::AutomationTypeSystem>>
                         ::ExternOutputType
             {
-                intercom::ComBoxData::< #struct_ident >::add_ref(
-                        &mut *(( self_vtable as usize - #vtable_offset ) as *mut _ ) )
+                let self_ptr = ( self_vtable as usize - #vtable_offset ) as *mut _;
+                intercom::logging::trace(format_args!(
+                    "[{:p}, through {:p}] Serving {}::add_ref",
+                    self_ptr, self_vtable, #struct_name));
+                intercom::ComBoxData::< #struct_ident >::add_ref_ptr(self_ptr)
             }
         ));
 
@@ -109,8 +117,11 @@ pub fn expand_com_impl(
                     intercom::type_system::AutomationTypeSystem>>
                         ::ExternOutputType
             {
-                intercom::ComBoxData::< #struct_ident >::release_ptr(
-                        ( self_vtable as usize - #vtable_offset ) as *mut _ )
+                let self_ptr = ( self_vtable as usize - #vtable_offset ) as *mut _;
+                intercom::logging::trace(format_args!(
+                    "[{:p}, through {:p}] Serving {}::release_ptr",
+                    self_ptr, self_vtable, #struct_name));
+                intercom::ComBoxData::< #struct_ident >::release_ptr(self_ptr)
             }
         ));
 
@@ -183,6 +194,7 @@ pub fn expand_com_impl(
                 quote!( let self_struct : &mut #maybe_dyn #itf_ident = &mut **self_combox )
             };
 
+            let method_name = method_ident.to_string();
             output.push(quote!(
                 #[allow(non_snake_case)]
                 #[allow(dead_code)]
@@ -190,12 +202,16 @@ pub fn expand_com_impl(
                 unsafe extern "system" fn #method_impl_ident(
                     #( #args ),*
                 ) -> #ret_ty {
+                    // Acquire the reference to the ComBoxData. For this we need
+                    // to offset the current 'self_vtable' vtable pointer.
+                    let self_combox = ( self_vtable as usize - #vtable_offset )
+                            as *mut intercom::ComBoxData< #struct_ident >;
+
                     use intercom::type_system::{IntercomFrom, IntercomInto};
                     let result : Result< #ret_ty, intercom::ComError > = ( || {
-                        // Acquire the reference to the ComBoxData. For this we need
-                        // to offset the current 'self_vtable' vtable pointer.
-                        let self_combox = ( self_vtable as usize - #vtable_offset )
-                                as *mut intercom::ComBoxData< #struct_ident >;
+                        intercom::logging::trace(format_args!(
+                            "[{:p}, through {:p}] Serving {}::{}",
+                            self_combox, self_vtable, #struct_name, #method_name));
 
                         #self_struct_stmt;
                         let #return_ident = self_struct.#method_rust_ident( #( #in_params ),* );
@@ -205,9 +221,19 @@ pub fn expand_com_impl(
 
                     use intercom::ErrorValue;
                     match result {
-                        Ok( v ) => v,
-                        Err( err ) => < #ret_ty as ErrorValue >::from_error(
-                                intercom::store_error( err ) ),
+                        Ok( v ) => {
+                            intercom::logging::trace(format_args!(
+                                "[{:p}, through {:p}] Serving {}::{}, OK",
+                                self_combox, self_vtable, #struct_name, #method_name));
+                            v
+                        },
+                        Err( err ) => {
+                            intercom::logging::trace(format_args!(
+                                "[{:p}, through {:p}] Serving {}::{}, ERROR",
+                                self_combox, self_vtable, #struct_name, #method_name));
+                            <#ret_ty as ErrorValue>::from_error(
+                                intercom::store_error(err))
+                        },
                     }
                 }
             ));

--- a/intercom-common/src/attributes/com_interface.rs
+++ b/intercom-common/src/attributes/com_interface.rs
@@ -83,9 +83,9 @@ pub fn expand_com_interface(
                 let ts_name = format!("{:?}", ts);
                 impl_branches.push(quote_spanned!(method.info.signature_span =>
                     if let Some( comptr ) = intercom::ComItf::maybe_ptr::<#ts_tokens>( self ) {
-                        intercom::logging::trace(format_args!(
+                        intercom::logging::trace(|l| l(module_path!(), format_args!(
                             "[{:p}, with {:p}] Calling {}::{}, type system: {}",
-                            self, comptr.ptr, #itf_name, #method_name, #ts_name));
+                            self, comptr.ptr, #itf_name, #method_name, #ts_name)));
 
                         #method_ts_impl
                     }
@@ -113,8 +113,8 @@ pub fn expand_com_interface(
                     #self_arg, #( #impl_args ),*
                 ) -> #return_ty {
 
-                    intercom::logging::trace(format_args!(
-                        "[{:p}] Calling {}::{}", self, #itf_name, #method_name));
+                    intercom::logging::trace(|l| l(module_path!(), format_args!(
+                        "[{:p}] Calling {}::{}", self, #itf_name, #method_name)));
 
                     #[allow(unused_imports)]
                     use intercom::ErrorValue;

--- a/intercom-common/src/attributes/com_interface.rs
+++ b/intercom-common/src/attributes/com_interface.rs
@@ -61,6 +61,7 @@ pub fn expand_com_interface(
     let itf =
         model::ComInterface::from_ast(&lib_name(), attr_tokens.into(), item_tokens.clone().into())?;
     let itf_ident = &itf.display_name;
+    let itf_name = itf.display_name.to_string();
     let maybe_dyn = match itf.item_type {
         utils::InterfaceType::Trait => quote_spanned!(itf.span => dyn),
         utils::InterfaceType::Struct => quote!(),
@@ -74,11 +75,18 @@ pub fn expand_com_interface(
     if itf.item_type == utils::InterfaceType::Trait {
         let mut impls = vec![];
         for (_, method) in itf_output.method_impls.iter() {
+            let method_rust_ident = &method.info.display_name;
+            let method_name = method_rust_ident.to_string();
             let mut impl_branches = vec![];
             for (ts, method_ts_impl) in method.impls.iter() {
                 let ts_tokens = ts.as_typesystem_type(method.info.signature_span);
+                let ts_name = format!("{:?}", ts);
                 impl_branches.push(quote_spanned!(method.info.signature_span =>
                     if let Some( comptr ) = intercom::ComItf::maybe_ptr::<#ts_tokens>( self ) {
+                        intercom::logging::trace(format_args!(
+                            "[{:p}, with {:p}] Calling {}::{}, type system: {}",
+                            self, comptr.ptr, #itf_name, #method_name, #ts_name));
+
                         #method_ts_impl
                     }
                 ));
@@ -97,7 +105,6 @@ pub fn expand_com_interface(
                 quote!()
             };
             let self_arg = &method.info.rust_self_arg;
-            let method_rust_ident = &method.info.display_name;
             let return_ty = &method.info.rust_return_ty;
 
             // Rust to COM implementation.
@@ -105,6 +112,9 @@ pub fn expand_com_interface(
                 #unsafety fn #method_rust_ident(
                     #self_arg, #( #impl_args ),*
                 ) -> #return_ty {
+
+                    intercom::logging::trace(format_args!(
+                        "[{:p}] Calling {}::{}", self, #itf_name, #method_name));
 
                     #[allow(unused_imports)]
                     use intercom::ErrorValue;

--- a/intercom/Cargo.toml
+++ b/intercom/Cargo.toml
@@ -21,10 +21,11 @@ failure = "0.1"
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
 handlebars = { version = "2.0", optional = true }
-log = { version = "0.4", optional = true }
+log = { version = "0.4" }
 
 [dev-dependencies]
 simple_logger = { version = "1.0", default-features = false }
+regex = "1.3"
 
 [target.'cfg(not(windows))'.dependencies]
 libc = "0.2"

--- a/intercom/Cargo.toml
+++ b/intercom/Cargo.toml
@@ -17,11 +17,14 @@ name = "intercom"
 
 [dependencies]
 intercom-attributes = { version = "0.3", path = "../intercom-attributes" }
-
 failure = "0.1"
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
 handlebars = { version = "2.0", optional = true }
+log = { version = "0.4", optional = true }
+
+[dev-dependencies]
+simple_logger = { version = "1.0", default-features = false }
 
 [target.'cfg(not(windows))'.dependencies]
 libc = "0.2"

--- a/intercom/benches/logging.rs
+++ b/intercom/benches/logging.rs
@@ -1,0 +1,62 @@
+#![feature(test)]
+extern crate test;
+
+extern crate intercom;
+extern crate simple_logger;
+
+#[intercom::com_class(IInterface)]
+struct S;
+
+#[intercom::com_interface]
+trait IInterface
+{
+    fn call(&self);
+}
+
+#[intercom::com_interface]
+trait IAnotherInterface
+{
+}
+
+#[intercom::com_impl]
+impl IInterface for S
+{
+    fn call(&self)
+    {
+        println!("Call");
+    }
+}
+
+#[bench]
+fn run_with_logging(bencher: &mut test::Bencher)
+{
+    simple_logger::init().unwrap();
+
+    bencher.iter(|| {
+        let combox = test::black_box(intercom::ComBox::new(S));
+        let rc: intercom::ComRc<dyn IInterface> = intercom::ComRc::from(combox);
+
+        test::black_box(&rc).call();
+
+        let rc: intercom::ComResult<intercom::ComRc<dyn IAnotherInterface>> =
+            intercom::ComItf::query_interface(&rc);
+
+        rc
+    });
+}
+
+#[bench]
+fn run_without_logging(bencher: &mut test::Bencher)
+{
+    bencher.iter(|| {
+        let combox = test::black_box(intercom::ComBox::new(S));
+        let rc: intercom::ComRc<dyn IInterface> = intercom::ComRc::from(combox);
+
+        test::black_box(&rc).call();
+
+        let rc: intercom::ComResult<intercom::ComRc<dyn IAnotherInterface>> =
+            intercom::ComItf::query_interface(&rc);
+
+        rc
+    });
+}

--- a/intercom/src/lib.rs
+++ b/intercom/src/lib.rs
@@ -74,6 +74,9 @@ pub use intercom_attributes::*;
 #[macro_use]
 extern crate failure;
 
+#[cfg(feature = "log")]
+extern crate log;
+
 pub mod prelude;
 
 mod classfactory;
@@ -99,6 +102,7 @@ pub mod type_system;
 pub mod typelib;
 pub use type_system::{BidirectionalTypeInfo, InputTypeInfo, OutputTypeInfo};
 pub mod attributes;
+pub mod logging;
 
 /// The `ComInterface` trait defines the COM interface details for a COM
 /// interface trait.

--- a/intercom/src/logging.rs
+++ b/intercom/src/logging.rs
@@ -1,27 +1,39 @@
 #[inline(always)]
 #[allow(unused_variables)]
-pub fn trace(args: std::fmt::Arguments<'_>)
+pub fn trace<FArgs>(f: FArgs)
+where
+    FArgs: FnOnce(fn(&str, std::fmt::Arguments<'_>)),
 {
-    #[cfg(feature = "log")]
-    log::logger().log(
-        &log::Record::builder()
-            .args(args)
-            .level(log::Level::Trace)
-            .target("intercom")
-            .build(),
-    );
+    if log::log_enabled!(log::Level::Trace) {
+        f(|module, args| {
+            log::logger().log(
+                &log::Record::builder()
+                    .level(log::Level::Trace)
+                    .target(&format!("generated::{}", module))
+                    .module_path(Some(module))
+                    .args(args)
+                    .build(),
+            )
+        });
+    }
 }
 
 #[inline(always)]
 #[allow(unused_variables)]
-pub fn error(args: std::fmt::Arguments<'_>)
+pub fn error<FArgs>(f: FArgs)
+where
+    FArgs: FnOnce(fn(&str, std::fmt::Arguments<'_>)),
 {
-    #[cfg(feature = "log")]
-    log::logger().log(
-        &log::Record::builder()
-            .args(args)
-            .level(log::Level::Error)
-            .target("intercom")
-            .build(),
-    );
+    if log::log_enabled!(log::Level::Error) {
+        f(|module, args| {
+            log::logger().log(
+                &log::Record::builder()
+                    .args(args)
+                    .level(log::Level::Error)
+                    .target(&format!("generated::{}", module))
+                    .module_path(Some(module))
+                    .build(),
+            )
+        });
+    }
 }

--- a/intercom/src/logging.rs
+++ b/intercom/src/logging.rs
@@ -1,0 +1,27 @@
+#[inline(always)]
+#[allow(unused_variables)]
+pub fn trace(args: std::fmt::Arguments<'_>)
+{
+    #[cfg(feature = "log")]
+    log::logger().log(
+        &log::Record::builder()
+            .args(args)
+            .level(log::Level::Trace)
+            .target("intercom")
+            .build(),
+    );
+}
+
+#[inline(always)]
+#[allow(unused_variables)]
+pub fn error(args: std::fmt::Arguments<'_>)
+{
+    #[cfg(feature = "log")]
+    log::logger().log(
+        &log::Record::builder()
+            .args(args)
+            .level(log::Level::Error)
+            .target("intercom")
+            .build(),
+    );
+}


### PR DESCRIPTION
Intercom now supports logging through the Rust `log` infrastructure. This is performed by exposing `intercom::logging` module and delegating to this module from the macro expansion code.

The call sites are a bit more complicated than usual logging to ensure that the logging does not result in performance penalty in case logging is not enabled. This was verified with micro benchmarking the implementation:

|Situation|Time
|-|-|
|Original|525 ns/iter|
|Logging enabled|~100 000 ns/iter|
|Unconditional `format_args!`| 620ns/iter|
|**Conditional `format_args!`**|580ns/iter|

There might still be some minor optimization wins here by turning the logging code into usual `if .. { log }` construct, but I don't want that noise in our `quote!(..)` calls - a macro exposed by `intercom` would be an acceptable solution to this, but don't feel like going there for now.

Fixes #134 

