### PR TITLE
Implement #[com_struct]

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Rust COM server:
 ```rust
 pub use intercom::*;
 
-#[com_library(Calculator)]
+#[com_library(class Calculator)]
 
 #[com_class(Calculator)]
 struct Calculator {

--- a/intercom-attributes/src/lib.rs
+++ b/intercom-attributes/src/lib.rs
@@ -106,6 +106,21 @@ pub fn com_class(attr: TokenStream, tokens: TokenStream) -> TokenStream
     }
 }
 
+/// Defines a COM struct that can be used as a parameter in COM methods.
+///
+/// ```rust,ignore
+/// #[com_struct]
+/// struct Data { /* ... */ }
+/// ```
+#[proc_macro_attribute]
+pub fn com_struct(attr: TokenStream, tokens: TokenStream) -> TokenStream
+{
+    match expand_com_struct(attr, tokens) {
+        Ok(t) => t,
+        Err(e) => panic!("{}", e),
+    }
+}
+
 /// Defines the COM library.
 ///
 /// ```rust,ignore

--- a/intercom-attributes/tests/data/macro/com_impl.rs.stdout
+++ b/intercom-attributes/tests/data/macro/com_impl.rs.stdout
@@ -985,8 +985,8 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
                                                                                 })));
                  let self_struct: &Foo = &**self_combox;
                  let __result =
-                     self_struct.arg_method((&<u16 as
-                                                  intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::intercom_from(a)?).intercom_into()?);
+                     self_struct.arg_method((<u16 as
+                                                 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::intercom_from(a)?).intercom_into()?);
                  Ok({ })
              })();
     use intercom::ErrorValue;
@@ -1472,10 +1472,10 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
         });
         let self_struct: &Foo = &**self_combox;
         let __result = self_struct.string_method(
-            (&<String as intercom::type_system::ExternType<
+            (<String as intercom::type_system::ExternType<
                 intercom::type_system::AutomationTypeSystem,
             >>::intercom_from(input)?)
-                .intercom_into()?,
+            .intercom_into()?,
         );
         Ok({ __result.intercom_into()? })
     })();
@@ -1567,10 +1567,10 @@ unsafe extern "system" fn __Foo_Foo_Automation_string_result_method_Automation(
         });
         let self_struct: &Foo = &**self_combox;
         let __result = self_struct.string_result_method(
-            (&<String as intercom::type_system::ExternType<
+            (<String as intercom::type_system::ExternType<
                 intercom::type_system::AutomationTypeSystem,
             >>::intercom_from(input)?)
-                .intercom_into()?,
+            .intercom_into()?,
         );
         Ok({
             match __result {
@@ -1678,14 +1678,14 @@ unsafe extern "system" fn __Foo_Foo_Automation_complete_method_Automation(
         });
         let self_struct: &mut Foo = &mut **self_combox;
         let __result = self_struct.complete_method(
-            (&<u16 as intercom::type_system::ExternType<
+            (<u16 as intercom::type_system::ExternType<
                 intercom::type_system::AutomationTypeSystem,
             >>::intercom_from(a)?)
-                .intercom_into()?,
-            (&<i16 as intercom::type_system::ExternType<
+            .intercom_into()?,
+            (<i16 as intercom::type_system::ExternType<
                 intercom::type_system::AutomationTypeSystem,
             >>::intercom_from(b)?)
-                .intercom_into()?,
+            .intercom_into()?,
         );
         Ok({
             match __result {
@@ -1788,10 +1788,10 @@ unsafe extern "system" fn __Foo_Foo_Automation_bool_method_Automation(
         });
         let self_struct: &Foo = &**self_combox;
         let __result = self_struct.bool_method(
-            (&<bool as intercom::type_system::ExternType<
+            (<bool as intercom::type_system::ExternType<
                 intercom::type_system::AutomationTypeSystem,
             >>::intercom_from(input)?)
-                .intercom_into()?,
+            .intercom_into()?,
         );
         Ok({
             match __result {
@@ -1894,10 +1894,10 @@ unsafe extern "system" fn __Foo_Foo_Automation_variant_method_Automation(
         });
         let self_struct: &Foo = &**self_combox;
         let __result = self_struct.variant_method(
-            (&<Variant as intercom::type_system::ExternType<
+            (<Variant as intercom::type_system::ExternType<
                 intercom::type_system::AutomationTypeSystem,
             >>::intercom_from(input)?)
-                .intercom_into()?,
+            .intercom_into()?,
         );
         Ok({
             match __result {
@@ -2232,8 +2232,8 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
                                                                                 })));
                  let self_struct: &Foo = &**self_combox;
                  let __result =
-                     self_struct.arg_method((&<u16 as
-                                                  intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::intercom_from(a)?).intercom_into()?);
+                     self_struct.arg_method((<u16 as
+                                                 intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::intercom_from(a)?).intercom_into()?);
                  Ok({ })
              })();
     use intercom::ErrorValue;
@@ -2736,8 +2736,8 @@ intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::Extern
                                                                                 })));
                  let self_struct: &Foo = &**self_combox;
                  let __result =
-                     self_struct.string_method((&<String as
-                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::intercom_from(input)?).intercom_into()?);
+                     self_struct.string_method((<String as
+                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::intercom_from(input)?).intercom_into()?);
                  Ok({ __result.intercom_into()? })
              })();
     use intercom::ErrorValue;
@@ -2830,10 +2830,10 @@ unsafe extern "system" fn __Foo_Foo_Raw_string_result_method_Raw(
         });
         let self_struct: &Foo = &**self_combox;
         let __result = self_struct.string_result_method(
-            (&<String as intercom::type_system::ExternType<
+            (<String as intercom::type_system::ExternType<
                 intercom::type_system::RawTypeSystem,
             >>::intercom_from(input)?)
-                .intercom_into()?,
+            .intercom_into()?,
         );
         Ok({
             match __result {
@@ -2941,14 +2941,14 @@ unsafe extern "system" fn __Foo_Foo_Raw_complete_method_Raw(
         let self_struct: &mut Foo = &mut **self_combox;
         let __result =
             self_struct.complete_method(
-                (&<u16 as intercom::type_system::ExternType<
+                (<u16 as intercom::type_system::ExternType<
                     intercom::type_system::RawTypeSystem,
                 >>::intercom_from(a)?)
-                    .intercom_into()?,
-                (&<i16 as intercom::type_system::ExternType<
+                .intercom_into()?,
+                (<i16 as intercom::type_system::ExternType<
                     intercom::type_system::RawTypeSystem,
                 >>::intercom_from(b)?)
-                    .intercom_into()?,
+                .intercom_into()?,
             );
         Ok({
             match __result {
@@ -3053,10 +3053,10 @@ unsafe extern "system" fn __Foo_Foo_Raw_bool_method_Raw(
         let self_struct: &Foo = &**self_combox;
         let __result =
             self_struct.bool_method(
-                (&<bool as intercom::type_system::ExternType<
+                (<bool as intercom::type_system::ExternType<
                     intercom::type_system::RawTypeSystem,
                 >>::intercom_from(input)?)
-                    .intercom_into()?,
+                .intercom_into()?,
             );
         Ok({
             match __result {
@@ -3160,10 +3160,10 @@ unsafe extern "system" fn __Foo_Foo_Raw_variant_method_Raw(
         });
         let self_struct: &Foo = &**self_combox;
         let __result = self_struct.variant_method(
-            (&<Variant as intercom::type_system::ExternType<
+            (<Variant as intercom::type_system::ExternType<
                 intercom::type_system::RawTypeSystem,
             >>::intercom_from(input)?)
-                .intercom_into()?,
+            .intercom_into()?,
         );
         Ok({
             match __result {

--- a/intercom-attributes/tests/data/macro/com_interface.rs.stdout
+++ b/intercom-attributes/tests/data/macro/com_interface.rs.stdout
@@ -306,10 +306,10 @@ impl Foo for intercom::ComItf<dyn Foo> {
             let __intercom_result: Result<(), intercom::ComError> = (|| unsafe {
                 let __result = ((**vtbl).arg_method)(
                     comptr.ptr,
-                    (&<u16 as intercom::type_system::ExternType<
+                    (<u16 as intercom::type_system::ExternType<
                         intercom::type_system::AutomationTypeSystem,
                     >>::intercom_from(a)?)
-                        .intercom_into()?,
+                    .intercom_into()?,
                 );
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
@@ -354,10 +354,10 @@ impl Foo for intercom::ComItf<dyn Foo> {
             let __intercom_result: Result<(), intercom::ComError> = (|| unsafe {
                 let __result = ((**vtbl).arg_method)(
                     comptr.ptr,
-                    (&<u16 as intercom::type_system::ExternType<
+                    (<u16 as intercom::type_system::ExternType<
                         intercom::type_system::RawTypeSystem,
                     >>::intercom_from(a)?)
-                        .intercom_into()?,
+                    .intercom_into()?,
                 );
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
@@ -425,10 +425,10 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 >>::ExternOutputType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).bool_method)(
                     comptr.ptr,
-                    (&<bool as intercom::type_system::ExternType<
+                    (<bool as intercom::type_system::ExternType<
                         intercom::type_system::AutomationTypeSystem,
                     >>::intercom_from(input)?)
-                        .intercom_into()?,
+                    .intercom_into()?,
                     &mut __out,
                 );
                 let __intercom_iid = intercom::GUID {
@@ -487,10 +487,10 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 >>::ExternOutputType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).bool_method)(
                     comptr.ptr,
-                    (&<bool as intercom::type_system::ExternType<
+                    (<bool as intercom::type_system::ExternType<
                         intercom::type_system::RawTypeSystem,
                     >>::intercom_from(input)?)
-                        .intercom_into()?,
+                    .intercom_into()?,
                     &mut __out,
                 );
                 let __intercom_iid = intercom::GUID {
@@ -712,10 +712,10 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 >>::ExternOutputType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).comitf_method)(
                     comptr.ptr,
-                    (&<ComItf<dyn Foo> as intercom::type_system::ExternType<
+                    (<ComItf<dyn Foo> as intercom::type_system::ExternType<
                         intercom::type_system::AutomationTypeSystem,
                     >>::intercom_from(itf)?)
-                        .intercom_into()?,
+                    .intercom_into()?,
                     &mut __out,
                 );
                 let __intercom_iid = intercom::GUID {
@@ -779,10 +779,10 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 >>::ExternOutputType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).comitf_method)(
                     comptr.ptr,
-                    (&<ComItf<dyn Foo> as intercom::type_system::ExternType<
+                    (<ComItf<dyn Foo> as intercom::type_system::ExternType<
                         intercom::type_system::RawTypeSystem,
                     >>::intercom_from(itf)?)
-                        .intercom_into()?,
+                    .intercom_into()?,
                     &mut __out,
                 );
                 let __intercom_iid = intercom::GUID {
@@ -871,14 +871,14 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 >>::ExternOutputType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).complete_method)(
                     comptr.ptr,
-                    (&<u16 as intercom::type_system::ExternType<
+                    (<u16 as intercom::type_system::ExternType<
                         intercom::type_system::AutomationTypeSystem,
                     >>::intercom_from(a)?)
-                        .intercom_into()?,
-                    (&<i16 as intercom::type_system::ExternType<
+                    .intercom_into()?,
+                    (<i16 as intercom::type_system::ExternType<
                         intercom::type_system::AutomationTypeSystem,
                     >>::intercom_from(b)?)
-                        .intercom_into()?,
+                    .intercom_into()?,
                     &mut __out,
                 );
                 let __intercom_iid = intercom::GUID {
@@ -937,14 +937,14 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 >>::ExternOutputType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).complete_method)(
                     comptr.ptr,
-                    (&<u16 as intercom::type_system::ExternType<
+                    (<u16 as intercom::type_system::ExternType<
                         intercom::type_system::RawTypeSystem,
                     >>::intercom_from(a)?)
-                        .intercom_into()?,
-                    (&<i16 as intercom::type_system::ExternType<
+                    .intercom_into()?,
+                    (<i16 as intercom::type_system::ExternType<
                         intercom::type_system::RawTypeSystem,
                     >>::intercom_from(b)?)
-                        .intercom_into()?,
+                    .intercom_into()?,
                     &mut __out,
                 );
                 let __intercom_iid = intercom::GUID {
@@ -1374,10 +1374,10 @@ impl Foo for intercom::ComItf<dyn Foo> {
             let __intercom_result: Result<String, intercom::ComError> = (|| unsafe {
                 let __result = ((**vtbl).string_method)(
                     comptr.ptr,
-                    (&<String as intercom::type_system::ExternType<
+                    (<String as intercom::type_system::ExternType<
                         intercom::type_system::AutomationTypeSystem,
                     >>::intercom_from(msg)?)
-                        .intercom_into()?,
+                    .intercom_into()?,
                 );
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
@@ -1422,10 +1422,10 @@ impl Foo for intercom::ComItf<dyn Foo> {
             let __intercom_result: Result<String, intercom::ComError> = (|| unsafe {
                 let __result = ((**vtbl).string_method)(
                     comptr.ptr,
-                    (&<String as intercom::type_system::ExternType<
+                    (<String as intercom::type_system::ExternType<
                         intercom::type_system::RawTypeSystem,
                     >>::intercom_from(msg)?)
-                        .intercom_into()?,
+                    .intercom_into()?,
                 );
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
@@ -1493,10 +1493,10 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 >>::ExternOutputType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).variant_method)(
                     comptr.ptr,
-                    (&<Variant as intercom::type_system::ExternType<
+                    (<Variant as intercom::type_system::ExternType<
                         intercom::type_system::AutomationTypeSystem,
                     >>::intercom_from(input)?)
-                        .intercom_into()?,
+                    .intercom_into()?,
                     &mut __out,
                 );
                 let __intercom_iid = intercom::GUID {
@@ -1556,10 +1556,10 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 >>::ExternOutputType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).variant_method)(
                     comptr.ptr,
-                    (&<Variant as intercom::type_system::ExternType<
+                    (<Variant as intercom::type_system::ExternType<
                         intercom::type_system::RawTypeSystem,
                     >>::intercom_from(input)?)
-                        .intercom_into()?,
+                    .intercom_into()?,
                     &mut __out,
                 );
                 let __intercom_iid = intercom::GUID {

--- a/intercom-attributes/tests/data/macro/com_library.rs
+++ b/intercom-attributes/tests/data/macro/com_library.rs
@@ -2,25 +2,28 @@ extern crate intercom;
 use intercom::*;
 use std::mem::MaybeUninit;
 
-pub mod some {
-    pub mod path {
+pub mod some
+{
+    pub mod path
+    {
         use std::mem::MaybeUninit;
         pub struct Type;
-        pub const CLSID_Type : i8 = 0i8;
-        pub(crate) fn get_intercom_coclass_info_for_Type() -> intercom::typelib::TypeInfo {
+        pub const CLSID_Type: i8 = 0i8;
+        pub(crate) fn get_intercom_coclass_info_for_Type() -> intercom::typelib::TypeInfo
+        {
             unsafe { MaybeUninit::uninit().assume_init() }
         }
     }
 }
 pub struct SimpleType;
-pub const CLSID_SimpleType : i8 = 0i8;
+pub const CLSID_SimpleType: i8 = 0i8;
 
-pub(crate) fn get_intercom_coclass_info_for_SimpleType() -> intercom::typelib::TypeInfo {
+pub(crate) fn get_intercom_coclass_info_for_SimpleType() -> intercom::typelib::TypeInfo
+{
     unsafe { MaybeUninit::uninit().assume_init() }
 }
 
-
 com_library!(
         libid = "00000000-0000-0000-0000-000000000000",
-        some::path::Type,
-        SimpleType );
+        class some::path::Type,
+        class SimpleType );

--- a/intercom-cli/src/generators/cpp_header.hbs
+++ b/intercom-cli/src/generators/cpp_header.hbs
@@ -35,6 +35,15 @@ namespace {{lib_name}}
 
 namespace raw
 {
+{{~#each structs}}
+    struct {{name}}
+    {
+    {{#each fields}}
+        {{arg_type}} {{name}};
+    {{/each}}
+    };
+{{~/each}}
+
 {{~#each interfaces}}
     struct {{name}};
 {{~/each}}

--- a/intercom-cli/src/generators/cpp_header.hbs
+++ b/intercom-cli/src/generators/cpp_header.hbs
@@ -85,6 +85,9 @@ namespace raw
     static constexpr intercom::IID IID_{{name}} = {{iid_struct}};
     using {{name}} = {{../lib_name}}::raw::{{name}};
 {{~/each}}
+{{~#each structs}}
+    using {{name}} = {{../lib_name}}::raw::{{name}};
+{{~/each}}
 {{~#each coclasses}}
     static constexpr intercom::CLSID CLSID_{{name}} = {{clsid_struct}};
 {{~/each}}

--- a/intercom-cli/src/generators/idl.hbs
+++ b/intercom-cli/src/generators/idl.hbs
@@ -25,6 +25,15 @@ library {{lib_name}}
     interface {{name}};
 {{/each}}
 
+{{#each structs}}
+    struct {{name}}
+    {
+    {{#each fields}}
+        {{arg_type}} {{name}};
+    {{/each}}
+    };
+{{/each}}
+
 {{#each interfaces}}
     [
         object,

--- a/intercom-cli/src/generators/mod.rs
+++ b/intercom-cli/src/generators/mod.rs
@@ -4,7 +4,7 @@
 use std::collections::HashMap;
 
 use intercom::type_system::TypeSystemName;
-use intercom::typelib::{Interface, TypeInfo, TypeLib};
+use intercom::typelib::{Interface, Struct, TypeInfo, TypeLib};
 
 /// A common error type for all the generators.
 #[derive(Fail, Debug)]
@@ -48,6 +48,7 @@ pub struct LibraryContext<'a>
 {
     pub itfs_by_ref: HashMap<String, &'a Interface>,
     pub itfs_by_name: HashMap<String, &'a Interface>,
+    pub structs_by_name: HashMap<String, &'a Struct>,
 }
 
 impl<'a> LibraryContext<'a>
@@ -78,9 +79,19 @@ impl<'a> LibraryContext<'a>
                 )
             })
             .collect();
+        let structs_by_name: HashMap<String, &Struct> = lib
+            .types
+            .iter()
+            .filter_map(|t| match t {
+                TypeInfo::Struct(stru) => Some(stru),
+                _ => None,
+            })
+            .map(|stru| (stru.name.to_string(), &**stru.as_ref()))
+            .collect();
         Ok(LibraryContext {
             itfs_by_name,
             itfs_by_ref,
+            structs_by_name,
         })
     }
 }

--- a/intercom-common/src/attributes/com_class.rs
+++ b/intercom-common/src/attributes/com_class.rs
@@ -21,7 +21,7 @@ pub fn expand_com_class(
 {
     // Parse the attribute.
     let mut output = vec![];
-    let cls = model::ComStruct::parse(&lib_name(), attr_tokens.into(), item_tokens.clone().into())?;
+    let cls = model::ComClass::parse(&lib_name(), attr_tokens.into(), item_tokens.clone().into())?;
     let struct_ident = &cls.name;
     let struct_name = struct_ident.to_string();
 
@@ -280,13 +280,13 @@ pub fn expand_com_class(
 
     output.push(
         create_get_typeinfo_function(&cls)
-            .map_err(|e| model::ParseError::ComStruct(cls.name.to_string(), e))?,
+            .map_err(|e| model::ParseError::ComClass(cls.name.to_string(), e))?,
     );
 
     Ok(tokens_to_tokenstream(item_tokens, output))
 }
 
-fn create_get_typeinfo_function(cls: &model::ComStruct) -> Result<TokenStream, String>
+fn create_get_typeinfo_function(cls: &model::ComClass) -> Result<TokenStream, String>
 {
     let fn_name = Ident::new(
         &format!("get_intercom_coclass_info_for_{}", cls.name),

--- a/intercom-common/src/attributes/com_interface.rs
+++ b/intercom-common/src/attributes/com_interface.rs
@@ -11,8 +11,6 @@ use crate::utils;
 
 use syn::spanned::Spanned;
 
-extern crate proc_macro;
-
 /// Interface level output.
 #[derive(Default)]
 struct InterfaceOutput

--- a/intercom-common/src/attributes/com_library.rs
+++ b/intercom-common/src/attributes/com_library.rs
@@ -151,13 +151,19 @@ fn create_get_typelib_function(lib: &model::ComLibrary) -> Result<TokenStream, S
             <#path as intercom::attributes::HasTypeInfo>::gather_type_info()
         )
     });
+    let create_struct_typeinfo = lib.structs.iter().map(|path| {
+        quote!(
+            <#path as intercom::attributes::StructHasTypeInfo>::gather_type_info()
+        )
+    });
     Ok(quote!(
         pub(crate) fn get_intercom_typelib() -> intercom::typelib::TypeLib
         {
             let types = vec![
                 <intercom::alloc::Allocator as intercom::attributes::HasTypeInfo>::gather_type_info(),
                 <intercom::error::ErrorStore as intercom::attributes::HasTypeInfo>::gather_type_info(),
-                #( #create_class_typeinfo ),*
+                #( #create_class_typeinfo, )*
+                #( #create_struct_typeinfo, )*
             ].into_iter().flatten().collect::<Vec<_>>();
             intercom::typelib::TypeLib::__new(
                 #lib_name.into(),

--- a/intercom-common/src/attributes/com_struct.rs
+++ b/intercom-common/src/attributes/com_struct.rs
@@ -1,0 +1,172 @@
+use super::common::*;
+use crate::model::{self, ComStruct};
+use crate::prelude::*;
+use crate::tyhandlers::ModelTypeSystem;
+use proc_macro2::TokenStream;
+use syn::{punctuated::Punctuated, spanned::Spanned, token::Comma, Field};
+
+pub fn expand_com_struct(
+    attr_tokens: TokenStreamNightly,
+    item_tokens: TokenStreamNightly,
+) -> Result<TokenStreamNightly, model::ParseError>
+{
+    let model = ComStruct::parse(&lib_name(), attr_tokens.into(), item_tokens.clone().into())?;
+
+    let mut output = vec![];
+    for ts in [ModelTypeSystem::Automation, ModelTypeSystem::Raw].into_iter() {
+        output.extend(generate_extern_struct(&model, *ts));
+
+        let struct_ident = &model.name;
+        let ts_tokens = ts.as_typesystem_type(struct_ident.span());
+        let extern_ident = Ident::new(&format!("{}_{:?}", model.name, ts), model.name.span());
+        output.push(quote!(
+            impl intercom::type_system::ExternType<#ts_tokens> for #struct_ident {
+                type ExternInputType = #extern_ident;
+                type ExternOutputType = #extern_ident;
+                type OwnedExternType = #struct_ident;
+                type OwnedNativeType = #struct_ident;
+            }
+        ));
+    }
+
+    // Create runtime type info.
+    output.push(
+        create_get_typeinfo_function(&model)
+            .map_err(|e| model::ParseError::ComStruct(model.name.to_string(), e))?,
+    );
+
+    Ok(tokens_to_tokenstream(item_tokens, output))
+}
+
+fn generate_extern_struct(s: &ComStruct, ts: ModelTypeSystem) -> Vec<TokenStream>
+{
+    let vis = &s.vis;
+    let original_ident = &s.name;
+    let ts_type = ts.as_typesystem_type(original_ident.span());
+    let extern_ident = Ident::new(&format!("{}_{:?}", s.name, ts), s.name.span());
+
+    let mut extern_fields = s.fields.clone();
+    match extern_fields {
+        syn::Fields::Named(ref mut fields) => change_types(&mut fields.named, ts),
+        syn::Fields::Unnamed(ref mut fields) => change_types(&mut fields.unnamed, ts),
+        _ => {}
+    }
+
+    let (field_to_native, field_to_extern) : ( Vec<_>, Vec<_> ) = match s.fields {
+        syn::Fields::Named(ref fields) => &fields.named,
+        syn::Fields::Unnamed(ref fields) => &fields.unnamed,
+        _ => panic!("Unit structs are not supported for [com_struct]"),
+    }
+    .iter()
+    .map(|field| {
+        let field_name = &field.ident;
+        let field_ty = &field.ty;
+        (
+            quote!( #field_name: <<#field_ty as intercom::type_system::ExternType<#ts_type>>::OwnedNativeType>::intercom_from(src.#field_name)?.intercom_into()? ),
+            quote!( #field_name: <<#field_ty as intercom::type_system::ExternType<#ts_type>>::OwnedExternType>::intercom_from(src.#field_name)?.intercom_into()? ),
+        )
+    })
+    .unzip();
+
+    vec![
+        quote!(
+        #[allow(non_camel_case_types)]
+        #vis struct #extern_ident #extern_fields
+        ),
+        quote!(impl intercom::type_system::IntercomFrom<#extern_ident> for
+            #original_ident {
+                unsafe fn intercom_from(src: #extern_ident) -> intercom::ComResult<Self> {
+                    use intercom::type_system::IntercomInto;
+                    Ok(Self {
+                        #( #field_to_native ),*
+                    })
+                }
+            }
+        ),
+        quote!(impl intercom::type_system::IntercomFrom<#original_ident> for
+            #extern_ident {
+                unsafe fn intercom_from(src: #original_ident) -> intercom::ComResult<Self> {
+                    use intercom::type_system::IntercomInto;
+                    Ok(Self {
+                        #( #field_to_extern ),*
+                    })
+                }
+            }
+        ),
+        quote!(impl intercom::type_system::BidirectionalTypeInfo for #extern_ident {
+            fn type_name() -> &'static str {
+                stringify!(#original_ident)
+            }
+        }),
+    ]
+}
+
+fn change_types(fields: &mut Punctuated<Field, Comma>, ts: ModelTypeSystem)
+{
+    for ref mut field in fields {
+        let ty = &field.ty;
+        let ts_type = ts.as_typesystem_type(ty.span());
+        field.ty = syn::parse2(
+            quote_spanned!(field.ty.span() => <#ty as intercom::type_system::ExternType<#ts_type>>::ExternOutputType),
+        ).unwrap();
+    }
+}
+
+fn create_get_typeinfo_function(model: &model::ComStruct) -> Result<TokenStream, String>
+{
+    let struct_name = model.name.to_string();
+    let mut variant_tokens = vec![];
+    for ts in [ModelTypeSystem::Automation, ModelTypeSystem::Raw].into_iter() {
+        variant_tokens.push(create_typeinfo_for_variant(model, *ts)?);
+    }
+
+    let struct_ident = &model.name;
+    Ok(quote_spanned!(struct_ident.span() =>
+        #[allow(non_snake_case)]
+        #[allow(dead_code)]
+        impl intercom::attributes::StructHasTypeInfo for #struct_ident
+        {
+            fn gather_type_info() -> Vec<intercom::typelib::TypeInfo>
+            {
+                let variants = vec![ #( #variant_tokens ),* ];
+
+                vec![ intercom::typelib::TypeInfo::Struct(
+                    intercom::ComBox::new( intercom::typelib::Struct {
+                        name: #struct_name.into(),
+                        variants: variants,
+                    })
+                ) ]
+            }
+        }
+    ))
+}
+
+fn create_typeinfo_for_variant(
+    model: &model::ComStruct,
+    ts: ModelTypeSystem,
+) -> Result<TokenStream, String>
+{
+    let ts_tokens = ts.as_typesystem_tokens(model.name.span());
+    let ts_type = ts.as_typesystem_type(model.name.span());
+    let fields = model.fields.iter().enumerate().map(|(i, f)| {
+        let field_name = f.ident.clone()
+            .map(|f| f.to_string())
+            .unwrap_or_else(|| format!("_{}", i));
+        let ty = &f.ty;
+        let ty = quote!( <#ty as intercom::type_system::ExternType<#ts_type>>::ExternOutputType);
+        quote_spanned!(f.ty.span() =>
+            intercom::typelib::Arg {
+                name: #field_name.into(),
+                ty: <#ty as intercom::type_system::OutputTypeInfo>::type_name().into(),
+                indirection_level: <#ty as intercom::type_system::OutputTypeInfo>::indirection_level(),
+                direction: intercom::typelib::Direction::In,
+            })
+    }).collect::<Vec<_>>();
+
+    Ok(quote_spanned!(model.name.span() =>
+        intercom::ComBox::new( intercom::typelib::StructVariant {
+            ts: #ts_tokens,
+            fields: vec![ #( #fields ),* ],
+        })
+    ))
+}

--- a/intercom-common/src/attributes/com_struct.rs
+++ b/intercom-common/src/attributes/com_struct.rs
@@ -13,7 +13,7 @@ pub fn expand_com_struct(
     let model = ComStruct::parse(&lib_name(), attr_tokens.into(), item_tokens.clone().into())?;
 
     let mut output = vec![];
-    for ts in [ModelTypeSystem::Automation, ModelTypeSystem::Raw].into_iter() {
+    for ts in [ModelTypeSystem::Automation, ModelTypeSystem::Raw].iter() {
         output.extend(generate_extern_struct(&model, *ts));
 
         let struct_ident = &model.name;
@@ -104,7 +104,7 @@ fn generate_extern_struct(s: &ComStruct, ts: ModelTypeSystem) -> Vec<TokenStream
 
 fn change_types(fields: &mut Punctuated<Field, Comma>, ts: ModelTypeSystem)
 {
-    for ref mut field in fields {
+    for field in fields.iter_mut() {
         let ty = &field.ty;
         let ts_type = ts.as_typesystem_type(ty.span());
         field.ty = syn::parse2(
@@ -117,7 +117,7 @@ fn create_get_typeinfo_function(model: &model::ComStruct) -> Result<TokenStream,
 {
     let struct_name = model.name.to_string();
     let mut variant_tokens = vec![];
-    for ts in [ModelTypeSystem::Automation, ModelTypeSystem::Raw].into_iter() {
+    for ts in [ModelTypeSystem::Automation, ModelTypeSystem::Raw].iter() {
         variant_tokens.push(create_typeinfo_for_variant(model, *ts)?);
     }
 

--- a/intercom-common/src/attributes/com_struct.rs
+++ b/intercom-common/src/attributes/com_struct.rs
@@ -71,6 +71,7 @@ fn generate_extern_struct(s: &ComStruct, ts: ModelTypeSystem) -> Vec<TokenStream
     vec![
         quote!(
         #[allow(non_camel_case_types)]
+        #[repr(C)]
         #vis struct #extern_ident #extern_fields
         ),
         quote!(impl intercom::type_system::IntercomFrom<#extern_ident> for

--- a/intercom-common/src/attributes/mod.rs
+++ b/intercom-common/src/attributes/mod.rs
@@ -12,6 +12,9 @@ pub use self::com_impl::expand_com_impl;
 mod com_library;
 pub use self::com_library::expand_com_library;
 
+mod com_struct;
+pub use self::com_struct::expand_com_struct;
+
 mod type_info;
 pub use self::type_info::expand_bidirectional_type_info;
 pub use self::type_info::expand_derive_extern_type;

--- a/intercom-common/src/model/comlibrary.rs
+++ b/intercom-common/src/model/comlibrary.rs
@@ -105,7 +105,7 @@ mod test
     {
         let lib = ComLibrary::parse(
             "library_name".into(),
-            quote!(libid = "12345678-1234-1234-1234-567890ABCDEF", Foo, Bar),
+            quote!(libid = "12345678-1234-1234-1234-567890ABCDEF", class Foo, class Bar),
         )
         .expect("com_library attribute parsing failed");
 
@@ -132,7 +132,7 @@ mod test
         // What the final GUID is isn't important, what _is_ important however
         // is that the final GUID will not change ever as long as the library
         // name stays the same.
-        let lib = ComLibrary::parse("another_library".into(), quote!(One, Two))
+        let lib = ComLibrary::parse("another_library".into(), quote!(class One, class Two))
             .expect("com_library attribute parsing failed");
 
         assert_eq!(lib.name, "another_library");

--- a/intercom-common/src/model/comlibrary.rs
+++ b/intercom-common/src/model/comlibrary.rs
@@ -32,6 +32,7 @@ impl syn::parse::Parse for LibraryType
 intercom_attribute!(
     ComLibraryAttr<ComLibraryAttrParam, LibraryType> {
         libid : LitStr,
+        on_load: Path,
     }
 );
 
@@ -43,6 +44,7 @@ pub struct ComLibrary
 {
     pub name: String,
     pub libid: GUID,
+    pub on_load: Option<Path>,
     pub coclasses: Vec<Path>,
     pub interfaces: Vec<Path>,
     pub structs: Vec<Path>,
@@ -75,6 +77,7 @@ impl ComLibrary
 
         Ok(ComLibrary {
             name: crate_name.to_owned(),
+            on_load: attr.on_load().map_err(ParseError::ComLibrary)?.cloned(),
             coclasses,
             interfaces,
             structs,

--- a/intercom-common/src/model/comstruct.rs
+++ b/intercom-common/src/model/comstruct.rs
@@ -1,0 +1,40 @@
+use super::*;
+use crate::prelude::*;
+
+use syn::{Fields, Ident, Visibility};
+
+/// Details of a struct marked with `#[com_class]` attribute.
+#[derive(Debug, PartialEq)]
+pub struct ComStruct
+{
+    pub name: Ident,
+    pub vis: Visibility,
+    pub fields: Fields,
+}
+
+impl ComStruct
+{
+    /// Creates ComStruct from AST elements.
+    pub fn parse(
+        _crate_name: &str,
+        _attr_params: TokenStream,
+        item: TokenStream,
+    ) -> ParseResult<ComStruct>
+    {
+        // Parse the inputs.
+        let item: ::syn::ItemStruct = ::syn::parse2(item)
+            .map_err(|_| ParseError::ComStruct("<Unknown>".into(), "Item syntax error".into()))?;
+
+        Ok(ComStruct {
+            name: item.ident.clone(),
+            vis: item.vis,
+            fields: item.fields,
+        })
+    }
+}
+
+#[cfg(test)]
+mod test
+{
+    use super::*;
+}

--- a/intercom-common/src/model/comstruct.rs
+++ b/intercom-common/src/model/comstruct.rs
@@ -32,9 +32,3 @@ impl ComStruct
         })
     }
 }
-
-#[cfg(test)]
-mod test
-{
-    use super::*;
-}

--- a/intercom-common/src/model/macros.rs
+++ b/intercom-common/src/model/macros.rs
@@ -120,7 +120,7 @@ macro_rules! intercom_attribute {
 
                 // Match the ident to the name and parse the correct enum alternative from the
                 // value.
-                Ok( match ident.to_string().as_ref() {
+                Ok( match ident.to_string().as_str() {
                     $(
                         stringify!( $name ) => $attr_param::$name( input.parse()? ),
                     )*

--- a/intercom-common/src/model/mod.rs
+++ b/intercom-common/src/model/mod.rs
@@ -17,6 +17,9 @@ pub enum ParseError
     #[fail(display = "Parsing [com_class] item {} failed: {}", _0, _1)]
     ComClass(String, String),
 
+    #[fail(display = "Parsing [com_struct] item {} failed: {}", _0, _1)]
+    ComStruct(String, String),
+
     #[fail(display = "Parsing [com_interface] item {} failed: {}", _0, _1)]
     ComInterface(String, String),
 
@@ -43,3 +46,5 @@ mod cominterface;
 pub use self::cominterface::*;
 mod comimpl;
 pub use self::comimpl::*;
+mod comstruct;
+pub use self::comstruct::*;

--- a/intercom-common/src/model/mod.rs
+++ b/intercom-common/src/model/mod.rs
@@ -15,7 +15,7 @@ pub enum ParseError
     ComLibrary(String),
 
     #[fail(display = "Parsing [com_class] item {} failed: {}", _0, _1)]
-    ComStruct(String, String),
+    ComClass(String, String),
 
     #[fail(display = "Parsing [com_interface] item {} failed: {}", _0, _1)]
     ComInterface(String, String),
@@ -37,8 +37,8 @@ mod macros;
 
 mod comlibrary;
 pub use self::comlibrary::*;
-mod comstruct;
-pub use self::comstruct::*;
+mod comclass;
+pub use self::comclass::*;
 mod cominterface;
 pub use self::cominterface::*;
 mod comimpl;

--- a/intercom-common/src/tyhandlers.rs
+++ b/intercom-common/src/tyhandlers.rs
@@ -134,13 +134,17 @@ impl TypeHandler
         let ts = self.context.type_system.as_typesystem_type(span);
         let ts_trait = quote_spanned!(
             span=> <#ty as intercom::type_system::ExternType< #ts > > );
+        let maybe_ref = match ty {
+            syn::Type::Reference(..) => quote!(&),
+            _ => quote!(),
+        };
 
         match dir {
             Direction::In => {
                 // Input arguments may use an intermediate type.
                 let intermediate = quote_spanned!(
                     span=> #ts_trait::OwnedNativeType::intercom_from( #ident )? );
-                quote_spanned!(span=> ( & #intermediate ).intercom_into()? )
+                quote_spanned!(span=> ( #maybe_ref #intermediate ).intercom_into()? )
             }
             Direction::Out | Direction::Retval => {
                 // Output arguments must not use an intermediate type
@@ -158,12 +162,16 @@ impl TypeHandler
         let ts = self.context.type_system.as_typesystem_type(span);
         let ts_trait = quote_spanned!(
             span=> <#ty as intercom::type_system::ExternType< #ts > > );
+        let maybe_ref = match ty {
+            syn::Type::Reference(..) => quote!(&),
+            _ => quote!(),
+        };
 
         match dir {
             Direction::In => {
                 let intermediate = quote_spanned!(
                     span=> #ts_trait::OwnedExternType::intercom_from( #ident )? );
-                quote_spanned!(span=> ( & #intermediate ).intercom_into()? )
+                quote_spanned!(span=> ( #maybe_ref #intermediate ).intercom_into()? )
             }
             Direction::Out | Direction::Retval => quote_spanned!(span=> #ident.intercom_into()? ),
         }

--- a/intercom-cpp/src/posix/dlwrapper.hpp
+++ b/intercom-cpp/src/posix/dlwrapper.hpp
@@ -85,6 +85,11 @@ public:
         m_handle = dlopen( m_file.c_str(), ( int ) m_flags );
         if( m_handle == nullptr )
             throw_if_failed();
+
+        // Invoke DllMain if one exists.
+        bool ( *dllMainFunc )( void*, uint32_t, void* );
+        if( try_load_function("DllMain", &dllMainFunc) )
+            (*dllMainFunc)(m_handle, 0, nullptr);
     }
 
     //! Decrements the reference count of the dynamic shared object.

--- a/intercom/src/attributes.rs
+++ b/intercom/src/attributes.rs
@@ -27,3 +27,8 @@ pub trait InterfaceHasTypeInfo
 {
     fn gather_type_info() -> Vec<crate::typelib::TypeInfo>;
 }
+
+pub trait StructHasTypeInfo
+{
+    fn gather_type_info() -> Vec<crate::typelib::TypeInfo>;
+}

--- a/intercom/src/lib.rs
+++ b/intercom/src/lib.rs
@@ -13,7 +13,7 @@
 //! use intercom::{com_library, com_class, com_interface, com_impl, ComResult};
 //!
 //! // Define COM classes to expose from this library.
-//! com_library!(Calculator);
+//! com_library!(class Calculator);
 //!
 //! // Define the COM class and the interfaces it implements.
 //! #[com_class(Calculator)]

--- a/intercom/src/lib.rs
+++ b/intercom/src/lib.rs
@@ -243,24 +243,6 @@ pub use crate::interfaces::IUnknown;
 pub use crate::interfaces::ISupportErrorInfo;
 // pub use crate::interfaces::__ISupportErrorInfo_AutomationVtbl as ISupportErrorInfoVtbl;
 
-// Do we need this? Would rather not export this through an extern crate
-// for another dll.
-//
-// com_library should have dllmain!() macro or similar that implements this
-// together with the COM registration.
-#[no_mangle]
-#[allow(non_camel_case_types)]
-#[deprecated]
-#[doc(hidden)]
-pub extern "stdcall" fn DllMain(
-    _dll_instance: *mut std::os::raw::c_void,
-    _reason: u32,
-    _reserved: *mut std::os::raw::c_void,
-) -> bool
-{
-    true
-}
-
 /// Basic COM result type.
 ///
 /// The `ComResult` maps the Rust concept of `Ok` and `Err` values to COM

--- a/intercom/src/strings.rs
+++ b/intercom/src/strings.rs
@@ -354,6 +354,7 @@ impl IntercomFrom<BString> for String
 {
     unsafe fn intercom_from(source: BString) -> Result<Self, ComError>
     {
+        log::trace!("String::intercom_from(BString)");
         source.to_string().map_err(|_| ComError::E_INVALIDARG)
     }
 }
@@ -362,6 +363,7 @@ impl IntercomFrom<CString> for String
 {
     unsafe fn intercom_from(source: CString) -> Result<Self, ComError>
     {
+        log::trace!("String::intercom_from(CString)");
         source.into_string().map_err(|_| ComError::E_INVALIDARG)
     }
 }
@@ -463,6 +465,7 @@ impl From<BString> for IntercomString
 {
     fn from(source: BString) -> Self
     {
+        log::trace!("");
         IntercomString::BString(source)
     }
 }
@@ -487,6 +490,7 @@ impl IntercomFrom<IntercomString> for BString
 {
     unsafe fn intercom_from(source: IntercomString) -> Result<Self, ComError>
     {
+        log::trace!("BString::intercom_from(IntercomString)");
         match source {
             IntercomString::BString(bstring) => bstring.intercom_into(),
             IntercomString::CString(cstring) => cstring.intercom_into(),
@@ -499,6 +503,7 @@ impl IntercomFrom<IntercomString> for CString
 {
     unsafe fn intercom_from(source: IntercomString) -> Result<Self, ComError>
     {
+        log::trace!("CString::intercom_from(IntercomString)");
         match source {
             IntercomString::BString(bstring) => bstring.intercom_into(),
             IntercomString::CString(cstring) => cstring.intercom_into(),
@@ -511,6 +516,7 @@ impl IntercomFrom<IntercomString> for String
 {
     unsafe fn intercom_from(source: IntercomString) -> Result<Self, ComError>
     {
+        log::trace!("String::intercom_from(IntercomString)");
         match source {
             IntercomString::BString(bstring) => bstring.intercom_into(),
             IntercomString::CString(cstring) => cstring.intercom_into(),
@@ -625,6 +631,7 @@ impl IntercomFrom<crate::raw::InBSTR> for String
 {
     unsafe fn intercom_from(source: crate::raw::InBSTR) -> ComResult<Self>
     {
+        log::trace!("String::intercom_from(InBSTR)");
         Ok(BStr::from_ptr(source.0)
             .to_string()
             .map_err(|_| ComError::E_INVALIDARG)?)
@@ -635,6 +642,7 @@ impl IntercomFrom<crate::raw::InBSTR> for BString
 {
     unsafe fn intercom_from(source: crate::raw::InBSTR) -> ComResult<Self>
     {
+        log::trace!("BString::intercom_from(InBSTR)");
         Ok(BStr::from_ptr(source.0).to_owned())
     }
 }
@@ -643,6 +651,7 @@ impl<'a> IntercomFrom<&'a crate::raw::InBSTR> for &'a BStr
 {
     unsafe fn intercom_from(source: &'a crate::raw::InBSTR) -> ComResult<Self>
     {
+        log::trace!("&BStr::intercom_from(&InBSTR)");
         Ok(BStr::from_ptr(source.0))
     }
 }
@@ -651,6 +660,7 @@ impl<'a> IntercomFrom<crate::raw::InBSTR> for &'a BStr
 {
     unsafe fn intercom_from(source: crate::raw::InBSTR) -> ComResult<Self>
     {
+        log::trace!("&BStr::intercom_from(InBSTR)");
         Ok(BStr::from_ptr(source.0))
     }
 }
@@ -659,6 +669,7 @@ impl IntercomFrom<crate::raw::InBSTR> for CString
 {
     unsafe fn intercom_from(source: crate::raw::InBSTR) -> ComResult<Self>
     {
+        log::trace!("CString::intercom_from(InBSTR)");
         CString::new(
             BStr::from_ptr(source.0)
                 .to_string()
@@ -674,6 +685,7 @@ where
 {
     default unsafe fn intercom_from(source: *mut TPtr) -> ComResult<Self>
     {
+        log::trace!("TTarget::intercom_from(*mut TPtr)");
         let bstring: ComResult<TTarget> = (source as *const TPtr).intercom_into();
 
         bstring
@@ -687,6 +699,7 @@ impl IntercomFrom<intercom::raw::OutBSTR> for BString
 {
     unsafe fn intercom_from(source: intercom::raw::OutBSTR) -> ComResult<Self>
     {
+        log::trace!("BString::intercom_from(OutBSTR)");
         Ok(BString::from_ptr(source.0))
     }
 }
@@ -695,9 +708,10 @@ impl IntercomFrom<intercom::raw::OutBSTR> for String
 {
     unsafe fn intercom_from(source: intercom::raw::OutBSTR) -> ComResult<Self>
     {
-        BString::from_ptr(source.0)
+        log::trace!("String::intercom_from(OutBSTR)");
+        BStr::from_ptr(source.0)
             .to_string()
-            .map_err(|_| ComError::E_INVALIDARG)
+            .map_err(|e| { log::error!("{:?}", e); ComError::E_INVALIDARG })
     }
 }
 
@@ -705,6 +719,7 @@ impl IntercomFrom<intercom::raw::OutBSTR> for CString
 {
     unsafe fn intercom_from(source: intercom::raw::OutBSTR) -> ComResult<Self>
     {
+        log::trace!("CString::intercom_from(OutBSTR)");
         CString::new(String::intercom_from(source)?).map_err(|_| ComError::E_INVALIDARG)
     }
 }
@@ -715,6 +730,7 @@ impl IntercomFrom<*const c_char> for String
 {
     unsafe fn intercom_from(source: *const c_char) -> ComResult<Self>
     {
+        log::trace!("String::intercom_from(*const char)");
         Ok(CStr::from_ptr(source)
             .to_str()
             .map_err(|_| ComError::E_INVALIDARG)?
@@ -749,6 +765,7 @@ impl IntercomFrom<*const c_char> for BString
 {
     unsafe fn intercom_from(source: *const c_char) -> ComResult<Self>
     {
+        log::trace!("BString::intercom_from(*const char)");
         Ok(BString::from(
             CStr::from_ptr(source)
                 .to_str()
@@ -777,6 +794,7 @@ impl<'a> IntercomFrom<*const c_char> for CString
 {
     unsafe fn intercom_from(source: *const c_char) -> ComResult<Self>
     {
+        log::trace!("CString::intercom_from(*const char)");
         Ok(CStr::from_ptr(source).into())
     }
 }
@@ -789,6 +807,7 @@ impl IntercomFrom<*mut c_char> for CString
 {
     unsafe fn intercom_from(source: *mut c_char) -> ComResult<CString>
     {
+        log::trace!("CString::intercom_from(*mut char)");
         Ok(CString::from_raw(source))
     }
 }
@@ -797,6 +816,7 @@ impl<'a> IntercomFrom<*const c_char> for &'a CStr
 {
     unsafe fn intercom_from(source: *const c_char) -> ComResult<Self>
     {
+        log::trace!("&CStr::intercom_from(*const char)");
         Ok(CStr::from_ptr(source))
     }
 }
@@ -805,6 +825,7 @@ impl<'a> IntercomFrom<&*const c_char> for &'a CStr
 {
     unsafe fn intercom_from(source: &*const c_char) -> ComResult<Self>
     {
+        log::trace!("&CStr::intercom_from(&*const char)");
         Ok(CStr::from_ptr(*source))
     }
 }
@@ -815,6 +836,7 @@ impl IntercomFrom<&BStr> for crate::raw::InBSTR
 {
     unsafe fn intercom_from(source: &BStr) -> ComResult<Self>
     {
+        log::trace!("InBSTR::intercom_from(&BStr)");
         Ok(crate::raw::InBSTR(source.as_ptr()))
     }
 }
@@ -823,6 +845,7 @@ impl IntercomFrom<&BString> for crate::raw::InBSTR
 {
     unsafe fn intercom_from(source: &BString) -> ComResult<Self>
     {
+        log::trace!("InBSTR::intercom_from(&BString)");
         Ok(crate::raw::InBSTR(source.as_ptr()))
     }
 }
@@ -831,6 +854,7 @@ impl IntercomFrom<BString> for crate::raw::OutBSTR
 {
     unsafe fn intercom_from(source: BString) -> ComResult<Self>
     {
+        log::trace!("OutBSTR::intercom_from(BString)");
         Ok(crate::raw::OutBSTR(source.into_ptr()))
     }
 }
@@ -839,6 +863,7 @@ impl IntercomFrom<BString> for crate::raw::InBSTR
 {
     unsafe fn intercom_from(source: BString) -> ComResult<Self>
     {
+        log::trace!("InBSTR::intercom_from(BString)");
         Ok(crate::raw::InBSTR(source.into_ptr()))
     }
 }
@@ -847,6 +872,7 @@ impl IntercomFrom<CString> for crate::raw::OutBSTR
 {
     unsafe fn intercom_from(source: CString) -> ComResult<Self>
     {
+        log::trace!("OutBSTR::intercom_from(CString)");
         let bstr: BString = source.intercom_into()?;
         Ok(crate::raw::OutBSTR(bstr.into_ptr()))
     }
@@ -858,6 +884,7 @@ impl IntercomFrom<&CStr> for *const c_char
 {
     unsafe fn intercom_from(source: &CStr) -> ComResult<Self>
     {
+        log::trace!("*const char::intercom_from(&CStr)");
         Ok(source.as_ptr())
     }
 }
@@ -866,6 +893,7 @@ impl IntercomFrom<&CString> for *const c_char
 {
     unsafe fn intercom_from(source: &CString) -> ComResult<Self>
     {
+        log::trace!("*const char::intercom_from(&CString)");
         Ok(source.as_ptr())
     }
 }
@@ -875,6 +903,7 @@ impl IntercomFrom<CString> for *const c_char
     unsafe fn intercom_from(source: CString) -> ComResult<Self>
     {
         // FIXME: These should be allocated with the intercom allocator.
+        log::trace!("*const char::intercom_from(CString)");
         let ptr = source.as_ptr();
         std::mem::forget(source);
         Ok(ptr as _)
@@ -886,6 +915,7 @@ impl IntercomFrom<CString> for *mut c_char
     unsafe fn intercom_from(source: CString) -> ComResult<Self>
     {
         // FIXME: These should be allocated with the intercom allocator.
+        log::trace!("*mut char::intercom_from(CString)");
         let ptr = source.as_ptr();
         std::mem::forget(source);
         Ok(ptr as _)
@@ -896,6 +926,7 @@ impl IntercomFrom<BString> for *mut c_char
 {
     unsafe fn intercom_from(source: BString) -> ComResult<Self>
     {
+        log::trace!("*mut char::intercom_from(BString)");
         let cstring: CString = source.intercom_into()?;
         cstring.intercom_into()
     }
@@ -907,6 +938,7 @@ impl IntercomFrom<String> for CString
 {
     unsafe fn intercom_from(source: String) -> ComResult<Self>
     {
+        log::trace!("CString::intercom_from(String)");
         CString::new(source).map_err(|_| ComError::E_INVALIDARG)
     }
 }
@@ -915,6 +947,7 @@ impl IntercomFrom<&str> for CString
 {
     unsafe fn intercom_from(source: &str) -> ComResult<Self>
     {
+        log::trace!("CString::intercom_from(&str)");
         CString::new(source).map_err(|_| ComError::E_INVALIDARG)
     }
 }
@@ -923,6 +956,7 @@ impl IntercomFrom<String> for BString
 {
     unsafe fn intercom_from(source: String) -> ComResult<Self>
     {
+        log::trace!("BString::intercom_from(String)");
         Ok(BString::from(source.as_ref()))
     }
 }
@@ -931,6 +965,7 @@ impl<'a> IntercomFrom<&'a str> for BString
 {
     unsafe fn intercom_from(source: &str) -> ComResult<Self>
     {
+        log::trace!("BString::intercom_from(&str)");
         Ok(BString::from(source))
     }
 }
@@ -941,6 +976,7 @@ impl IntercomFrom<CString> for BString
 {
     unsafe fn intercom_from(source: CString) -> ComResult<Self>
     {
+        log::trace!("BString::intercom_from(CString)");
         Ok(BString::from(
             source
                 .to_str()
@@ -954,6 +990,7 @@ impl<'a> IntercomFrom<&'a CString> for &'a CStr
 {
     unsafe fn intercom_from(source: &'a CString) -> ComResult<Self>
     {
+        log::trace!("&CStr::intercom_from(&CString)");
         Ok(source.as_ref())
     }
 }
@@ -964,6 +1001,7 @@ impl IntercomFrom<BString> for CString
 {
     unsafe fn intercom_from(source: BString) -> ComResult<Self>
     {
+        log::trace!("CString::intercom_from(BString)");
         CString::new(source.to_string().map_err(|_| ComError::E_INVALIDARG)?)
             .map_err(|_| ComError::E_INVALIDARG)
     }
@@ -973,6 +1011,7 @@ impl<'a> IntercomFrom<&'a BString> for &'a BStr
 {
     unsafe fn intercom_from(source: &'a BString) -> ComResult<Self>
     {
+        log::trace!("&BStr::intercom_from(BString)");
         Ok(source.as_ref())
     }
 }
@@ -981,6 +1020,7 @@ impl IntercomFrom<&BStr> for CString
 {
     unsafe fn intercom_from(source: &BStr) -> ComResult<Self>
     {
+        log::trace!("CString::intercom_from(&BStr)");
         CString::new(source.to_string().map_err(|_| ComError::E_INVALIDARG)?)
             .map_err(|_| ComError::E_INVALIDARG)
     }
@@ -990,6 +1030,7 @@ impl IntercomFrom<&CStr> for BString
 {
     unsafe fn intercom_from(source: &CStr) -> ComResult<Self>
     {
+        log::trace!("BString::intercom_from(&CStr)");
         Ok(BString::from(
             source
                 .to_str()
@@ -1003,6 +1044,7 @@ impl<'a> IntercomFrom<&'a String> for &'a str
 {
     unsafe fn intercom_from(source: &'a String) -> ComResult<Self>
     {
+        log::trace!("&str::intercom_from(&String)");
         Ok(source.as_ref())
     }
 }
@@ -1011,6 +1053,7 @@ impl IntercomFrom<String> for *mut c_char
 {
     unsafe fn intercom_from(source: String) -> ComResult<Self>
     {
+        log::trace!("*mut char::intercom_from(String)");
         let bytes = source.as_bytes();
 
         // We just allocated the memory. This is safe.
@@ -1026,6 +1069,7 @@ impl IntercomFrom<String> for intercom::raw::OutBSTR
 {
     unsafe fn intercom_from(source: String) -> ComResult<Self>
     {
+        log::trace!("OutBSTR::intercom_from(String)");
         Ok(intercom::raw::OutBSTR(BString::from(source).into_ptr()))
     }
 }

--- a/test/cpp-raw/CMakeLists.txt
+++ b/test/cpp-raw/CMakeLists.txt
@@ -22,6 +22,7 @@ ${PROJECT_SOURCE_DIR}/stateful.cpp
 ${PROJECT_SOURCE_DIR}/strings.cpp
 ${PROJECT_SOURCE_DIR}/type_system_callbacks.cpp
 ${PROJECT_SOURCE_DIR}/variant.cpp
+${PROJECT_SOURCE_DIR}/structs.cpp
 )
 
 include_directories("${PROJECT_BINARY_DIR}")

--- a/test/cpp-raw/structs.cpp
+++ b/test/cpp-raw/structs.cpp
@@ -1,0 +1,211 @@
+
+#include <string>
+using std::char_traits;
+
+#include "../cpp-utility/os.hpp"
+#include "../cpp-utility/catch.hpp"
+
+#include "testlib.hpp"
+
+namespace {
+
+    intercom::BSTR AllocBstr(
+        IAllocator_Automation* pAllocator,
+        const char16_t* str
+    )
+    {
+        return pAllocator->AllocBstr(
+            const_cast<uint16_t*>(
+                reinterpret_cast<const uint16_t*>(str)),
+            static_cast<uint32_t>(
+                char_traits<char16_t>::length(str)));
+    }
+
+    void check_equal(const char16_t* text, intercom::BSTR right)
+    {
+        const size_t len_size_t = text == nullptr ? 0 : char_traits<char16_t>::length(text);
+        const uint32_t len = static_cast<uint32_t>(len_size_t);
+
+        if (len == 0) {
+            REQUIRE(right == nullptr);
+            return;
+        }
+
+        if (len != 0)
+            REQUIRE(right != nullptr);
+
+        uint32_t right_len = 0;
+        std::memcpy(
+            reinterpret_cast<char*>(&right_len),
+            reinterpret_cast<char*>(right) - 4,
+            4);
+
+        REQUIRE(len * 2 == right_len);
+
+        uint16_t right_termination = 0xffff;
+        std::memcpy(
+            reinterpret_cast<char*>(&right_termination),
+            reinterpret_cast<char*>(right) + right_len,
+            2);
+
+        REQUIRE(right_termination == 0);
+
+        for (uint32_t i = 0; i < len; i++) {
+            REQUIRE(text[i] == right[i]);
+        }
+    }
+
+}
+
+TEST_CASE( "Struct" ) {
+
+    // Initialize COM.
+    InitializeRuntime();
+
+    IStructParameterTests_Automation* pTests = nullptr;
+    intercom::HRESULT hr = CreateInstance(
+        CLSID_StructParameterTests,
+        IID_IStructParameterTests_Automation,
+        &pTests );
+    REQUIRE( hr == intercom::SC_OK );
+
+    SECTION( "Output" )
+    {
+        SECTION( "Basic struct" )
+        {
+            BasicStruct_Automation bsa;
+            REQUIRE( pTests->GetBasicStruct(1, 2, 3, &bsa) == intercom::SC_OK );
+            REQUIRE( bsa.a == 1 );
+            REQUIRE( bsa.b == 2 );
+            REQUIRE( bsa.c == 3 );
+        }
+
+        SECTION( "BString struct" )
+        {
+            // Construct allocator.
+            IAllocator_Automation* pAllocator = nullptr;
+            hr = CreateInstance(
+                CLSID_Allocator,
+                IID_IAllocator_Automation,
+                &pAllocator );
+            REQUIRE( hr == intercom::SC_OK );
+
+            StringStruct_Automation ssa;
+            BSTR a = AllocBstr(pAllocator, u"foo");
+            BSTR b = AllocBstr(pAllocator, u"bar");
+
+            REQUIRE( pTests->GetStringStruct(a, b, &ssa ) == intercom::SC_OK );
+
+            check_equal(u"foo", ssa.a);
+            check_equal(u"bar", ssa.b);
+
+            pAllocator->FreeBstr( a );
+            pAllocator->FreeBstr( b );
+            pAllocator->FreeBstr( ssa.a );
+            pAllocator->FreeBstr( ssa.b );
+            pAllocator->Release();
+        }
+
+        SECTION( "CString struct" )
+        {
+            // Construct allocator.
+            IAllocator_Raw* pAllocator = nullptr;
+            hr = CreateInstance(
+                CLSID_Allocator,
+                IID_IAllocator_Raw,
+                &pAllocator );
+            REQUIRE( hr == intercom::SC_OK );
+
+            IStructParameterTests_Raw* pTests_raw;
+            REQUIRE(pTests->QueryInterface(IID_IStructParameterTests_Raw, reinterpret_cast<void**>( &pTests_raw ) ) == intercom::SC_OK);
+
+            StringStruct_Raw ssa;
+            REQUIRE( pTests_raw->GetStringStruct("foo", "bar", &ssa ) == intercom::SC_OK );
+
+            REQUIRE( strcmp( ssa.a, "foo" ) == 0 );
+            REQUIRE( strcmp( ssa.b, "bar" ) == 0 );
+
+            pAllocator->Free( ssa.a );
+            pAllocator->Free( ssa.b );
+        }
+
+        SECTION( "Complex struct" )
+        {
+            Rectangle_Automation rect;
+
+            REQUIRE( pTests->GetComplexStruct(1.0, 100.0, 123.456, 789.123, &rect ) == intercom::SC_OK );
+
+            REQUIRE(rect.top_left.x == 1.0);
+            REQUIRE(rect.top_left.y == 100.0);
+            REQUIRE(rect.bottom_right.x == 123.456);
+            REQUIRE(rect.bottom_right.y == 789.123);
+        }
+    }
+
+    SECTION( "Input" )
+    {
+        SECTION( "Basic struct" )
+        {
+            BasicStruct_Automation bsa;
+            bsa.a = 123;
+            bsa.b = 2345;
+            bsa.c = 34567;
+            REQUIRE( pTests->VerifyBasicStruct(bsa, 123, 2345, 34567) == intercom::SC_OK );
+        }
+
+        SECTION( "BString struct" )
+        {
+            // Construct allocator.
+            IAllocator_Automation* pAllocator = nullptr;
+            hr = CreateInstance(
+                CLSID_Allocator,
+                IID_IAllocator_Automation,
+                &pAllocator );
+            REQUIRE( hr == intercom::SC_OK );
+
+            BSTR a = AllocBstr(pAllocator, u"foo");
+            BSTR b = AllocBstr(pAllocator, u"bar");
+
+            StringStruct_Automation ssa;
+            ssa.a = a;
+            ssa.b = b;
+
+            REQUIRE( pTests->VerifyStringStruct(ssa, a, b) == intercom::SC_OK );
+
+            pAllocator->FreeBstr( a );
+            pAllocator->FreeBstr( b );
+            pAllocator->Release();
+        }
+
+        SECTION( "CString struct" )
+        {
+            // Construct allocator.
+            IAllocator_Raw* pAllocator = nullptr;
+            hr = CreateInstance(
+                CLSID_Allocator,
+                IID_IAllocator_Raw,
+                &pAllocator );
+            REQUIRE( hr == intercom::SC_OK );
+
+            IStructParameterTests_Raw* pTests_raw;
+            REQUIRE(pTests->QueryInterface(IID_IStructParameterTests_Raw, reinterpret_cast<void**>( &pTests_raw ) ) == intercom::SC_OK);
+
+            StringStruct_Raw ssa;
+            ssa.a = "foo";
+            ssa.b = "bar";
+
+            REQUIRE( pTests_raw->VerifyStringStruct(ssa, "foo", "bar") == intercom::SC_OK );
+        }
+
+        SECTION( "Complex struct" )
+        {
+            Rectangle_Automation rect;
+            rect.top_left.x = 1.0;
+            rect.top_left.y = 100.0;
+            rect.bottom_right.x = 123.456;
+            rect.bottom_right.y = 789.123;
+
+            REQUIRE( pTests->VerifyComplexStruct(rect, 1.0, 100.0, 123.456, 789.123) == intercom::SC_OK );
+        }
+    }
+}

--- a/test/cpp-raw/structs.cpp
+++ b/test/cpp-raw/structs.cpp
@@ -91,8 +91,8 @@ TEST_CASE( "Struct" ) {
             REQUIRE( hr == intercom::SC_OK );
 
             StringStruct_Automation ssa;
-            BSTR a = AllocBstr(pAllocator, u"foo");
-            BSTR b = AllocBstr(pAllocator, u"bar");
+            intercom::BSTR a = AllocBstr(pAllocator, u"foo");
+            intercom::BSTR b = AllocBstr(pAllocator, u"bar");
 
             REQUIRE( pTests->GetStringStruct(a, b, &ssa ) == intercom::SC_OK );
 
@@ -120,13 +120,18 @@ TEST_CASE( "Struct" ) {
             REQUIRE(pTests->QueryInterface(IID_IStructParameterTests_Raw, reinterpret_cast<void**>( &pTests_raw ) ) == intercom::SC_OK);
 
             StringStruct_Raw ssa;
-            REQUIRE( pTests_raw->GetStringStruct("foo", "bar", &ssa ) == intercom::SC_OK );
+            REQUIRE( pTests_raw->GetStringStruct(
+                    const_cast<char*>("foo"),
+                    const_cast<char*>("bar"),
+                    &ssa ) == intercom::SC_OK );
 
             REQUIRE( strcmp( ssa.a, "foo" ) == 0 );
             REQUIRE( strcmp( ssa.b, "bar" ) == 0 );
 
             pAllocator->Free( ssa.a );
             pAllocator->Free( ssa.b );
+            pAllocator->Release();
+            pTests_raw->Release();
         }
 
         SECTION( "Complex struct" )
@@ -163,8 +168,8 @@ TEST_CASE( "Struct" ) {
                 &pAllocator );
             REQUIRE( hr == intercom::SC_OK );
 
-            BSTR a = AllocBstr(pAllocator, u"foo");
-            BSTR b = AllocBstr(pAllocator, u"bar");
+            intercom::BSTR a = AllocBstr(pAllocator, u"foo");
+            intercom::BSTR b = AllocBstr(pAllocator, u"bar");
 
             StringStruct_Automation ssa;
             ssa.a = a;
@@ -191,10 +196,16 @@ TEST_CASE( "Struct" ) {
             REQUIRE(pTests->QueryInterface(IID_IStructParameterTests_Raw, reinterpret_cast<void**>( &pTests_raw ) ) == intercom::SC_OK);
 
             StringStruct_Raw ssa;
-            ssa.a = "foo";
-            ssa.b = "bar";
+            ssa.a = const_cast<char*>("foo");
+            ssa.b = const_cast<char*>("bar");
 
-            REQUIRE( pTests_raw->VerifyStringStruct(ssa, "foo", "bar") == intercom::SC_OK );
+            REQUIRE( pTests_raw->VerifyStringStruct(ssa,
+                        const_cast<char*>("foo"),
+                        const_cast<char*>("bar"))
+                    == intercom::SC_OK );
+
+            pAllocator->Release();
+            pTests_raw->Release();
         }
 
         SECTION( "Complex struct" )
@@ -208,4 +219,6 @@ TEST_CASE( "Struct" ) {
             REQUIRE( pTests->VerifyComplexStruct(rect, 1.0, 100.0, 123.456, 789.123) == intercom::SC_OK );
         }
     }
+
+    pTests->Release();
 }

--- a/test/multilib/src/lib.rs
+++ b/test/multilib/src/lib.rs
@@ -1,4 +1,4 @@
-#![crate_type="dylib"]
+#![crate_type = "dylib"]
 #![feature(type_ascription)]
 
 extern crate intercom;
@@ -6,32 +6,37 @@ use intercom::*;
 extern crate winapi;
 
 // Declare available COM classes.
-com_library!( HelloWorld );
+com_library!( class HelloWorld );
 
 #[com_interface]
 trait IHelloWorld
 {
-    fn get_hello( &self ) -> String;
+    fn get_hello(&self) -> String;
 }
 
-#[com_class( clsid = "{25ccb3f6-b782-4b2d-933e-54ab447da0aa}", IHelloWorld )]
-pub struct HelloWorld { }
+#[com_class(clsid = "{25ccb3f6-b782-4b2d-933e-54ab447da0aa}", IHelloWorld)]
+pub struct HelloWorld {}
 
 impl HelloWorld
 {
-    pub fn new() -> HelloWorld {
-        HelloWorld { }
+    pub fn new() -> HelloWorld
+    {
+        HelloWorld {}
     }
 }
 
 #[com_impl]
-impl IHelloWorld for HelloWorld {
-    fn get_hello( &self ) -> String { "Hello World!".to_string() }
+impl IHelloWorld for HelloWorld
+{
+    fn get_hello(&self) -> String
+    {
+        "Hello World!".to_string()
+    }
 }
 
 #[test]
 fn hello_world_returns_hello_world()
 {
     let hello = HelloWorld::new();
-    assert_eq!( hello.get_hello(), "Hello World!" );
+    assert_eq!(hello.get_hello(), "Hello World!");
 }

--- a/test/testlib/Cargo.toml
+++ b/test/testlib/Cargo.toml
@@ -10,3 +10,4 @@ crate-type = [ "cdylib" ]
 intercom = { path = "../../intercom" }
 winapi = "0.2.8"
 chrono = "0.4"
+env_logger = "0.7"

--- a/test/testlib/src/lib.rs
+++ b/test/testlib/src/lib.rs
@@ -1,38 +1,44 @@
-#![crate_type="dylib"]
+#![crate_type = "dylib"]
 #![feature(type_ascription, specialization)]
-
 
 extern crate intercom;
 use intercom::*;
-extern crate winapi;
 extern crate chrono;
+extern crate winapi;
 
+pub mod alloc;
+pub mod error_info;
+pub mod interface_params;
 pub mod primitive;
+pub mod result;
 pub mod return_interfaces;
 pub mod stateful;
-pub mod result;
-pub mod interface_params;
-pub mod error_info;
-pub mod alloc;
 pub mod strings;
+pub mod struct_parameters;
 pub mod type_system_callbacks;
-pub mod variant;
 pub mod unicode;
+pub mod variant;
 
 // Declare available COM classes.
 com_library!(
-    primitive::PrimitiveOperations,
-    return_interfaces::RefCountOperations,
-    return_interfaces::ClassCreator,
-    return_interfaces::CreatedClass,
-    stateful::StatefulOperations,
-    result::ResultOperations,
-    interface_params::SharedImplementation,
-    error_info::ErrorTests,
-    alloc::AllocTests,
-    strings::StringTests,
-    type_system_callbacks::TypeSystemCaller,
-    variant::VariantTests,
-    variant::VariantImpl,
-    unicode::UnicodeConversion,
+    class primitive::PrimitiveOperations,
+    class return_interfaces::RefCountOperations,
+    class return_interfaces::ClassCreator,
+    class return_interfaces::CreatedClass,
+    class stateful::StatefulOperations,
+    class result::ResultOperations,
+    class interface_params::SharedImplementation,
+    class error_info::ErrorTests,
+    class alloc::AllocTests,
+    class strings::StringTests,
+    class type_system_callbacks::TypeSystemCaller,
+    class variant::VariantTests,
+    class variant::VariantImpl,
+    class unicode::UnicodeConversion,
+
+    class struct_parameters::StructParameterTests,
+    user_type struct_parameters::BasicStruct,
+    user_type struct_parameters::StringStruct,
+    user_type struct_parameters::Rectangle,
+    user_type struct_parameters::Point,
 );

--- a/test/testlib/src/lib.rs
+++ b/test/testlib/src/lib.rs
@@ -21,6 +21,8 @@ pub mod variant;
 
 // Declare available COM classes.
 com_library!(
+    on_load = on_load,
+
     class primitive::PrimitiveOperations,
     class return_interfaces::RefCountOperations,
     class return_interfaces::ClassCreator,
@@ -42,3 +44,14 @@ com_library!(
     user_type struct_parameters::Rectangle,
     user_type struct_parameters::Point,
 );
+
+fn on_load() {
+    env_logger::builder()
+        .format(|buf, record| {
+            let file = record.file().unwrap_or("<unknown>");
+            let line = record.line().unwrap_or(0);
+            use std::io::Write;
+            writeln!(buf, "{} - {}:{}: {}", record.level(), file, line, record.args())
+        })
+        .init();
+}

--- a/test/testlib/src/struct_parameters.rs
+++ b/test/testlib/src/struct_parameters.rs
@@ -1,0 +1,116 @@
+use intercom::*;
+
+#[com_struct]
+pub struct BasicStruct
+{
+    a: u32,
+    b: u32,
+    c: u32,
+}
+
+#[com_struct]
+pub struct StringStruct
+{
+    a: String,
+    b: String,
+}
+
+#[com_struct]
+pub struct Rectangle
+{
+    top_left: Point,
+    bottom_right: Point,
+}
+
+#[com_struct]
+pub struct Point
+{
+    x: f64,
+    y: f64,
+}
+
+#[com_class(StructParameterTests)]
+pub struct StructParameterTests;
+impl StructParameterTests
+{
+    pub fn new() -> StructParameterTests
+    {
+        StructParameterTests
+    }
+}
+
+#[com_impl]
+#[com_interface]
+impl StructParameterTests
+{
+    fn get_basic_struct(&self, a: u32, b: u32, c: u32) -> ComResult<BasicStruct>
+    {
+        Ok(BasicStruct { a, b, c })
+    }
+
+    fn get_string_struct(&self, a: &str, b: &str) -> ComResult<StringStruct>
+    {
+        Ok(StringStruct {
+            a: a.to_string(),
+            b: b.to_string(),
+        })
+    }
+
+    fn get_complex_struct(&self, x1: f64, y1: f64, x2: f64, y2: f64) -> ComResult<Rectangle>
+    {
+        Ok(Rectangle {
+            top_left: Point { x: x1, y: y1 },
+            bottom_right: Point { x: x2, y: y2 },
+        })
+    }
+
+    fn verify_basic_struct(&self, data: BasicStruct, a: u32, b: u32, c: u32) -> ComResult<()>
+    {
+        if data.a != a {
+            return Err(intercom::ComError::E_INVALIDARG);
+        }
+        if data.b != b {
+            return Err(intercom::ComError::E_INVALIDARG);
+        }
+        if data.c != c {
+            return Err(intercom::ComError::E_INVALIDARG);
+        }
+        Ok(())
+    }
+
+    fn verify_string_struct(&self, data: StringStruct, a: &str, b: &str) -> ComResult<()>
+    {
+        if data.a != a {
+            return Err(intercom::ComError::E_INVALIDARG);
+        }
+        if data.b != b {
+            return Err(intercom::ComError::E_INVALIDARG);
+        }
+        Ok(())
+    }
+
+    fn verify_complex_struct(
+        &self,
+        data: Rectangle,
+        x1: f64,
+        y1: f64,
+        x2: f64,
+        y2: f64,
+    ) -> ComResult<()>
+    {
+        if data.top_left.x != x1 {
+            return Err(intercom::ComError::E_INVALIDARG);
+        }
+        if data.top_left.y != y1 {
+            return Err(intercom::ComError::E_INVALIDARG);
+        }
+        if data.bottom_right.x != x2 {
+            return Err(intercom::ComError::E_INVALIDARG);
+        }
+        if data.bottom_right.y != y2 {
+            return Err(intercom::ComError::E_INVALIDARG);
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This is support for generating COM compatible plain struct types from Rust structs. We generate one struct for each type system (we could have gone with one generic struct, but being generic over `TS: TypeSystem` is difficult since that's an open set and we are implementing our `IntercomFrom` traits only for `AutomationTypeSystem` and `RawTypeSystem` (Rust doesn't realize that those are the only type systems anyway).

There was a draft implementation for also input and output structs, but that became unmanageable. I have a feeling we'll get rid of the direction and our `ExternType` gets reduced to `type ExternType` insted of the seperate `ExternInputType` and `ExternOutputType`. This should also drop the need for Input/Output type info and simplify many things.

There might be a pile of memory leaks currently as I simplified the string handling and removed one `free(..)` from the `*mut` blanket `IntercomFrom` implementation. This was the wrong place to do that anyway. I think we'll need to recognize input/output pointers differently and probably require `CleanUp` implementation in `ExternType` that gets invoked when the types should be cleaned up. This should happen for the temporaries we've created when calling COM APIs and any incoming memory that we receive that we've turned into a Rust-type of some kind.