### PR TITLE
Split ExternType into ExternInput + ExternOutput

### DIFF
--- a/intercom-attributes/src/lib.rs
+++ b/intercom-attributes/src/lib.rs
@@ -139,11 +139,21 @@ pub fn named_type_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStr
     }
 }
 
-/// Derives the implementation of the trait ExternType for a type.
-#[proc_macro_derive(ExternType)]
-pub fn derive_extern_type(input: proc_macro::TokenStream) -> proc_macro::TokenStream
+/// Derives the implementation of the trait ExternParameter for a type.
+#[proc_macro_derive(ExternParameter)]
+pub fn derive_extern_parameter(input: proc_macro::TokenStream) -> proc_macro::TokenStream
 {
-    match expand_derive_extern_type(input) {
+    match expand_derive_extern_parameter(input) {
+        Ok(t) => t,
+        Err(e) => panic!("{}", e),
+    }
+}
+
+/// Derives the implementation of the trait ExternOutput for a type.
+#[proc_macro_derive(ExternOutput)]
+pub fn derive_extern_output(input: proc_macro::TokenStream) -> proc_macro::TokenStream
+{
+    match expand_derive_extern_output(input) {
         Ok(t) => t,
         Err(e) => panic!("{}", e),
     }

--- a/intercom-attributes/src/lib.rs
+++ b/intercom-attributes/src/lib.rs
@@ -139,8 +139,8 @@ pub fn named_type_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStr
     }
 }
 
-/// Derives the implementation of the trait ExternParameter for a type.
-#[proc_macro_derive(ExternParameter)]
+/// Derives the implementation of the trait ExternInput for a type.
+#[proc_macro_derive(ExternInput)]
 pub fn derive_extern_parameter(input: proc_macro::TokenStream) -> proc_macro::TokenStream
 {
     match expand_derive_extern_parameter(input) {

--- a/intercom-attributes/src/lib.rs
+++ b/intercom-attributes/src/lib.rs
@@ -129,8 +129,8 @@ pub fn com_library(args: TokenStream) -> TokenStream
     }
 }
 
-/// Derives the implementation of the trait BidirectionalTypeInfo for a type.
-#[proc_macro_derive(BidirectionalTypeInfo)]
+/// Derives the implementation of the trait ForeignType for a type.
+#[proc_macro_derive(ForeignType)]
 pub fn named_type_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream
 {
     match expand_bidirectional_type_info(input) {

--- a/intercom-attributes/tests/data/macro/com_impl.rs.stdout
+++ b/intercom-attributes/tests/data/macro/com_impl.rs.stdout
@@ -750,15 +750,15 @@ impl Foo {
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_Automation_query_interface(
     self_vtable: intercom::RawComPtr,
-    riid: <intercom::REFIID as intercom::type_system::ExternType<
+    riid: <intercom::REFIID as intercom::type_system::ExternInput<
         intercom::type_system::AutomationTypeSystem,
-    >>::ExternInputType,
-    out: *mut <intercom::RawComPtr as intercom::type_system::ExternType<
+    >>::ForeignType,
+    out: *mut <intercom::RawComPtr as intercom::type_system::ExternOutput<
         intercom::type_system::AutomationTypeSystem,
-    >>::ExternOutputType,
-) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
+    >>::ForeignType,
+) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
     intercom::type_system::AutomationTypeSystem,
->>::ExternOutputType {
+>>::ForeignType {
     let self_ptr = (self_vtable as usize
         - <Foo as intercom::attributes::ComClass<
             Foo,
@@ -788,7 +788,7 @@ unsafe extern "system" fn __Foo_Foo_Automation_add_ref(self_vtable:
                                                            intercom::RawComPtr)
  ->
      <u32 as
-intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
+intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
     let self_ptr = (self_vtable as usize
         - <Foo as intercom::attributes::ComClass<
             Foo,
@@ -818,7 +818,7 @@ unsafe extern "system" fn __Foo_Foo_Automation_release(self_vtable:
                                                            intercom::RawComPtr)
  ->
      <u32 as
-intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
+intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
     let self_ptr = (self_vtable as usize
         - <Foo as intercom::attributes::ComClass<
             Foo,
@@ -848,16 +848,15 @@ unsafe extern "system" fn __Foo_Foo_Automation_simple_method_Automation(self_vta
                                                                             intercom::RawComPtr)
  ->
      <() as
-intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
+intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
     let self_combox = (self_vtable as usize
         - <Foo as intercom::attributes::ComClass<
             Foo,
             intercom::type_system::AutomationTypeSystem,
         >>::offset()) as *mut intercom::ComBoxData<Foo>;
-    use intercom::type_system::{IntercomFrom, IntercomInto};
     let result:
             Result<<() as
-                   intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+                   intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
                    intercom::ComError> =
         (||
              {
@@ -928,9 +927,9 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
                     ),
                 )
             });
-            <<() as
-             intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                as ErrorValue>::from_error(intercom::store_error(err))
+            <<() as intercom::type_system::ExternOutput<
+                intercom::type_system::AutomationTypeSystem,
+            >>::ForeignType as ErrorValue>::from_error(intercom::store_error(err))
         }
     }
 }
@@ -942,19 +941,18 @@ unsafe extern "system" fn __Foo_Foo_Automation_arg_method_Automation(self_vtable
                                                                      a:
                                                                          <u16
                                                                          as
-                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType)
+                                                                         intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
  ->
      <() as
-intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
+intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
     let self_combox = (self_vtable as usize
         - <Foo as intercom::attributes::ComClass<
             Foo,
             intercom::type_system::AutomationTypeSystem,
         >>::offset()) as *mut intercom::ComBoxData<Foo>;
-    use intercom::type_system::{IntercomFrom, IntercomInto};
     let result:
             Result<<() as
-                   intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+                   intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
                    intercom::ComError> =
         (||
              {
@@ -985,8 +983,8 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
                                                                                 })));
                  let self_struct: &Foo = &**self_combox;
                  let __result =
-                     self_struct.arg_method((&<u16 as
-                                                  intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::intercom_from(a)?).intercom_into()?);
+                     self_struct.arg_method(<u16 as
+                                                intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::from_foreign_parameter(a)?);
                  Ok({ })
              })();
     use intercom::ErrorValue;
@@ -1027,9 +1025,9 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
                     ),
                 )
             });
-            <<() as
-             intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                as ErrorValue>::from_error(intercom::store_error(err))
+            <<() as intercom::type_system::ExternOutput<
+                intercom::type_system::AutomationTypeSystem,
+            >>::ForeignType as ErrorValue>::from_error(intercom::store_error(err))
         }
     }
 }
@@ -1040,16 +1038,15 @@ unsafe extern "system" fn __Foo_Foo_Automation_simple_result_method_Automation(s
                                                                                    intercom::RawComPtr)
  ->
      <u16 as
-intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
+intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
     let self_combox = (self_vtable as usize
         - <Foo as intercom::attributes::ComClass<
             Foo,
             intercom::type_system::AutomationTypeSystem,
         >>::offset()) as *mut intercom::ComBoxData<Foo>;
-    use intercom::type_system::{IntercomFrom, IntercomInto};
     let result:
             Result<<u16 as
-                   intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+                   intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
                    intercom::ComError> =
         (||
              {
@@ -1080,7 +1077,10 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
                                                                                 })));
                  let self_struct: &Foo = &**self_combox;
                  let __result = self_struct.simple_result_method();
-                 Ok({ __result.intercom_into()? })
+                 Ok({
+                        <u16 as
+                            intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::into_foreign_output(__result)?
+                    })
              })();
     use intercom::ErrorValue;
     match result {
@@ -1120,9 +1120,9 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
                     ),
                 )
             });
-            <<u16 as intercom::type_system::ExternType<
+            <<u16 as intercom::type_system::ExternOutput<
                 intercom::type_system::AutomationTypeSystem,
-            >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(err))
+            >>::ForeignType as ErrorValue>::from_error(intercom::store_error(err))
         }
     }
 }
@@ -1131,22 +1131,21 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_Automation_com_result_method_Automation(
     self_vtable: intercom::RawComPtr,
-    __out: *mut <u16 as intercom::type_system::ExternType<
+    __out: *mut <u16 as intercom::type_system::ExternOutput<
         intercom::type_system::AutomationTypeSystem,
-    >>::ExternOutputType,
-) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
+    >>::ForeignType,
+) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
     intercom::type_system::AutomationTypeSystem,
->>::ExternOutputType {
+>>::ForeignType {
     let self_combox = (self_vtable as usize
         - <Foo as intercom::attributes::ComClass<
             Foo,
             intercom::type_system::AutomationTypeSystem,
         >>::offset()) as *mut intercom::ComBoxData<Foo>;
-    use intercom::type_system::{IntercomFrom, IntercomInto};
     let result: Result<
-        <intercom::raw::HRESULT as intercom::type_system::ExternType<
+        <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
             intercom::type_system::AutomationTypeSystem,
-        >>::ExternOutputType,
+        >>::ForeignType,
         intercom::ComError,
     > = (|| {
         intercom::logging::trace(|l| {
@@ -1170,7 +1169,9 @@ unsafe extern "system" fn __Foo_Foo_Automation_com_result_method_Automation(
         Ok({
             match __result {
                 Ok(v1) => {
-                    *__out = v1.intercom_into()?;
+                    *__out = <u16 as intercom::type_system::ExternOutput<
+                        intercom::type_system::AutomationTypeSystem,
+                    >>::into_foreign_output(v1)?;
                     intercom::raw::S_OK
                 }
                 Err(e) => {
@@ -1218,9 +1219,9 @@ unsafe extern "system" fn __Foo_Foo_Automation_com_result_method_Automation(
                     ),
                 )
             });
-            <<intercom::raw::HRESULT as intercom::type_system::ExternType<
+            <<intercom::raw::HRESULT as intercom::type_system::ExternOutput<
                 intercom::type_system::AutomationTypeSystem,
-            >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(err))
+            >>::ForeignType as ErrorValue>::from_error(intercom::store_error(err))
         }
     }
 }
@@ -1229,22 +1230,21 @@ unsafe extern "system" fn __Foo_Foo_Automation_com_result_method_Automation(
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_Automation_rust_result_method_Automation(
     self_vtable: intercom::RawComPtr,
-    __out: *mut <u16 as intercom::type_system::ExternType<
+    __out: *mut <u16 as intercom::type_system::ExternOutput<
         intercom::type_system::AutomationTypeSystem,
-    >>::ExternOutputType,
-) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
+    >>::ForeignType,
+) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
     intercom::type_system::AutomationTypeSystem,
->>::ExternOutputType {
+>>::ForeignType {
     let self_combox = (self_vtable as usize
         - <Foo as intercom::attributes::ComClass<
             Foo,
             intercom::type_system::AutomationTypeSystem,
         >>::offset()) as *mut intercom::ComBoxData<Foo>;
-    use intercom::type_system::{IntercomFrom, IntercomInto};
     let result: Result<
-        <intercom::raw::HRESULT as intercom::type_system::ExternType<
+        <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
             intercom::type_system::AutomationTypeSystem,
-        >>::ExternOutputType,
+        >>::ForeignType,
         intercom::ComError,
     > = (|| {
         intercom::logging::trace(|l| {
@@ -1268,7 +1268,9 @@ unsafe extern "system" fn __Foo_Foo_Automation_rust_result_method_Automation(
         Ok({
             match __result {
                 Ok(v1) => {
-                    *__out = v1.intercom_into()?;
+                    *__out = <u16 as intercom::type_system::ExternOutput<
+                        intercom::type_system::AutomationTypeSystem,
+                    >>::into_foreign_output(v1)?;
                     intercom::raw::S_OK
                 }
                 Err(e) => {
@@ -1316,9 +1318,9 @@ unsafe extern "system" fn __Foo_Foo_Automation_rust_result_method_Automation(
                     ),
                 )
             });
-            <<intercom::raw::HRESULT as intercom::type_system::ExternType<
+            <<intercom::raw::HRESULT as intercom::type_system::ExternOutput<
                 intercom::type_system::AutomationTypeSystem,
-            >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(err))
+            >>::ForeignType as ErrorValue>::from_error(intercom::store_error(err))
         }
     }
 }
@@ -1327,28 +1329,27 @@ unsafe extern "system" fn __Foo_Foo_Automation_rust_result_method_Automation(
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_Automation_tuple_result_method_Automation(
     self_vtable: intercom::RawComPtr,
-    __out1: *mut <u8 as intercom::type_system::ExternType<
+    __out1: *mut <u8 as intercom::type_system::ExternOutput<
         intercom::type_system::AutomationTypeSystem,
-    >>::ExternOutputType,
-    __out2: *mut <u16 as intercom::type_system::ExternType<
+    >>::ForeignType,
+    __out2: *mut <u16 as intercom::type_system::ExternOutput<
         intercom::type_system::AutomationTypeSystem,
-    >>::ExternOutputType,
-    __out3: *mut <u32 as intercom::type_system::ExternType<
+    >>::ForeignType,
+    __out3: *mut <u32 as intercom::type_system::ExternOutput<
         intercom::type_system::AutomationTypeSystem,
-    >>::ExternOutputType,
-) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
+    >>::ForeignType,
+) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
     intercom::type_system::AutomationTypeSystem,
->>::ExternOutputType {
+>>::ForeignType {
     let self_combox = (self_vtable as usize
         - <Foo as intercom::attributes::ComClass<
             Foo,
             intercom::type_system::AutomationTypeSystem,
         >>::offset()) as *mut intercom::ComBoxData<Foo>;
-    use intercom::type_system::{IntercomFrom, IntercomInto};
     let result: Result<
-        <intercom::raw::HRESULT as intercom::type_system::ExternType<
+        <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
             intercom::type_system::AutomationTypeSystem,
-        >>::ExternOutputType,
+        >>::ForeignType,
         intercom::ComError,
     > = (|| {
         intercom::logging::trace(|l| {
@@ -1372,9 +1373,15 @@ unsafe extern "system" fn __Foo_Foo_Automation_tuple_result_method_Automation(
         Ok({
             match __result {
                 Ok((v1, v2, v3)) => {
-                    *__out1 = v1.intercom_into()?;
-                    *__out2 = v2.intercom_into()?;
-                    *__out3 = v3.intercom_into()?;
+                    *__out1 = <u8 as intercom::type_system::ExternOutput<
+                        intercom::type_system::AutomationTypeSystem,
+                    >>::into_foreign_output(v1)?;
+                    *__out2 = <u16 as intercom::type_system::ExternOutput<
+                        intercom::type_system::AutomationTypeSystem,
+                    >>::into_foreign_output(v2)?;
+                    *__out3 = <u32 as intercom::type_system::ExternOutput<
+                        intercom::type_system::AutomationTypeSystem,
+                    >>::into_foreign_output(v3)?;
                     intercom::raw::S_OK
                 }
                 Err(e) => {
@@ -1424,9 +1431,9 @@ unsafe extern "system" fn __Foo_Foo_Automation_tuple_result_method_Automation(
                     ),
                 )
             });
-            <<intercom::raw::HRESULT as intercom::type_system::ExternType<
+            <<intercom::raw::HRESULT as intercom::type_system::ExternOutput<
                 intercom::type_system::AutomationTypeSystem,
-            >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(err))
+            >>::ForeignType as ErrorValue>::from_error(intercom::store_error(err))
         }
     }
 }
@@ -1438,20 +1445,19 @@ unsafe extern "system" fn __Foo_Foo_Automation_string_method_Automation(self_vta
                                                                         input:
                                                                             <String
                                                                             as
-                                                                            intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType)
+                                                                            intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
  ->
      <String as
-intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
+intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
     let self_combox = (self_vtable as usize
         - <Foo as intercom::attributes::ComClass<
             Foo,
             intercom::type_system::AutomationTypeSystem,
         >>::offset()) as *mut intercom::ComBoxData<Foo>;
-    use intercom::type_system::{IntercomFrom, IntercomInto};
     let result: Result<
-        <String as intercom::type_system::ExternType<
+        <String as intercom::type_system::ExternOutput<
             intercom::type_system::AutomationTypeSystem,
-        >>::ExternOutputType,
+        >>::ForeignType,
         intercom::ComError,
     > = (|| {
         intercom::logging::trace(|l| {
@@ -1471,13 +1477,14 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
             )
         });
         let self_struct: &Foo = &**self_combox;
-        let __result = self_struct.string_method(
-            (&<String as intercom::type_system::ExternType<
+        let __result = self_struct.string_method(<String as intercom::type_system::ExternInput<
+            intercom::type_system::AutomationTypeSystem,
+        >>::from_foreign_parameter(input)?);
+        Ok({
+            <String as intercom::type_system::ExternOutput<
                 intercom::type_system::AutomationTypeSystem,
-            >>::intercom_from(input)?)
-                .intercom_into()?,
-        );
-        Ok({ __result.intercom_into()? })
+            >>::into_foreign_output(__result)?
+        })
     })();
     use intercom::ErrorValue;
     match result {
@@ -1517,9 +1524,9 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
                     ),
                 )
             });
-            <<String as intercom::type_system::ExternType<
+            <<String as intercom::type_system::ExternOutput<
                 intercom::type_system::AutomationTypeSystem,
-            >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(err))
+            >>::ForeignType as ErrorValue>::from_error(intercom::store_error(err))
         }
     }
 }
@@ -1528,25 +1535,24 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_Automation_string_result_method_Automation(
     self_vtable: intercom::RawComPtr,
-    input: <String as intercom::type_system::ExternType<
+    input: <String as intercom::type_system::ExternInput<
         intercom::type_system::AutomationTypeSystem,
-    >>::ExternInputType,
-    __out: *mut <String as intercom::type_system::ExternType<
+    >>::ForeignType,
+    __out: *mut <String as intercom::type_system::ExternOutput<
         intercom::type_system::AutomationTypeSystem,
-    >>::ExternOutputType,
-) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
+    >>::ForeignType,
+) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
     intercom::type_system::AutomationTypeSystem,
->>::ExternOutputType {
+>>::ForeignType {
     let self_combox = (self_vtable as usize
         - <Foo as intercom::attributes::ComClass<
             Foo,
             intercom::type_system::AutomationTypeSystem,
         >>::offset()) as *mut intercom::ComBoxData<Foo>;
-    use intercom::type_system::{IntercomFrom, IntercomInto};
     let result: Result<
-        <intercom::raw::HRESULT as intercom::type_system::ExternType<
+        <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
             intercom::type_system::AutomationTypeSystem,
-        >>::ExternOutputType,
+        >>::ForeignType,
         intercom::ComError,
     > = (|| {
         intercom::logging::trace(|l| {
@@ -1566,16 +1572,16 @@ unsafe extern "system" fn __Foo_Foo_Automation_string_result_method_Automation(
             )
         });
         let self_struct: &Foo = &**self_combox;
-        let __result = self_struct.string_result_method(
-            (&<String as intercom::type_system::ExternType<
+        let __result =
+            self_struct.string_result_method(<String as intercom::type_system::ExternInput<
                 intercom::type_system::AutomationTypeSystem,
-            >>::intercom_from(input)?)
-                .intercom_into()?,
-        );
+            >>::from_foreign_parameter(input)?);
         Ok({
             match __result {
                 Ok(v1) => {
-                    *__out = v1.intercom_into()?;
+                    *__out = <String as intercom::type_system::ExternOutput<
+                        intercom::type_system::AutomationTypeSystem,
+                    >>::into_foreign_output(v1)?;
                     intercom::raw::S_OK
                 }
                 Err(e) => {
@@ -1623,9 +1629,9 @@ unsafe extern "system" fn __Foo_Foo_Automation_string_result_method_Automation(
                     ),
                 )
             });
-            <<intercom::raw::HRESULT as intercom::type_system::ExternType<
+            <<intercom::raw::HRESULT as intercom::type_system::ExternOutput<
                 intercom::type_system::AutomationTypeSystem,
-            >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(err))
+            >>::ForeignType as ErrorValue>::from_error(intercom::store_error(err))
         }
     }
 }
@@ -1637,27 +1643,26 @@ unsafe extern "system" fn __Foo_Foo_Automation_complete_method_Automation(
     a:
                                                                               <u16
                                                                               as
-                                                                              intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
+                                                                              intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
     b:
                                                                               <i16
                                                                               as
-                                                                              intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
-    __out: *mut <bool as intercom::type_system::ExternType<
+                                                                              intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
+    __out: *mut <bool as intercom::type_system::ExternOutput<
         intercom::type_system::AutomationTypeSystem,
-    >>::ExternOutputType,
-) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
+    >>::ForeignType,
+) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
     intercom::type_system::AutomationTypeSystem,
->>::ExternOutputType {
+>>::ForeignType {
     let self_combox = (self_vtable as usize
         - <Foo as intercom::attributes::ComClass<
             Foo,
             intercom::type_system::AutomationTypeSystem,
         >>::offset()) as *mut intercom::ComBoxData<Foo>;
-    use intercom::type_system::{IntercomFrom, IntercomInto};
     let result: Result<
-        <intercom::raw::HRESULT as intercom::type_system::ExternType<
+        <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
             intercom::type_system::AutomationTypeSystem,
-        >>::ExternOutputType,
+        >>::ForeignType,
         intercom::ComError,
     > = (|| {
         intercom::logging::trace(|l| {
@@ -1678,19 +1683,19 @@ unsafe extern "system" fn __Foo_Foo_Automation_complete_method_Automation(
         });
         let self_struct: &mut Foo = &mut **self_combox;
         let __result = self_struct.complete_method(
-            (&<u16 as intercom::type_system::ExternType<
+            <u16 as intercom::type_system::ExternInput<
                 intercom::type_system::AutomationTypeSystem,
-            >>::intercom_from(a)?)
-                .intercom_into()?,
-            (&<i16 as intercom::type_system::ExternType<
+            >>::from_foreign_parameter(a)?,
+            <i16 as intercom::type_system::ExternInput<
                 intercom::type_system::AutomationTypeSystem,
-            >>::intercom_from(b)?)
-                .intercom_into()?,
+            >>::from_foreign_parameter(b)?,
         );
         Ok({
             match __result {
                 Ok(v1) => {
-                    *__out = v1.intercom_into()?;
+                    *__out = <bool as intercom::type_system::ExternOutput<
+                        intercom::type_system::AutomationTypeSystem,
+                    >>::into_foreign_output(v1)?;
                     intercom::raw::S_OK
                 }
                 Err(e) => {
@@ -1738,9 +1743,9 @@ unsafe extern "system" fn __Foo_Foo_Automation_complete_method_Automation(
                     ),
                 )
             });
-            <<intercom::raw::HRESULT as intercom::type_system::ExternType<
+            <<intercom::raw::HRESULT as intercom::type_system::ExternOutput<
                 intercom::type_system::AutomationTypeSystem,
-            >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(err))
+            >>::ForeignType as ErrorValue>::from_error(intercom::store_error(err))
         }
     }
 }
@@ -1749,25 +1754,24 @@ unsafe extern "system" fn __Foo_Foo_Automation_complete_method_Automation(
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_Automation_bool_method_Automation(
     self_vtable: intercom::RawComPtr,
-    input: <bool as intercom::type_system::ExternType<
+    input: <bool as intercom::type_system::ExternInput<
         intercom::type_system::AutomationTypeSystem,
-    >>::ExternInputType,
-    __out: *mut <bool as intercom::type_system::ExternType<
+    >>::ForeignType,
+    __out: *mut <bool as intercom::type_system::ExternOutput<
         intercom::type_system::AutomationTypeSystem,
-    >>::ExternOutputType,
-) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
+    >>::ForeignType,
+) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
     intercom::type_system::AutomationTypeSystem,
->>::ExternOutputType {
+>>::ForeignType {
     let self_combox = (self_vtable as usize
         - <Foo as intercom::attributes::ComClass<
             Foo,
             intercom::type_system::AutomationTypeSystem,
         >>::offset()) as *mut intercom::ComBoxData<Foo>;
-    use intercom::type_system::{IntercomFrom, IntercomInto};
     let result: Result<
-        <intercom::raw::HRESULT as intercom::type_system::ExternType<
+        <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
             intercom::type_system::AutomationTypeSystem,
-        >>::ExternOutputType,
+        >>::ForeignType,
         intercom::ComError,
     > = (|| {
         intercom::logging::trace(|l| {
@@ -1787,16 +1791,15 @@ unsafe extern "system" fn __Foo_Foo_Automation_bool_method_Automation(
             )
         });
         let self_struct: &Foo = &**self_combox;
-        let __result = self_struct.bool_method(
-            (&<bool as intercom::type_system::ExternType<
-                intercom::type_system::AutomationTypeSystem,
-            >>::intercom_from(input)?)
-                .intercom_into()?,
-        );
+        let __result = self_struct.bool_method(<bool as intercom::type_system::ExternInput<
+            intercom::type_system::AutomationTypeSystem,
+        >>::from_foreign_parameter(input)?);
         Ok({
             match __result {
                 Ok(v1) => {
-                    *__out = v1.intercom_into()?;
+                    *__out = <bool as intercom::type_system::ExternOutput<
+                        intercom::type_system::AutomationTypeSystem,
+                    >>::into_foreign_output(v1)?;
                     intercom::raw::S_OK
                 }
                 Err(e) => {
@@ -1844,9 +1847,9 @@ unsafe extern "system" fn __Foo_Foo_Automation_bool_method_Automation(
                     ),
                 )
             });
-            <<intercom::raw::HRESULT as intercom::type_system::ExternType<
+            <<intercom::raw::HRESULT as intercom::type_system::ExternOutput<
                 intercom::type_system::AutomationTypeSystem,
-            >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(err))
+            >>::ForeignType as ErrorValue>::from_error(intercom::store_error(err))
         }
     }
 }
@@ -1855,25 +1858,24 @@ unsafe extern "system" fn __Foo_Foo_Automation_bool_method_Automation(
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_Automation_variant_method_Automation(
     self_vtable: intercom::RawComPtr,
-    input: <Variant as intercom::type_system::ExternType<
+    input: <Variant as intercom::type_system::ExternInput<
         intercom::type_system::AutomationTypeSystem,
-    >>::ExternInputType,
-    __out: *mut <Variant as intercom::type_system::ExternType<
+    >>::ForeignType,
+    __out: *mut <Variant as intercom::type_system::ExternOutput<
         intercom::type_system::AutomationTypeSystem,
-    >>::ExternOutputType,
-) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
+    >>::ForeignType,
+) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
     intercom::type_system::AutomationTypeSystem,
->>::ExternOutputType {
+>>::ForeignType {
     let self_combox = (self_vtable as usize
         - <Foo as intercom::attributes::ComClass<
             Foo,
             intercom::type_system::AutomationTypeSystem,
         >>::offset()) as *mut intercom::ComBoxData<Foo>;
-    use intercom::type_system::{IntercomFrom, IntercomInto};
     let result: Result<
-        <intercom::raw::HRESULT as intercom::type_system::ExternType<
+        <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
             intercom::type_system::AutomationTypeSystem,
-        >>::ExternOutputType,
+        >>::ForeignType,
         intercom::ComError,
     > = (|| {
         intercom::logging::trace(|l| {
@@ -1893,16 +1895,16 @@ unsafe extern "system" fn __Foo_Foo_Automation_variant_method_Automation(
             )
         });
         let self_struct: &Foo = &**self_combox;
-        let __result = self_struct.variant_method(
-            (&<Variant as intercom::type_system::ExternType<
+        let __result =
+            self_struct.variant_method(<Variant as intercom::type_system::ExternInput<
                 intercom::type_system::AutomationTypeSystem,
-            >>::intercom_from(input)?)
-                .intercom_into()?,
-        );
+            >>::from_foreign_parameter(input)?);
         Ok({
             match __result {
                 Ok(v1) => {
-                    *__out = v1.intercom_into()?;
+                    *__out = <Variant as intercom::type_system::ExternOutput<
+                        intercom::type_system::AutomationTypeSystem,
+                    >>::into_foreign_output(v1)?;
                     intercom::raw::S_OK
                 }
                 Err(e) => {
@@ -1950,9 +1952,9 @@ unsafe extern "system" fn __Foo_Foo_Automation_variant_method_Automation(
                     ),
                 )
             });
-            <<intercom::raw::HRESULT as intercom::type_system::ExternType<
+            <<intercom::raw::HRESULT as intercom::type_system::ExternOutput<
                 intercom::type_system::AutomationTypeSystem,
-            >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(err))
+            >>::ForeignType as ErrorValue>::from_error(intercom::store_error(err))
         }
     }
 }
@@ -1993,15 +1995,15 @@ impl intercom::attributes::ComImpl<Foo, intercom::type_system::AutomationTypeSys
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_Raw_query_interface(
     self_vtable: intercom::RawComPtr,
-    riid: <intercom::REFIID as intercom::type_system::ExternType<
+    riid: <intercom::REFIID as intercom::type_system::ExternInput<
         intercom::type_system::AutomationTypeSystem,
-    >>::ExternInputType,
-    out: *mut <intercom::RawComPtr as intercom::type_system::ExternType<
+    >>::ForeignType,
+    out: *mut <intercom::RawComPtr as intercom::type_system::ExternOutput<
         intercom::type_system::AutomationTypeSystem,
-    >>::ExternOutputType,
-) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
+    >>::ForeignType,
+) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
     intercom::type_system::AutomationTypeSystem,
->>::ExternOutputType {
+>>::ForeignType {
     let self_ptr =
         (self_vtable as usize -
              <Foo as
@@ -2032,7 +2034,7 @@ unsafe extern "system" fn __Foo_Foo_Raw_add_ref(self_vtable:
                                                     intercom::RawComPtr)
  ->
      <u32 as
-intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
+intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
     let self_ptr =
         (self_vtable as usize -
              <Foo as
@@ -2063,7 +2065,7 @@ unsafe extern "system" fn __Foo_Foo_Raw_release(self_vtable:
                                                     intercom::RawComPtr)
  ->
      <u32 as
-intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
+intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
     let self_ptr =
         (self_vtable as usize -
              <Foo as
@@ -2094,17 +2096,16 @@ unsafe extern "system" fn __Foo_Foo_Raw_simple_method_Raw(self_vtable:
                                                               intercom::RawComPtr)
  ->
      <() as
-intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
+intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
     let self_combox =
         (self_vtable as usize -
              <Foo as
                  intercom::attributes::ComClass<Foo,
                                                 intercom::type_system::RawTypeSystem>>::offset())
             as *mut intercom::ComBoxData<Foo>;
-    use intercom::type_system::{IntercomFrom, IntercomInto};
     let result:
             Result<<() as
-                   intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+                   intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
                    intercom::ComError> =
         (||
              {
@@ -2175,9 +2176,9 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
                     ),
                 )
             });
-            <<() as
-             intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                as ErrorValue>::from_error(intercom::store_error(err))
+            <<() as intercom::type_system::ExternOutput<
+                intercom::type_system::AutomationTypeSystem,
+            >>::ForeignType as ErrorValue>::from_error(intercom::store_error(err))
         }
     }
 }
@@ -2188,20 +2189,19 @@ unsafe extern "system" fn __Foo_Foo_Raw_arg_method_Raw(self_vtable:
                                                            intercom::RawComPtr,
                                                        a:
                                                            <u16 as
-                                                           intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType)
+                                                           intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType)
  ->
      <() as
-intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
+intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
     let self_combox =
         (self_vtable as usize -
              <Foo as
                  intercom::attributes::ComClass<Foo,
                                                 intercom::type_system::RawTypeSystem>>::offset())
             as *mut intercom::ComBoxData<Foo>;
-    use intercom::type_system::{IntercomFrom, IntercomInto};
     let result:
             Result<<() as
-                   intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+                   intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
                    intercom::ComError> =
         (||
              {
@@ -2232,8 +2232,8 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
                                                                                 })));
                  let self_struct: &Foo = &**self_combox;
                  let __result =
-                     self_struct.arg_method((&<u16 as
-                                                  intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::intercom_from(a)?).intercom_into()?);
+                     self_struct.arg_method(<u16 as
+                                                intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::from_foreign_parameter(a)?);
                  Ok({ })
              })();
     use intercom::ErrorValue;
@@ -2274,30 +2274,28 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
                     ),
                 )
             });
-            <<() as
-             intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                as ErrorValue>::from_error(intercom::store_error(err))
+            <<() as intercom::type_system::ExternOutput<
+                intercom::type_system::AutomationTypeSystem,
+            >>::ForeignType as ErrorValue>::from_error(intercom::store_error(err))
         }
     }
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Raw_simple_result_method_Raw(self_vtable:
-                                                                     intercom::RawComPtr)
- ->
-     <u16 as
-intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType{
+unsafe extern "system" fn __Foo_Foo_Raw_simple_result_method_Raw(
+    self_vtable: intercom::RawComPtr,
+) -> <u16 as intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
+{
     let self_combox =
         (self_vtable as usize -
              <Foo as
                  intercom::attributes::ComClass<Foo,
                                                 intercom::type_system::RawTypeSystem>>::offset())
             as *mut intercom::ComBoxData<Foo>;
-    use intercom::type_system::{IntercomFrom, IntercomInto};
     let result:
             Result<<u16 as
-                   intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
+                   intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType,
                    intercom::ComError> =
         (||
              {
@@ -2328,7 +2326,10 @@ intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::Extern
                                                                                 })));
                  let self_struct: &Foo = &**self_combox;
                  let __result = self_struct.simple_result_method();
-                 Ok({ __result.intercom_into()? })
+                 Ok({
+                        <u16 as
+                            intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::into_foreign_output(__result)?
+                    })
              })();
     use intercom::ErrorValue;
     match result {
@@ -2369,7 +2370,7 @@ intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::Extern
                 )
             });
             <<u16 as
-             intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+             intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
                 as ErrorValue>::from_error(intercom::store_error(err))
         }
     }
@@ -2379,23 +2380,22 @@ intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::Extern
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_Raw_com_result_method_Raw(
     self_vtable: intercom::RawComPtr,
-    __out:
-                                                                  *mut <u16 as
-                                                                       intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
-) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
+    __out: *mut <u16 as intercom::type_system::ExternOutput<
+        intercom::type_system::RawTypeSystem,
+    >>::ForeignType,
+) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
     intercom::type_system::RawTypeSystem,
->>::ExternOutputType {
+>>::ForeignType {
     let self_combox =
         (self_vtable as usize -
              <Foo as
                  intercom::attributes::ComClass<Foo,
                                                 intercom::type_system::RawTypeSystem>>::offset())
             as *mut intercom::ComBoxData<Foo>;
-    use intercom::type_system::{IntercomFrom, IntercomInto};
     let result: Result<
-        <intercom::raw::HRESULT as intercom::type_system::ExternType<
+        <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
             intercom::type_system::RawTypeSystem,
-        >>::ExternOutputType,
+        >>::ForeignType,
         intercom::ComError,
     > = (|| {
         intercom::logging::trace(|l| {
@@ -2419,7 +2419,9 @@ unsafe extern "system" fn __Foo_Foo_Raw_com_result_method_Raw(
         Ok({
             match __result {
                 Ok(v1) => {
-                    *__out = v1.intercom_into()?;
+                    *__out = <u16 as intercom::type_system::ExternOutput<
+                        intercom::type_system::RawTypeSystem,
+                    >>::into_foreign_output(v1)?;
                     intercom::raw::S_OK
                 }
                 Err(e) => {
@@ -2467,9 +2469,9 @@ unsafe extern "system" fn __Foo_Foo_Raw_com_result_method_Raw(
                     ),
                 )
             });
-            <<intercom::raw::HRESULT as intercom::type_system::ExternType<
+            <<intercom::raw::HRESULT as intercom::type_system::ExternOutput<
                 intercom::type_system::RawTypeSystem,
-            >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(err))
+            >>::ForeignType as ErrorValue>::from_error(intercom::store_error(err))
         }
     }
 }
@@ -2478,24 +2480,22 @@ unsafe extern "system" fn __Foo_Foo_Raw_com_result_method_Raw(
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_Raw_rust_result_method_Raw(
     self_vtable: intercom::RawComPtr,
-    __out:
-                                                                   *mut <u16
-                                                                        as
-                                                                        intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
-) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
+    __out: *mut <u16 as intercom::type_system::ExternOutput<
+        intercom::type_system::RawTypeSystem,
+    >>::ForeignType,
+) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
     intercom::type_system::RawTypeSystem,
->>::ExternOutputType {
+>>::ForeignType {
     let self_combox =
         (self_vtable as usize -
              <Foo as
                  intercom::attributes::ComClass<Foo,
                                                 intercom::type_system::RawTypeSystem>>::offset())
             as *mut intercom::ComBoxData<Foo>;
-    use intercom::type_system::{IntercomFrom, IntercomInto};
     let result: Result<
-        <intercom::raw::HRESULT as intercom::type_system::ExternType<
+        <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
             intercom::type_system::RawTypeSystem,
-        >>::ExternOutputType,
+        >>::ForeignType,
         intercom::ComError,
     > = (|| {
         intercom::logging::trace(|l| {
@@ -2519,7 +2519,9 @@ unsafe extern "system" fn __Foo_Foo_Raw_rust_result_method_Raw(
         Ok({
             match __result {
                 Ok(v1) => {
-                    *__out = v1.intercom_into()?;
+                    *__out = <u16 as intercom::type_system::ExternOutput<
+                        intercom::type_system::RawTypeSystem,
+                    >>::into_foreign_output(v1)?;
                     intercom::raw::S_OK
                 }
                 Err(e) => {
@@ -2567,9 +2569,9 @@ unsafe extern "system" fn __Foo_Foo_Raw_rust_result_method_Raw(
                     ),
                 )
             });
-            <<intercom::raw::HRESULT as intercom::type_system::ExternType<
+            <<intercom::raw::HRESULT as intercom::type_system::ExternOutput<
                 intercom::type_system::RawTypeSystem,
-            >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(err))
+            >>::ForeignType as ErrorValue>::from_error(intercom::store_error(err))
         }
     }
 }
@@ -2578,32 +2580,28 @@ unsafe extern "system" fn __Foo_Foo_Raw_rust_result_method_Raw(
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_Raw_tuple_result_method_Raw(
     self_vtable: intercom::RawComPtr,
-    __out1:
-                                                                    *mut <u8
-                                                                         as
-                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
-    __out2:
-                                                                    *mut <u16
-                                                                         as
-                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
-    __out3:
-                                                                    *mut <u32
-                                                                         as
-                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
-) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
+    __out1: *mut <u8 as intercom::type_system::ExternOutput<
+        intercom::type_system::RawTypeSystem,
+    >>::ForeignType,
+    __out2: *mut <u16 as intercom::type_system::ExternOutput<
+        intercom::type_system::RawTypeSystem,
+    >>::ForeignType,
+    __out3: *mut <u32 as intercom::type_system::ExternOutput<
+        intercom::type_system::RawTypeSystem,
+    >>::ForeignType,
+) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
     intercom::type_system::RawTypeSystem,
->>::ExternOutputType {
+>>::ForeignType {
     let self_combox =
         (self_vtable as usize -
              <Foo as
                  intercom::attributes::ComClass<Foo,
                                                 intercom::type_system::RawTypeSystem>>::offset())
             as *mut intercom::ComBoxData<Foo>;
-    use intercom::type_system::{IntercomFrom, IntercomInto};
     let result: Result<
-        <intercom::raw::HRESULT as intercom::type_system::ExternType<
+        <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
             intercom::type_system::RawTypeSystem,
-        >>::ExternOutputType,
+        >>::ForeignType,
         intercom::ComError,
     > = (|| {
         intercom::logging::trace(|l| {
@@ -2627,9 +2625,15 @@ unsafe extern "system" fn __Foo_Foo_Raw_tuple_result_method_Raw(
         Ok({
             match __result {
                 Ok((v1, v2, v3)) => {
-                    *__out1 = v1.intercom_into()?;
-                    *__out2 = v2.intercom_into()?;
-                    *__out3 = v3.intercom_into()?;
+                    *__out1 = <u8 as intercom::type_system::ExternOutput<
+                        intercom::type_system::RawTypeSystem,
+                    >>::into_foreign_output(v1)?;
+                    *__out2 = <u16 as intercom::type_system::ExternOutput<
+                        intercom::type_system::RawTypeSystem,
+                    >>::into_foreign_output(v2)?;
+                    *__out3 = <u32 as intercom::type_system::ExternOutput<
+                        intercom::type_system::RawTypeSystem,
+                    >>::into_foreign_output(v3)?;
                     intercom::raw::S_OK
                 }
                 Err(e) => {
@@ -2679,9 +2683,9 @@ unsafe extern "system" fn __Foo_Foo_Raw_tuple_result_method_Raw(
                     ),
                 )
             });
-            <<intercom::raw::HRESULT as intercom::type_system::ExternType<
+            <<intercom::raw::HRESULT as intercom::type_system::ExternOutput<
                 intercom::type_system::RawTypeSystem,
-            >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(err))
+            >>::ForeignType as ErrorValue>::from_error(intercom::store_error(err))
         }
     }
 }
@@ -2692,20 +2696,19 @@ unsafe extern "system" fn __Foo_Foo_Raw_string_method_Raw(self_vtable:
                                                               intercom::RawComPtr,
                                                           input:
                                                               <String as
-                                                              intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType)
+                                                              intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType)
  ->
      <String as
-intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType{
+intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType{
     let self_combox =
         (self_vtable as usize -
              <Foo as
                  intercom::attributes::ComClass<Foo,
                                                 intercom::type_system::RawTypeSystem>>::offset())
             as *mut intercom::ComBoxData<Foo>;
-    use intercom::type_system::{IntercomFrom, IntercomInto};
     let result:
             Result<<String as
-                   intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
+                   intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType,
                    intercom::ComError> =
         (||
              {
@@ -2736,9 +2739,12 @@ intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::Extern
                                                                                 })));
                  let self_struct: &Foo = &**self_combox;
                  let __result =
-                     self_struct.string_method((&<String as
-                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::intercom_from(input)?).intercom_into()?);
-                 Ok({ __result.intercom_into()? })
+                     self_struct.string_method(<String as
+                                                   intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::from_foreign_parameter(input)?);
+                 Ok({
+                        <String as
+                            intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::into_foreign_output(__result)?
+                    })
              })();
     use intercom::ErrorValue;
     match result {
@@ -2779,7 +2785,7 @@ intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::Extern
                 )
             });
             <<String as
-             intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+             intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
                 as ErrorValue>::from_error(intercom::store_error(err))
         }
     }
@@ -2792,24 +2798,23 @@ unsafe extern "system" fn __Foo_Foo_Raw_string_result_method_Raw(
     input:
                                                                      <String
                                                                      as
-                                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
-    __out: *mut <String as intercom::type_system::ExternType<
+                                                                     intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
+    __out: *mut <String as intercom::type_system::ExternOutput<
         intercom::type_system::RawTypeSystem,
-    >>::ExternOutputType,
-) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
+    >>::ForeignType,
+) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
     intercom::type_system::RawTypeSystem,
->>::ExternOutputType {
+>>::ForeignType {
     let self_combox =
         (self_vtable as usize -
              <Foo as
                  intercom::attributes::ComClass<Foo,
                                                 intercom::type_system::RawTypeSystem>>::offset())
             as *mut intercom::ComBoxData<Foo>;
-    use intercom::type_system::{IntercomFrom, IntercomInto};
     let result: Result<
-        <intercom::raw::HRESULT as intercom::type_system::ExternType<
+        <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
             intercom::type_system::RawTypeSystem,
-        >>::ExternOutputType,
+        >>::ForeignType,
         intercom::ComError,
     > = (|| {
         intercom::logging::trace(|l| {
@@ -2829,16 +2834,16 @@ unsafe extern "system" fn __Foo_Foo_Raw_string_result_method_Raw(
             )
         });
         let self_struct: &Foo = &**self_combox;
-        let __result = self_struct.string_result_method(
-            (&<String as intercom::type_system::ExternType<
-                intercom::type_system::RawTypeSystem,
-            >>::intercom_from(input)?)
-                .intercom_into()?,
-        );
+        let __result = self_struct
+            .string_result_method(<String as intercom::type_system::ExternInput<
+            intercom::type_system::RawTypeSystem,
+        >>::from_foreign_parameter(input)?);
         Ok({
             match __result {
                 Ok(v1) => {
-                    *__out = v1.intercom_into()?;
+                    *__out = <String as intercom::type_system::ExternOutput<
+                        intercom::type_system::RawTypeSystem,
+                    >>::into_foreign_output(v1)?;
                     intercom::raw::S_OK
                 }
                 Err(e) => {
@@ -2886,9 +2891,9 @@ unsafe extern "system" fn __Foo_Foo_Raw_string_result_method_Raw(
                     ),
                 )
             });
-            <<intercom::raw::HRESULT as intercom::type_system::ExternType<
+            <<intercom::raw::HRESULT as intercom::type_system::ExternOutput<
                 intercom::type_system::RawTypeSystem,
-            >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(err))
+            >>::ForeignType as ErrorValue>::from_error(intercom::store_error(err))
         }
     }
 }
@@ -2899,27 +2904,26 @@ unsafe extern "system" fn __Foo_Foo_Raw_complete_method_Raw(
     self_vtable: intercom::RawComPtr,
     a:
                                                                 <u16 as
-                                                                intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
+                                                                intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
     b:
                                                                 <i16 as
-                                                                intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
-    __out:
-                                                                *mut <bool as
-                                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
-) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
+                                                                intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
+    __out: *mut <bool as intercom::type_system::ExternOutput<
+        intercom::type_system::RawTypeSystem,
+    >>::ForeignType,
+) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
     intercom::type_system::RawTypeSystem,
->>::ExternOutputType {
+>>::ForeignType {
     let self_combox =
         (self_vtable as usize -
              <Foo as
                  intercom::attributes::ComClass<Foo,
                                                 intercom::type_system::RawTypeSystem>>::offset())
             as *mut intercom::ComBoxData<Foo>;
-    use intercom::type_system::{IntercomFrom, IntercomInto};
     let result: Result<
-        <intercom::raw::HRESULT as intercom::type_system::ExternType<
+        <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
             intercom::type_system::RawTypeSystem,
-        >>::ExternOutputType,
+        >>::ForeignType,
         intercom::ComError,
     > = (|| {
         intercom::logging::trace(|l| {
@@ -2941,19 +2945,19 @@ unsafe extern "system" fn __Foo_Foo_Raw_complete_method_Raw(
         let self_struct: &mut Foo = &mut **self_combox;
         let __result =
             self_struct.complete_method(
-                (&<u16 as intercom::type_system::ExternType<
+                <u16 as intercom::type_system::ExternInput<
                     intercom::type_system::RawTypeSystem,
-                >>::intercom_from(a)?)
-                    .intercom_into()?,
-                (&<i16 as intercom::type_system::ExternType<
+                >>::from_foreign_parameter(a)?,
+                <i16 as intercom::type_system::ExternInput<
                     intercom::type_system::RawTypeSystem,
-                >>::intercom_from(b)?)
-                    .intercom_into()?,
+                >>::from_foreign_parameter(b)?,
             );
         Ok({
             match __result {
                 Ok(v1) => {
-                    *__out = v1.intercom_into()?;
+                    *__out = <bool as intercom::type_system::ExternOutput<
+                        intercom::type_system::RawTypeSystem,
+                    >>::into_foreign_output(v1)?;
                     intercom::raw::S_OK
                 }
                 Err(e) => {
@@ -3001,9 +3005,9 @@ unsafe extern "system" fn __Foo_Foo_Raw_complete_method_Raw(
                     ),
                 )
             });
-            <<intercom::raw::HRESULT as intercom::type_system::ExternType<
+            <<intercom::raw::HRESULT as intercom::type_system::ExternOutput<
                 intercom::type_system::RawTypeSystem,
-            >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(err))
+            >>::ForeignType as ErrorValue>::from_error(intercom::store_error(err))
         }
     }
 }
@@ -3014,24 +3018,23 @@ unsafe extern "system" fn __Foo_Foo_Raw_bool_method_Raw(
     self_vtable: intercom::RawComPtr,
     input:
                                                             <bool as
-                                                            intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
-    __out:
-                                                            *mut <bool as
-                                                                 intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
-) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
+                                                            intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
+    __out: *mut <bool as intercom::type_system::ExternOutput<
+        intercom::type_system::RawTypeSystem,
+    >>::ForeignType,
+) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
     intercom::type_system::RawTypeSystem,
->>::ExternOutputType {
+>>::ForeignType {
     let self_combox =
         (self_vtable as usize -
              <Foo as
                  intercom::attributes::ComClass<Foo,
                                                 intercom::type_system::RawTypeSystem>>::offset())
             as *mut intercom::ComBoxData<Foo>;
-    use intercom::type_system::{IntercomFrom, IntercomInto};
     let result: Result<
-        <intercom::raw::HRESULT as intercom::type_system::ExternType<
+        <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
             intercom::type_system::RawTypeSystem,
-        >>::ExternOutputType,
+        >>::ForeignType,
         intercom::ComError,
     > = (|| {
         intercom::logging::trace(|l| {
@@ -3051,17 +3054,15 @@ unsafe extern "system" fn __Foo_Foo_Raw_bool_method_Raw(
             )
         });
         let self_struct: &Foo = &**self_combox;
-        let __result =
-            self_struct.bool_method(
-                (&<bool as intercom::type_system::ExternType<
-                    intercom::type_system::RawTypeSystem,
-                >>::intercom_from(input)?)
-                    .intercom_into()?,
-            );
+        let __result = self_struct.bool_method(<bool as intercom::type_system::ExternInput<
+            intercom::type_system::RawTypeSystem,
+        >>::from_foreign_parameter(input)?);
         Ok({
             match __result {
                 Ok(v1) => {
-                    *__out = v1.intercom_into()?;
+                    *__out = <bool as intercom::type_system::ExternOutput<
+                        intercom::type_system::RawTypeSystem,
+                    >>::into_foreign_output(v1)?;
                     intercom::raw::S_OK
                 }
                 Err(e) => {
@@ -3109,9 +3110,9 @@ unsafe extern "system" fn __Foo_Foo_Raw_bool_method_Raw(
                     ),
                 )
             });
-            <<intercom::raw::HRESULT as intercom::type_system::ExternType<
+            <<intercom::raw::HRESULT as intercom::type_system::ExternOutput<
                 intercom::type_system::RawTypeSystem,
-            >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(err))
+            >>::ForeignType as ErrorValue>::from_error(intercom::store_error(err))
         }
     }
 }
@@ -3122,24 +3123,23 @@ unsafe extern "system" fn __Foo_Foo_Raw_variant_method_Raw(
     self_vtable: intercom::RawComPtr,
     input:
                                                                <Variant as
-                                                               intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
-    __out: *mut <Variant as intercom::type_system::ExternType<
+                                                               intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
+    __out: *mut <Variant as intercom::type_system::ExternOutput<
         intercom::type_system::RawTypeSystem,
-    >>::ExternOutputType,
-) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
+    >>::ForeignType,
+) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
     intercom::type_system::RawTypeSystem,
->>::ExternOutputType {
+>>::ForeignType {
     let self_combox =
         (self_vtable as usize -
              <Foo as
                  intercom::attributes::ComClass<Foo,
                                                 intercom::type_system::RawTypeSystem>>::offset())
             as *mut intercom::ComBoxData<Foo>;
-    use intercom::type_system::{IntercomFrom, IntercomInto};
     let result: Result<
-        <intercom::raw::HRESULT as intercom::type_system::ExternType<
+        <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
             intercom::type_system::RawTypeSystem,
-        >>::ExternOutputType,
+        >>::ForeignType,
         intercom::ComError,
     > = (|| {
         intercom::logging::trace(|l| {
@@ -3159,16 +3159,16 @@ unsafe extern "system" fn __Foo_Foo_Raw_variant_method_Raw(
             )
         });
         let self_struct: &Foo = &**self_combox;
-        let __result = self_struct.variant_method(
-            (&<Variant as intercom::type_system::ExternType<
+        let __result =
+            self_struct.variant_method(<Variant as intercom::type_system::ExternInput<
                 intercom::type_system::RawTypeSystem,
-            >>::intercom_from(input)?)
-                .intercom_into()?,
-        );
+            >>::from_foreign_parameter(input)?);
         Ok({
             match __result {
                 Ok(v1) => {
-                    *__out = v1.intercom_into()?;
+                    *__out = <Variant as intercom::type_system::ExternOutput<
+                        intercom::type_system::RawTypeSystem,
+                    >>::into_foreign_output(v1)?;
                     intercom::raw::S_OK
                 }
                 Err(e) => {
@@ -3216,9 +3216,9 @@ unsafe extern "system" fn __Foo_Foo_Raw_variant_method_Raw(
                     ),
                 )
             });
-            <<intercom::raw::HRESULT as intercom::type_system::ExternType<
+            <<intercom::raw::HRESULT as intercom::type_system::ExternOutput<
                 intercom::type_system::RawTypeSystem,
-            >>::ExternOutputType as ErrorValue>::from_error(intercom::store_error(err))
+            >>::ForeignType as ErrorValue>::from_error(intercom::store_error(err))
         }
     }
 }

--- a/intercom-attributes/tests/data/macro/com_interface.rs.stdout
+++ b/intercom-attributes/tests/data/macro/com_interface.rs.stdout
@@ -40,92 +40,92 @@ pub struct __IntercomVtableForFoo_Automation {
                                                      intercom::RawComPtr)
                            ->
                                <() as
-                               intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+                               intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
     pub arg_method: unsafe extern "system" fn(self_vtable:
                                                   intercom::RawComPtr,
                                               a:
                                                   <u16 as
-                                                  intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType)
+                                                  intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
                         ->
                             <() as
-                            intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+                            intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
     pub simple_result_method: unsafe extern "system" fn(self_vtable:
                                                             intercom::RawComPtr)
                                   ->
                                       <u16 as
-                                      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+                                      intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
     pub com_result_method: unsafe extern "system" fn(self_vtable:
                                                          intercom::RawComPtr,
                                                      __out:
                                                          *mut <u16 as
-                                                              intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
+                                                              intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
                                ->
                                    <intercom::raw::HRESULT as
-                                   intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+                                   intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
     pub rust_result_method: unsafe extern "system" fn(self_vtable:
                                                           intercom::RawComPtr,
                                                       __out:
                                                           *mut <u16 as
-                                                               intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
+                                                               intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
                                 ->
                                     <intercom::raw::HRESULT as
-                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+                                    intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
     pub complete_method: unsafe extern "system" fn(self_vtable:
                                                        intercom::RawComPtr,
                                                    a:
                                                        <u16 as
-                                                       intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
+                                                       intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
                                                    b:
                                                        <i16 as
-                                                       intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
+                                                       intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
                                                    __out:
                                                        *mut <bool as
-                                                            intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
+                                                            intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
                              ->
                                  <intercom::raw::HRESULT as
-                                 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+                                 intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
     pub string_method: unsafe extern "system" fn(self_vtable:
                                                      intercom::RawComPtr,
                                                  msg:
                                                      <String as
-                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType)
+                                                     intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
                            ->
                                <String as
-                               intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+                               intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
     pub comitf_method: unsafe extern "system" fn(self_vtable:
                                                      intercom::RawComPtr,
                                                  itf:
                                                      <ComItf<dyn Foo> as
-                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
+                                                     intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
                                                  __out:
                                                      *mut <ComItf<dyn IUnknown>
                                                           as
-                                                          intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
+                                                          intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
                            ->
                                <intercom::raw::HRESULT as
-                               intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+                               intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
     pub bool_method: unsafe extern "system" fn(self_vtable:
                                                    intercom::RawComPtr,
                                                input:
                                                    <bool as
-                                                   intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
+                                                   intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
                                                __out:
                                                    *mut <bool as
-                                                        intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
+                                                        intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
                          ->
                              <intercom::raw::HRESULT as
-                             intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+                             intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
     pub variant_method: unsafe extern "system" fn(self_vtable:
                                                       intercom::RawComPtr,
                                                   input:
                                                       <Variant as
-                                                      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType,
+                                                      intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
                                                   __out:
                                                       *mut <Variant as
-                                                           intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType)
+                                                           intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
                             ->
                                 <intercom::raw::HRESULT as
-                                intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+                                intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
 }
 #[allow(non_camel_case_types)]
 #[allow(non_snake_case)]
@@ -154,92 +154,92 @@ pub struct __IntercomVtableForFoo_Raw {
                                                      intercom::RawComPtr)
                            ->
                                <() as
-                               intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+                               intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
     pub arg_method: unsafe extern "system" fn(self_vtable:
                                                   intercom::RawComPtr,
                                               a:
                                                   <u16 as
-                                                  intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType)
+                                                  intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType)
                         ->
                             <() as
-                            intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+                            intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
     pub simple_result_method: unsafe extern "system" fn(self_vtable:
                                                             intercom::RawComPtr)
                                   ->
                                       <u16 as
-                                      intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
+                                      intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType,
     pub com_result_method: unsafe extern "system" fn(self_vtable:
                                                          intercom::RawComPtr,
                                                      __out:
                                                          *mut <u16 as
-                                                              intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
+                                                              intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType)
                                ->
                                    <intercom::raw::HRESULT as
-                                   intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
+                                   intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType,
     pub rust_result_method: unsafe extern "system" fn(self_vtable:
                                                           intercom::RawComPtr,
                                                       __out:
                                                           *mut <u16 as
-                                                               intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
+                                                               intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType)
                                 ->
                                     <intercom::raw::HRESULT as
-                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
+                                    intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType,
     pub complete_method: unsafe extern "system" fn(self_vtable:
                                                        intercom::RawComPtr,
                                                    a:
                                                        <u16 as
-                                                       intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
+                                                       intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
                                                    b:
                                                        <i16 as
-                                                       intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
+                                                       intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
                                                    __out:
                                                        *mut <bool as
-                                                            intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
+                                                            intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType)
                              ->
                                  <intercom::raw::HRESULT as
-                                 intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
+                                 intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType,
     pub string_method: unsafe extern "system" fn(self_vtable:
                                                      intercom::RawComPtr,
                                                  msg:
                                                      <String as
-                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType)
+                                                     intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType)
                            ->
                                <String as
-                               intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
+                               intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType,
     pub comitf_method: unsafe extern "system" fn(self_vtable:
                                                      intercom::RawComPtr,
                                                  itf:
                                                      <ComItf<dyn Foo> as
-                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
+                                                     intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
                                                  __out:
                                                      *mut <ComItf<dyn IUnknown>
                                                           as
-                                                          intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
+                                                          intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType)
                            ->
                                <intercom::raw::HRESULT as
-                               intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
+                               intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType,
     pub bool_method: unsafe extern "system" fn(self_vtable:
                                                    intercom::RawComPtr,
                                                input:
                                                    <bool as
-                                                   intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
+                                                   intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
                                                __out:
                                                    *mut <bool as
-                                                        intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
+                                                        intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType)
                          ->
                              <intercom::raw::HRESULT as
-                             intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
+                             intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType,
     pub variant_method: unsafe extern "system" fn(self_vtable:
                                                       intercom::RawComPtr,
                                                   input:
                                                       <Variant as
-                                                      intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType,
+                                                      intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
                                                   __out:
                                                       *mut <Variant as
-                                                           intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType)
+                                                           intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType)
                             ->
                                 <intercom::raw::HRESULT as
-                                intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType,
+                                intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType,
 }
 #[allow(non_camel_case_types)]
 #[allow(non_snake_case)]
@@ -297,7 +297,6 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::AutomationTypeSystem,
@@ -306,10 +305,10 @@ impl Foo for intercom::ComItf<dyn Foo> {
             let __intercom_result: Result<(), intercom::ComError> = (|| unsafe {
                 let __result = ((**vtbl).arg_method)(
                     comptr.ptr,
-                    (&<u16 as intercom::type_system::ExternType<
+                    <u16 as intercom::type_system::ExternInput<
                         intercom::type_system::AutomationTypeSystem,
-                    >>::intercom_from(a)?)
-                        .intercom_into()?,
+                    >>::into_foreign_parameter(a)?
+                    .0,
                 );
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
@@ -345,7 +344,6 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::RawTypeSystem,
@@ -354,10 +352,10 @@ impl Foo for intercom::ComItf<dyn Foo> {
             let __intercom_result: Result<(), intercom::ComError> = (|| unsafe {
                 let __result = ((**vtbl).arg_method)(
                     comptr.ptr,
-                    (&<u16 as intercom::type_system::ExternType<
+                    <u16 as intercom::type_system::ExternInput<
                         intercom::type_system::RawTypeSystem,
-                    >>::intercom_from(a)?)
-                        .intercom_into()?,
+                    >>::into_foreign_parameter(a)?
+                    .0,
                 );
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
@@ -413,22 +411,21 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::AutomationTypeSystem,
                 >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<ComResult<bool>, intercom::ComError> = (|| unsafe {
-                let mut __out: <bool as intercom::type_system::ExternType<
+                let mut __out: <bool as intercom::type_system::ExternOutput<
                     intercom::type_system::AutomationTypeSystem,
-                >>::ExternOutputType = intercom::type_system::ExternDefault::extern_default();
+                >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).bool_method)(
                     comptr.ptr,
-                    (&<bool as intercom::type_system::ExternType<
+                    <bool as intercom::type_system::ExternInput<
                         intercom::type_system::AutomationTypeSystem,
-                    >>::intercom_from(input)?)
-                        .intercom_into()?,
+                    >>::into_foreign_parameter(input)?
+                    .0,
                     &mut __out,
                 );
                 let __intercom_iid = intercom::GUID {
@@ -439,7 +436,9 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 };
                 Ok({
                     if __result == intercom::raw::S_OK || __result == intercom::raw::S_FALSE {
-                        Ok(__out.intercom_into()?)
+                        Ok(<bool as intercom::type_system::ExternOutput<
+                            intercom::type_system::AutomationTypeSystem,
+                        >>::from_foreign_output(__out)?)
                     } else {
                         return Err(intercom::load_error(
                             self.as_ref(),
@@ -475,22 +474,21 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::RawTypeSystem,
                 >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<ComResult<bool>, intercom::ComError> = (|| unsafe {
-                let mut __out: <bool as intercom::type_system::ExternType<
+                let mut __out: <bool as intercom::type_system::ExternOutput<
                     intercom::type_system::RawTypeSystem,
-                >>::ExternOutputType = intercom::type_system::ExternDefault::extern_default();
+                >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).bool_method)(
                     comptr.ptr,
-                    (&<bool as intercom::type_system::ExternType<
+                    <bool as intercom::type_system::ExternInput<
                         intercom::type_system::RawTypeSystem,
-                    >>::intercom_from(input)?)
-                        .intercom_into()?,
+                    >>::into_foreign_parameter(input)?
+                    .0,
                     &mut __out,
                 );
                 let __intercom_iid = intercom::GUID {
@@ -501,7 +499,9 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 };
                 Ok({
                     if __result == intercom::raw::S_OK || __result == intercom::raw::S_FALSE {
-                        Ok(__out.intercom_into()?)
+                        Ok(<bool as intercom::type_system::ExternOutput<
+                            intercom::type_system::RawTypeSystem,
+                        >>::from_foreign_output(__out)?)
                     } else {
                         return Err(intercom::load_error(
                             self.as_ref(),
@@ -565,16 +565,15 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::AutomationTypeSystem,
                 >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<ComResult<u16>, intercom::ComError> = (|| unsafe {
-                let mut __out: <u16 as intercom::type_system::ExternType<
+                let mut __out: <u16 as intercom::type_system::ExternOutput<
                     intercom::type_system::AutomationTypeSystem,
-                >>::ExternOutputType = intercom::type_system::ExternDefault::extern_default();
+                >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).com_result_method)(comptr.ptr, &mut __out);
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
@@ -584,7 +583,9 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 };
                 Ok({
                     if __result == intercom::raw::S_OK || __result == intercom::raw::S_FALSE {
-                        Ok(__out.intercom_into()?)
+                        Ok(<u16 as intercom::type_system::ExternOutput<
+                            intercom::type_system::AutomationTypeSystem,
+                        >>::from_foreign_output(__out)?)
                     } else {
                         return Err(intercom::load_error(
                             self.as_ref(),
@@ -620,16 +621,15 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::RawTypeSystem,
                 >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<ComResult<u16>, intercom::ComError> = (|| unsafe {
-                let mut __out: <u16 as intercom::type_system::ExternType<
+                let mut __out: <u16 as intercom::type_system::ExternOutput<
                     intercom::type_system::RawTypeSystem,
-                >>::ExternOutputType = intercom::type_system::ExternDefault::extern_default();
+                >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).com_result_method)(comptr.ptr, &mut __out);
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
@@ -639,7 +639,9 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 };
                 Ok({
                     if __result == intercom::raw::S_OK || __result == intercom::raw::S_FALSE {
-                        Ok(__out.intercom_into()?)
+                        Ok(<u16 as intercom::type_system::ExternOutput<
+                            intercom::type_system::RawTypeSystem,
+                        >>::from_foreign_output(__out)?)
                     } else {
                         return Err(intercom::load_error(
                             self.as_ref(),
@@ -697,7 +699,6 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::AutomationTypeSystem,
@@ -707,15 +708,15 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 ComResult<ComItf<dyn IUnknown>>,
                 intercom::ComError,
             > = (|| unsafe {
-                let mut __out: <ComItf<dyn IUnknown> as intercom::type_system::ExternType<
+                let mut __out: <ComItf<dyn IUnknown> as intercom::type_system::ExternOutput<
                     intercom::type_system::AutomationTypeSystem,
-                >>::ExternOutputType = intercom::type_system::ExternDefault::extern_default();
+                >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).comitf_method)(
                     comptr.ptr,
-                    (&<ComItf<dyn Foo> as intercom::type_system::ExternType<
+                    <ComItf<dyn Foo> as intercom::type_system::ExternInput<
                         intercom::type_system::AutomationTypeSystem,
-                    >>::intercom_from(itf)?)
-                        .intercom_into()?,
+                    >>::into_foreign_parameter(itf)?
+                    .0,
                     &mut __out,
                 );
                 let __intercom_iid = intercom::GUID {
@@ -726,7 +727,11 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 };
                 Ok({
                     if __result == intercom::raw::S_OK || __result == intercom::raw::S_FALSE {
-                        Ok(__out.intercom_into()?)
+                        Ok(
+                            <ComItf<dyn IUnknown> as intercom::type_system::ExternOutput<
+                                intercom::type_system::AutomationTypeSystem,
+                            >>::from_foreign_output(__out)?,
+                        )
                     } else {
                         return Err(intercom::load_error(
                             self.as_ref(),
@@ -764,7 +769,6 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::RawTypeSystem,
@@ -774,15 +778,15 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 ComResult<ComItf<dyn IUnknown>>,
                 intercom::ComError,
             > = (|| unsafe {
-                let mut __out: <ComItf<dyn IUnknown> as intercom::type_system::ExternType<
+                let mut __out: <ComItf<dyn IUnknown> as intercom::type_system::ExternOutput<
                     intercom::type_system::RawTypeSystem,
-                >>::ExternOutputType = intercom::type_system::ExternDefault::extern_default();
+                >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).comitf_method)(
                     comptr.ptr,
-                    (&<ComItf<dyn Foo> as intercom::type_system::ExternType<
+                    <ComItf<dyn Foo> as intercom::type_system::ExternInput<
                         intercom::type_system::RawTypeSystem,
-                    >>::intercom_from(itf)?)
-                        .intercom_into()?,
+                    >>::into_foreign_parameter(itf)?
+                    .0,
                     &mut __out,
                 );
                 let __intercom_iid = intercom::GUID {
@@ -793,7 +797,11 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 };
                 Ok({
                     if __result == intercom::raw::S_OK || __result == intercom::raw::S_FALSE {
-                        Ok(__out.intercom_into()?)
+                        Ok(
+                            <ComItf<dyn IUnknown> as intercom::type_system::ExternOutput<
+                                intercom::type_system::RawTypeSystem,
+                            >>::from_foreign_output(__out)?,
+                        )
                     } else {
                         return Err(intercom::load_error(
                             self.as_ref(),
@@ -859,26 +867,25 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::AutomationTypeSystem,
                 >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<ComResult<bool>, intercom::ComError> = (|| unsafe {
-                let mut __out: <bool as intercom::type_system::ExternType<
+                let mut __out: <bool as intercom::type_system::ExternOutput<
                     intercom::type_system::AutomationTypeSystem,
-                >>::ExternOutputType = intercom::type_system::ExternDefault::extern_default();
+                >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).complete_method)(
                     comptr.ptr,
-                    (&<u16 as intercom::type_system::ExternType<
+                    <u16 as intercom::type_system::ExternInput<
                         intercom::type_system::AutomationTypeSystem,
-                    >>::intercom_from(a)?)
-                        .intercom_into()?,
-                    (&<i16 as intercom::type_system::ExternType<
+                    >>::into_foreign_parameter(a)?
+                    .0,
+                    <i16 as intercom::type_system::ExternInput<
                         intercom::type_system::AutomationTypeSystem,
-                    >>::intercom_from(b)?)
-                        .intercom_into()?,
+                    >>::into_foreign_parameter(b)?
+                    .0,
                     &mut __out,
                 );
                 let __intercom_iid = intercom::GUID {
@@ -889,7 +896,9 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 };
                 Ok({
                     if __result == intercom::raw::S_OK || __result == intercom::raw::S_FALSE {
-                        Ok(__out.intercom_into()?)
+                        Ok(<bool as intercom::type_system::ExternOutput<
+                            intercom::type_system::AutomationTypeSystem,
+                        >>::from_foreign_output(__out)?)
                     } else {
                         return Err(intercom::load_error(
                             self.as_ref(),
@@ -925,26 +934,25 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::RawTypeSystem,
                 >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<ComResult<bool>, intercom::ComError> = (|| unsafe {
-                let mut __out: <bool as intercom::type_system::ExternType<
+                let mut __out: <bool as intercom::type_system::ExternOutput<
                     intercom::type_system::RawTypeSystem,
-                >>::ExternOutputType = intercom::type_system::ExternDefault::extern_default();
+                >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).complete_method)(
                     comptr.ptr,
-                    (&<u16 as intercom::type_system::ExternType<
+                    <u16 as intercom::type_system::ExternInput<
                         intercom::type_system::RawTypeSystem,
-                    >>::intercom_from(a)?)
-                        .intercom_into()?,
-                    (&<i16 as intercom::type_system::ExternType<
+                    >>::into_foreign_parameter(a)?
+                    .0,
+                    <i16 as intercom::type_system::ExternInput<
                         intercom::type_system::RawTypeSystem,
-                    >>::intercom_from(b)?)
-                        .intercom_into()?,
+                    >>::into_foreign_parameter(b)?
+                    .0,
                     &mut __out,
                 );
                 let __intercom_iid = intercom::GUID {
@@ -955,7 +963,9 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 };
                 Ok({
                     if __result == intercom::raw::S_OK || __result == intercom::raw::S_FALSE {
-                        Ok(__out.intercom_into()?)
+                        Ok(<bool as intercom::type_system::ExternOutput<
+                            intercom::type_system::RawTypeSystem,
+                        >>::from_foreign_output(__out)?)
                     } else {
                         return Err(intercom::load_error(
                             self.as_ref(),
@@ -1019,16 +1029,15 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::AutomationTypeSystem,
                 >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<Result<u16, i32>, intercom::ComError> = (|| unsafe {
-                let mut __out: <u16 as intercom::type_system::ExternType<
+                let mut __out: <u16 as intercom::type_system::ExternOutput<
                     intercom::type_system::AutomationTypeSystem,
-                >>::ExternOutputType = intercom::type_system::ExternDefault::extern_default();
+                >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).rust_result_method)(comptr.ptr, &mut __out);
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
@@ -1038,7 +1047,9 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 };
                 Ok({
                     if __result == intercom::raw::S_OK || __result == intercom::raw::S_FALSE {
-                        Ok(__out.intercom_into()?)
+                        Ok(<u16 as intercom::type_system::ExternOutput<
+                            intercom::type_system::AutomationTypeSystem,
+                        >>::from_foreign_output(__out)?)
                     } else {
                         return Err(intercom::load_error(
                             self.as_ref(),
@@ -1074,16 +1085,15 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::RawTypeSystem,
                 >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<Result<u16, i32>, intercom::ComError> = (|| unsafe {
-                let mut __out: <u16 as intercom::type_system::ExternType<
+                let mut __out: <u16 as intercom::type_system::ExternOutput<
                     intercom::type_system::RawTypeSystem,
-                >>::ExternOutputType = intercom::type_system::ExternDefault::extern_default();
+                >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).rust_result_method)(comptr.ptr, &mut __out);
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
@@ -1093,7 +1103,9 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 };
                 Ok({
                     if __result == intercom::raw::S_OK || __result == intercom::raw::S_FALSE {
-                        Ok(__out.intercom_into()?)
+                        Ok(<u16 as intercom::type_system::ExternOutput<
+                            intercom::type_system::RawTypeSystem,
+                        >>::from_foreign_output(__out)?)
                     } else {
                         return Err(intercom::load_error(
                             self.as_ref(),
@@ -1151,7 +1163,6 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::AutomationTypeSystem,
@@ -1193,7 +1204,6 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::RawTypeSystem,
@@ -1261,7 +1271,6 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::AutomationTypeSystem,
@@ -1275,7 +1284,11 @@ impl Foo for intercom::ComItf<dyn Foo> {
                     data3: 0u16,
                     data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8],
                 };
-                Ok({ __result.intercom_into()? })
+                Ok({
+                    <u16 as intercom::type_system::ExternOutput<
+                        intercom::type_system::AutomationTypeSystem,
+                    >>::from_foreign_output(__result)?
+                })
             })();
             return match __intercom_result {
                 Ok(v) => v,
@@ -1303,7 +1316,6 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::RawTypeSystem,
@@ -1317,7 +1329,11 @@ impl Foo for intercom::ComItf<dyn Foo> {
                     data3: 0u16,
                     data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8],
                 };
-                Ok({ __result.intercom_into()? })
+                Ok({
+                    <u16 as intercom::type_system::ExternOutput<
+                        intercom::type_system::RawTypeSystem,
+                    >>::from_foreign_output(__result)?
+                })
             })();
             return match __intercom_result {
                 Ok(v) => v,
@@ -1365,7 +1381,6 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::AutomationTypeSystem,
@@ -1374,10 +1389,10 @@ impl Foo for intercom::ComItf<dyn Foo> {
             let __intercom_result: Result<String, intercom::ComError> = (|| unsafe {
                 let __result = ((**vtbl).string_method)(
                     comptr.ptr,
-                    (&<String as intercom::type_system::ExternType<
+                    <String as intercom::type_system::ExternInput<
                         intercom::type_system::AutomationTypeSystem,
-                    >>::intercom_from(msg)?)
-                        .intercom_into()?,
+                    >>::into_foreign_parameter(msg)?
+                    .0,
                 );
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
@@ -1385,7 +1400,11 @@ impl Foo for intercom::ComItf<dyn Foo> {
                     data3: 0u16,
                     data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8],
                 };
-                Ok({ __result.intercom_into()? })
+                Ok({
+                    <String as intercom::type_system::ExternOutput<
+                        intercom::type_system::AutomationTypeSystem,
+                    >>::from_foreign_output(__result)?
+                })
             })();
             return match __intercom_result {
                 Ok(v) => v,
@@ -1413,7 +1432,6 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::RawTypeSystem,
@@ -1422,10 +1440,10 @@ impl Foo for intercom::ComItf<dyn Foo> {
             let __intercom_result: Result<String, intercom::ComError> = (|| unsafe {
                 let __result = ((**vtbl).string_method)(
                     comptr.ptr,
-                    (&<String as intercom::type_system::ExternType<
+                    <String as intercom::type_system::ExternInput<
                         intercom::type_system::RawTypeSystem,
-                    >>::intercom_from(msg)?)
-                        .intercom_into()?,
+                    >>::into_foreign_parameter(msg)?
+                    .0,
                 );
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
@@ -1433,7 +1451,11 @@ impl Foo for intercom::ComItf<dyn Foo> {
                     data3: 0u16,
                     data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8],
                 };
-                Ok({ __result.intercom_into()? })
+                Ok({
+                    <String as intercom::type_system::ExternOutput<
+                        intercom::type_system::RawTypeSystem,
+                    >>::from_foreign_output(__result)?
+                })
             })();
             return match __intercom_result {
                 Ok(v) => v,
@@ -1481,22 +1503,21 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::AutomationTypeSystem,
                 >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<ComResult<Variant>, intercom::ComError> = (|| unsafe {
-                let mut __out: <Variant as intercom::type_system::ExternType<
+                let mut __out: <Variant as intercom::type_system::ExternOutput<
                     intercom::type_system::AutomationTypeSystem,
-                >>::ExternOutputType = intercom::type_system::ExternDefault::extern_default();
+                >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).variant_method)(
                     comptr.ptr,
-                    (&<Variant as intercom::type_system::ExternType<
+                    <Variant as intercom::type_system::ExternInput<
                         intercom::type_system::AutomationTypeSystem,
-                    >>::intercom_from(input)?)
-                        .intercom_into()?,
+                    >>::into_foreign_parameter(input)?
+                    .0,
                     &mut __out,
                 );
                 let __intercom_iid = intercom::GUID {
@@ -1507,7 +1528,9 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 };
                 Ok({
                     if __result == intercom::raw::S_OK || __result == intercom::raw::S_FALSE {
-                        Ok(__out.intercom_into()?)
+                        Ok(<Variant as intercom::type_system::ExternOutput<
+                            intercom::type_system::AutomationTypeSystem,
+                        >>::from_foreign_output(__out)?)
                     } else {
                         return Err(intercom::load_error(
                             self.as_ref(),
@@ -1544,22 +1567,21 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::RawTypeSystem,
                 >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<ComResult<Variant>, intercom::ComError> = (|| unsafe {
-                let mut __out: <Variant as intercom::type_system::ExternType<
+                let mut __out: <Variant as intercom::type_system::ExternOutput<
                     intercom::type_system::RawTypeSystem,
-                >>::ExternOutputType = intercom::type_system::ExternDefault::extern_default();
+                >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).variant_method)(
                     comptr.ptr,
-                    (&<Variant as intercom::type_system::ExternType<
+                    <Variant as intercom::type_system::ExternInput<
                         intercom::type_system::RawTypeSystem,
-                    >>::intercom_from(input)?)
-                        .intercom_into()?,
+                    >>::into_foreign_parameter(input)?
+                    .0,
                     &mut __out,
                 );
                 let __intercom_iid = intercom::GUID {
@@ -1570,7 +1592,9 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 };
                 Ok({
                     if __result == intercom::raw::S_OK || __result == intercom::raw::S_FALSE {
-                        Ok(__out.intercom_into()?)
+                        Ok(<Variant as intercom::type_system::ExternOutput<
+                            intercom::type_system::RawTypeSystem,
+                        >>::from_foreign_output(__out)?)
                     } else {
                         return Err(intercom::load_error(
                             self.as_ref(),
@@ -1617,7 +1641,7 @@ impl intercom::ComInterface for dyn Foo {
         com_itf
     }
 }
-impl intercom::type_system::BidirectionalTypeInfo for dyn Foo {
+impl intercom::type_system::ForeignType for dyn Foo {
     #[doc = r" The name of the type."]
     fn type_name() -> &'static str {
         "Foo"
@@ -1681,15 +1705,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
                                                                                                                                                                                                                         intercom::typelib::Direction::In,}]),}),
                                                                                                                     intercom::ComBox::new(intercom::typelib::Method{name:
@@ -1700,15 +1724,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                ty:
                                                                                                                                                                                                    <<u16
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
-                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                       intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                indirection_level:
                                                                                                                                                                                                    <<u16
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
-                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                       intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                direction:
                                                                                                                                                                                                    intercom::typelib::Direction::Return,},
                                                                                                                                                                     parameters:
@@ -1722,15 +1746,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                ty:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
-                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                       intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                indirection_level:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
-                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                       intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                direction:
                                                                                                                                                                                                    intercom::typelib::Direction::Return,},
                                                                                                                                                                     parameters:
@@ -1740,15 +1764,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
                                                                                                                                                                                                                         intercom::typelib::Direction::Retval,}]),}),
                                                                                                                     intercom::ComBox::new(intercom::typelib::Method{name:
@@ -1759,15 +1783,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                ty:
                                                                                                                                                                                                    <<i32
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
-                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                       intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                indirection_level:
                                                                                                                                                                                                    <<i32
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
-                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                       intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                direction:
                                                                                                                                                                                                    intercom::typelib::Direction::Return,},
                                                                                                                                                                     parameters:
@@ -1777,15 +1801,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
                                                                                                                                                                                                                         intercom::typelib::Direction::Retval,}]),}),
                                                                                                                     intercom::ComBox::new(intercom::typelib::Method{name:
@@ -1796,15 +1820,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                ty:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
-                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                       intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                indirection_level:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
-                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                       intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                direction:
                                                                                                                                                                                                    intercom::typelib::Direction::Return,},
                                                                                                                                                                     parameters:
@@ -1814,15 +1838,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
                                                                                                                                                                                                                         intercom::typelib::Direction::In,},
                                                                                                                                                                                              intercom::typelib::Arg{name:
@@ -1830,15 +1854,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<i16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<i16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
                                                                                                                                                                                                                         intercom::typelib::Direction::In,},
                                                                                                                                                                                              intercom::typelib::Arg{name:
@@ -1846,15 +1870,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<bool
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<bool
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
                                                                                                                                                                                                                         intercom::typelib::Direction::Retval,}]),}),
                                                                                                                     intercom::ComBox::new(intercom::typelib::Method{name:
@@ -1865,15 +1889,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                ty:
                                                                                                                                                                                                    <<String
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
-                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                       intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                indirection_level:
                                                                                                                                                                                                    <<String
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
-                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                       intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                direction:
                                                                                                                                                                                                    intercom::typelib::Direction::Return,},
                                                                                                                                                                     parameters:
@@ -1883,15 +1907,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<String
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<String
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
                                                                                                                                                                                                                         intercom::typelib::Direction::In,}]),}),
                                                                                                                     intercom::ComBox::new(intercom::typelib::Method{name:
@@ -1902,15 +1926,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                ty:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
-                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                       intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                indirection_level:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
-                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                       intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                direction:
                                                                                                                                                                                                    intercom::typelib::Direction::Return,},
                                                                                                                                                                     parameters:
@@ -1920,15 +1944,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<ComItf<dyn Foo>
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<ComItf<dyn Foo>
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
                                                                                                                                                                                                                         intercom::typelib::Direction::In,},
                                                                                                                                                                                              intercom::typelib::Arg{name:
@@ -1936,15 +1960,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<ComItf<dyn IUnknown>
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<ComItf<dyn IUnknown>
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
                                                                                                                                                                                                                         intercom::typelib::Direction::Retval,}]),}),
                                                                                                                     intercom::ComBox::new(intercom::typelib::Method{name:
@@ -1955,15 +1979,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                ty:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
-                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                       intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                indirection_level:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
-                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                       intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                direction:
                                                                                                                                                                                                    intercom::typelib::Direction::Return,},
                                                                                                                                                                     parameters:
@@ -1973,15 +1997,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<bool
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<bool
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
                                                                                                                                                                                                                         intercom::typelib::Direction::In,},
                                                                                                                                                                                              intercom::typelib::Arg{name:
@@ -1989,15 +2013,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<bool
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<bool
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
                                                                                                                                                                                                                         intercom::typelib::Direction::Retval,}]),}),
                                                                                                                     intercom::ComBox::new(intercom::typelib::Method{name:
@@ -2008,15 +2032,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                ty:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
-                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                       intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                indirection_level:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
-                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                       intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                direction:
                                                                                                                                                                                                    intercom::typelib::Direction::Return,},
                                                                                                                                                                     parameters:
@@ -2026,15 +2050,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<Variant
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<Variant
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
                                                                                                                                                                                                                         intercom::typelib::Direction::In,},
                                                                                                                                                                                              intercom::typelib::Arg{name:
@@ -2042,15 +2066,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<Variant
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<Variant
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
                                                                                                                                                                                                                         intercom::typelib::Direction::Retval,}]),})]),}),
                                  intercom::ComBox::new(intercom::typelib::InterfaceVariant{ts:
@@ -2105,15 +2129,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
                                                                                                                                                                                                                         intercom::typelib::Direction::In,}]),}),
                                                                                                                     intercom::ComBox::new(intercom::typelib::Method{name:
@@ -2124,15 +2148,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                ty:
                                                                                                                                                                                                    <<u16
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
-                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                       intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                indirection_level:
                                                                                                                                                                                                    <<u16
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
-                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                       intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                direction:
                                                                                                                                                                                                    intercom::typelib::Direction::Return,},
                                                                                                                                                                     parameters:
@@ -2146,15 +2170,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                ty:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
-                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                       intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                indirection_level:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
-                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                       intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                direction:
                                                                                                                                                                                                    intercom::typelib::Direction::Return,},
                                                                                                                                                                     parameters:
@@ -2164,15 +2188,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
                                                                                                                                                                                                                         intercom::typelib::Direction::Retval,}]),}),
                                                                                                                     intercom::ComBox::new(intercom::typelib::Method{name:
@@ -2183,15 +2207,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                ty:
                                                                                                                                                                                                    <<i32
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
-                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                       intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                indirection_level:
                                                                                                                                                                                                    <<i32
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
-                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                       intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                direction:
                                                                                                                                                                                                    intercom::typelib::Direction::Return,},
                                                                                                                                                                     parameters:
@@ -2201,15 +2225,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
                                                                                                                                                                                                                         intercom::typelib::Direction::Retval,}]),}),
                                                                                                                     intercom::ComBox::new(intercom::typelib::Method{name:
@@ -2220,15 +2244,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                ty:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
-                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                       intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                indirection_level:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
-                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                       intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                direction:
                                                                                                                                                                                                    intercom::typelib::Direction::Return,},
                                                                                                                                                                     parameters:
@@ -2238,15 +2262,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
                                                                                                                                                                                                                         intercom::typelib::Direction::In,},
                                                                                                                                                                                              intercom::typelib::Arg{name:
@@ -2254,15 +2278,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<i16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<i16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
                                                                                                                                                                                                                         intercom::typelib::Direction::In,},
                                                                                                                                                                                              intercom::typelib::Arg{name:
@@ -2270,15 +2294,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<bool
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<bool
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
                                                                                                                                                                                                                         intercom::typelib::Direction::Retval,}]),}),
                                                                                                                     intercom::ComBox::new(intercom::typelib::Method{name:
@@ -2289,15 +2313,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                ty:
                                                                                                                                                                                                    <<String
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
-                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                       intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                indirection_level:
                                                                                                                                                                                                    <<String
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
-                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                       intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                direction:
                                                                                                                                                                                                    intercom::typelib::Direction::Return,},
                                                                                                                                                                     parameters:
@@ -2307,15 +2331,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<String
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<String
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
                                                                                                                                                                                                                         intercom::typelib::Direction::In,}]),}),
                                                                                                                     intercom::ComBox::new(intercom::typelib::Method{name:
@@ -2326,15 +2350,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                ty:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
-                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                       intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                indirection_level:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
-                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                       intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                direction:
                                                                                                                                                                                                    intercom::typelib::Direction::Return,},
                                                                                                                                                                     parameters:
@@ -2344,15 +2368,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<ComItf<dyn Foo>
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<ComItf<dyn Foo>
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
                                                                                                                                                                                                                         intercom::typelib::Direction::In,},
                                                                                                                                                                                              intercom::typelib::Arg{name:
@@ -2360,15 +2384,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<ComItf<dyn IUnknown>
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<ComItf<dyn IUnknown>
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
                                                                                                                                                                                                                         intercom::typelib::Direction::Retval,}]),}),
                                                                                                                     intercom::ComBox::new(intercom::typelib::Method{name:
@@ -2379,15 +2403,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                ty:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
-                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                       intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                indirection_level:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
-                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                       intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                direction:
                                                                                                                                                                                                    intercom::typelib::Direction::Return,},
                                                                                                                                                                     parameters:
@@ -2397,15 +2421,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<bool
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<bool
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
                                                                                                                                                                                                                         intercom::typelib::Direction::In,},
                                                                                                                                                                                              intercom::typelib::Arg{name:
@@ -2413,15 +2437,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<bool
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<bool
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
                                                                                                                                                                                                                         intercom::typelib::Direction::Retval,}]),}),
                                                                                                                     intercom::ComBox::new(intercom::typelib::Method{name:
@@ -2432,15 +2456,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                ty:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
-                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                       intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                indirection_level:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
-                                                                                                                                                                                                       intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                       intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                direction:
                                                                                                                                                                                                    intercom::typelib::Direction::Return,},
                                                                                                                                                                     parameters:
@@ -2450,15 +2474,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<Variant
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<Variant
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternInputType
+                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::InputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
                                                                                                                                                                                                                         intercom::typelib::Direction::In,},
                                                                                                                                                                                              intercom::typelib::Arg{name:
@@ -2466,15 +2490,15 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<Variant
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::type_name().into(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<Variant
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ExternOutputType
+                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
-                                                                                                                                                                                                                            intercom::type_system::OutputTypeInfo>::indirection_level(),
+                                                                                                                                                                                                                            intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
                                                                                                                                                                                                                         intercom::typelib::Direction::Retval,}]),})]),})]);
         <[_]>::into_vec(box [intercom::typelib::TypeInfo::Interface(

--- a/intercom-attributes/tests/data/macro/private_item.rs.stdout
+++ b/intercom-attributes/tests/data/macro/private_item.rs.stdout
@@ -21,9 +21,9 @@ struct __IntercomVtableForIFoo_Automation {
     >>::VTable,
     pub trait_method: unsafe extern "system" fn(
         self_vtable: intercom::RawComPtr,
-    ) -> <() as intercom::type_system::ExternType<
+    ) -> <() as intercom::type_system::ExternOutput<
         intercom::type_system::AutomationTypeSystem,
-    >>::ExternOutputType,
+    >>::ForeignType,
 }
 #[allow(non_camel_case_types)]
 #[allow(non_snake_case)]
@@ -51,9 +51,9 @@ struct __IntercomVtableForIFoo_Raw {
     >>::VTable,
     pub trait_method: unsafe extern "system" fn(
         self_vtable: intercom::RawComPtr,
-    ) -> <() as intercom::type_system::ExternType<
+    ) -> <() as intercom::type_system::ExternOutput<
         intercom::type_system::AutomationTypeSystem,
-    >>::ExternOutputType,
+    >>::ForeignType,
 }
 #[allow(non_camel_case_types)]
 #[allow(non_snake_case)]
@@ -111,7 +111,6 @@ impl IFoo for intercom::ComItf<dyn IFoo> {
                 )
             });
             #[allow(unused_imports)]
-            use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
                 as *const *const <dyn IFoo as intercom::attributes::ComInterface<
                     intercom::type_system::AutomationTypeSystem,
@@ -153,7 +152,6 @@ impl IFoo for intercom::ComItf<dyn IFoo> {
                 )
             });
             #[allow(unused_imports)]
-            use intercom::type_system::{IntercomFrom, IntercomInto};
             let vtbl = comptr.ptr
                 as *const *const <dyn IFoo as intercom::attributes::ComInterface<
                     intercom::type_system::RawTypeSystem,
@@ -203,7 +201,7 @@ impl intercom::ComInterface for dyn IFoo {
         com_itf
     }
 }
-impl intercom::type_system::BidirectionalTypeInfo for dyn IFoo {
+impl intercom::type_system::ForeignType for dyn IFoo {
     #[doc = r" The name of the type."]
     fn type_name() -> &'static str {
         "IFoo"
@@ -1216,15 +1214,15 @@ impl Foo {
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_Automation_query_interface(
     self_vtable: intercom::RawComPtr,
-    riid: <intercom::REFIID as intercom::type_system::ExternType<
+    riid: <intercom::REFIID as intercom::type_system::ExternInput<
         intercom::type_system::AutomationTypeSystem,
-    >>::ExternInputType,
-    out: *mut <intercom::RawComPtr as intercom::type_system::ExternType<
+    >>::ForeignType,
+    out: *mut <intercom::RawComPtr as intercom::type_system::ExternOutput<
         intercom::type_system::AutomationTypeSystem,
-    >>::ExternOutputType,
-) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
+    >>::ForeignType,
+) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
     intercom::type_system::AutomationTypeSystem,
->>::ExternOutputType {
+>>::ForeignType {
     let self_ptr = (self_vtable as usize
         - <Foo as intercom::attributes::ComClass<
             Foo,
@@ -1254,7 +1252,7 @@ unsafe extern "system" fn __Foo_Foo_Automation_add_ref(self_vtable:
                                                            intercom::RawComPtr)
  ->
      <u32 as
-intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
+intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
     let self_ptr = (self_vtable as usize
         - <Foo as intercom::attributes::ComClass<
             Foo,
@@ -1284,7 +1282,7 @@ unsafe extern "system" fn __Foo_Foo_Automation_release(self_vtable:
                                                            intercom::RawComPtr)
  ->
      <u32 as
-intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
+intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
     let self_ptr = (self_vtable as usize
         - <Foo as intercom::attributes::ComClass<
             Foo,
@@ -1314,16 +1312,15 @@ unsafe extern "system" fn __Foo_Foo_Automation_struct_method_Automation(self_vta
                                                                             intercom::RawComPtr)
  ->
      <() as
-intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
+intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
     let self_combox = (self_vtable as usize
         - <Foo as intercom::attributes::ComClass<
             Foo,
             intercom::type_system::AutomationTypeSystem,
         >>::offset()) as *mut intercom::ComBoxData<Foo>;
-    use intercom::type_system::{IntercomFrom, IntercomInto};
     let result:
             Result<<() as
-                   intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+                   intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
                    intercom::ComError> =
         (||
              {
@@ -1394,9 +1391,9 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
                     ),
                 )
             });
-            <<() as
-             intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                as ErrorValue>::from_error(intercom::store_error(err))
+            <<() as intercom::type_system::ExternOutput<
+                intercom::type_system::AutomationTypeSystem,
+            >>::ForeignType as ErrorValue>::from_error(intercom::store_error(err))
         }
     }
 }
@@ -1427,15 +1424,15 @@ impl intercom::attributes::ComImpl<Foo, intercom::type_system::AutomationTypeSys
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_Raw_query_interface(
     self_vtable: intercom::RawComPtr,
-    riid: <intercom::REFIID as intercom::type_system::ExternType<
+    riid: <intercom::REFIID as intercom::type_system::ExternInput<
         intercom::type_system::AutomationTypeSystem,
-    >>::ExternInputType,
-    out: *mut <intercom::RawComPtr as intercom::type_system::ExternType<
+    >>::ForeignType,
+    out: *mut <intercom::RawComPtr as intercom::type_system::ExternOutput<
         intercom::type_system::AutomationTypeSystem,
-    >>::ExternOutputType,
-) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
+    >>::ForeignType,
+) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
     intercom::type_system::AutomationTypeSystem,
->>::ExternOutputType {
+>>::ForeignType {
     let self_ptr =
         (self_vtable as usize -
              <Foo as
@@ -1466,7 +1463,7 @@ unsafe extern "system" fn __Foo_Foo_Raw_add_ref(self_vtable:
                                                     intercom::RawComPtr)
  ->
      <u32 as
-intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
+intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
     let self_ptr =
         (self_vtable as usize -
              <Foo as
@@ -1497,7 +1494,7 @@ unsafe extern "system" fn __Foo_Foo_Raw_release(self_vtable:
                                                     intercom::RawComPtr)
  ->
      <u32 as
-intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
+intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
     let self_ptr =
         (self_vtable as usize -
              <Foo as
@@ -1528,17 +1525,16 @@ unsafe extern "system" fn __Foo_Foo_Raw_struct_method_Raw(self_vtable:
                                                               intercom::RawComPtr)
  ->
      <() as
-intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
+intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
     let self_combox =
         (self_vtable as usize -
              <Foo as
                  intercom::attributes::ComClass<Foo,
                                                 intercom::type_system::RawTypeSystem>>::offset())
             as *mut intercom::ComBoxData<Foo>;
-    use intercom::type_system::{IntercomFrom, IntercomInto};
     let result:
             Result<<() as
-                   intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+                   intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
                    intercom::ComError> =
         (||
              {
@@ -1609,9 +1605,9 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
                     ),
                 )
             });
-            <<() as
-             intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                as ErrorValue>::from_error(intercom::store_error(err))
+            <<() as intercom::type_system::ExternOutput<
+                intercom::type_system::AutomationTypeSystem,
+            >>::ForeignType as ErrorValue>::from_error(intercom::store_error(err))
         }
     }
 }
@@ -1651,9 +1647,10 @@ pub struct __IntercomVtableForFoo_Automation {
     >>::VTable,
     pub struct_method: unsafe extern "system" fn(
         self_vtable: intercom::RawComPtr,
-    ) -> <() as intercom::type_system::ExternType<
+    )
+        -> <() as intercom::type_system::ExternOutput<
         intercom::type_system::AutomationTypeSystem,
-    >>::ExternOutputType,
+    >>::ForeignType,
 }
 #[allow(non_camel_case_types)]
 #[allow(non_snake_case)]
@@ -1681,9 +1678,10 @@ pub struct __IntercomVtableForFoo_Raw {
     >>::VTable,
     pub struct_method: unsafe extern "system" fn(
         self_vtable: intercom::RawComPtr,
-    ) -> <() as intercom::type_system::ExternType<
+    )
+        -> <() as intercom::type_system::ExternOutput<
         intercom::type_system::AutomationTypeSystem,
-    >>::ExternOutputType,
+    >>::ForeignType,
 }
 #[allow(non_camel_case_types)]
 #[allow(non_snake_case)]
@@ -1738,7 +1736,7 @@ impl intercom::ComInterface for Foo {
         }
     }
 }
-impl intercom::type_system::BidirectionalTypeInfo for Foo {
+impl intercom::type_system::ForeignType for Foo {
     #[doc = r" The name of the type."]
     fn type_name() -> &'static str {
         "Foo"
@@ -1807,15 +1805,15 @@ impl IFoo for Foo {
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_IFoo_Automation_query_interface(
     self_vtable: intercom::RawComPtr,
-    riid: <intercom::REFIID as intercom::type_system::ExternType<
+    riid: <intercom::REFIID as intercom::type_system::ExternInput<
         intercom::type_system::AutomationTypeSystem,
-    >>::ExternInputType,
-    out: *mut <intercom::RawComPtr as intercom::type_system::ExternType<
+    >>::ForeignType,
+    out: *mut <intercom::RawComPtr as intercom::type_system::ExternOutput<
         intercom::type_system::AutomationTypeSystem,
-    >>::ExternOutputType,
-) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
+    >>::ForeignType,
+) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
     intercom::type_system::AutomationTypeSystem,
->>::ExternOutputType {
+>>::ForeignType {
     let self_ptr = (self_vtable as usize
         - <Foo as intercom::attributes::ComClass<
             dyn IFoo,
@@ -1845,7 +1843,7 @@ unsafe extern "system" fn __Foo_IFoo_Automation_add_ref(self_vtable:
                                                             intercom::RawComPtr)
  ->
      <u32 as
-intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
+intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
     let self_ptr = (self_vtable as usize
         - <Foo as intercom::attributes::ComClass<
             dyn IFoo,
@@ -1875,7 +1873,7 @@ unsafe extern "system" fn __Foo_IFoo_Automation_release(self_vtable:
                                                             intercom::RawComPtr)
  ->
      <u32 as
-intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
+intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
     let self_ptr = (self_vtable as usize
         - <Foo as intercom::attributes::ComClass<
             dyn IFoo,
@@ -1905,16 +1903,15 @@ unsafe extern "system" fn __Foo_IFoo_Automation_trait_method_Automation(self_vta
                                                                             intercom::RawComPtr)
  ->
      <() as
-intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
+intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
     let self_combox = (self_vtable as usize
         - <Foo as intercom::attributes::ComClass<
             dyn IFoo,
             intercom::type_system::AutomationTypeSystem,
         >>::offset()) as *mut intercom::ComBoxData<Foo>;
-    use intercom::type_system::{IntercomFrom, IntercomInto};
     let result:
             Result<<() as
-                   intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+                   intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
                    intercom::ComError> =
         (||
              {
@@ -1985,9 +1982,9 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
                     ),
                 )
             });
-            <<() as
-             intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                as ErrorValue>::from_error(intercom::store_error(err))
+            <<() as intercom::type_system::ExternOutput<
+                intercom::type_system::AutomationTypeSystem,
+            >>::ForeignType as ErrorValue>::from_error(intercom::store_error(err))
         }
     }
 }
@@ -2018,15 +2015,15 @@ impl intercom::attributes::ComImpl<dyn IFoo, intercom::type_system::AutomationTy
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_IFoo_Raw_query_interface(
     self_vtable: intercom::RawComPtr,
-    riid: <intercom::REFIID as intercom::type_system::ExternType<
+    riid: <intercom::REFIID as intercom::type_system::ExternInput<
         intercom::type_system::AutomationTypeSystem,
-    >>::ExternInputType,
-    out: *mut <intercom::RawComPtr as intercom::type_system::ExternType<
+    >>::ForeignType,
+    out: *mut <intercom::RawComPtr as intercom::type_system::ExternOutput<
         intercom::type_system::AutomationTypeSystem,
-    >>::ExternOutputType,
-) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
+    >>::ForeignType,
+) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
     intercom::type_system::AutomationTypeSystem,
->>::ExternOutputType {
+>>::ForeignType {
     let self_ptr =
         (self_vtable as usize
             - <Foo as intercom::attributes::ComClass<
@@ -2057,7 +2054,7 @@ unsafe extern "system" fn __Foo_IFoo_Raw_add_ref(self_vtable:
                                                      intercom::RawComPtr)
  ->
      <u32 as
-intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
+intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
     let self_ptr =
         (self_vtable as usize
             - <Foo as intercom::attributes::ComClass<
@@ -2088,7 +2085,7 @@ unsafe extern "system" fn __Foo_IFoo_Raw_release(self_vtable:
                                                      intercom::RawComPtr)
  ->
      <u32 as
-intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
+intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
     let self_ptr =
         (self_vtable as usize
             - <Foo as intercom::attributes::ComClass<
@@ -2119,17 +2116,16 @@ unsafe extern "system" fn __Foo_IFoo_Raw_trait_method_Raw(self_vtable:
                                                               intercom::RawComPtr)
  ->
      <() as
-intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType{
+intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
     let self_combox =
         (self_vtable as usize
             - <Foo as intercom::attributes::ComClass<
                 dyn IFoo,
                 intercom::type_system::RawTypeSystem,
             >>::offset()) as *mut intercom::ComBoxData<Foo>;
-    use intercom::type_system::{IntercomFrom, IntercomInto};
     let result:
             Result<<() as
-                   intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType,
+                   intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
                    intercom::ComError> =
         (||
              {
@@ -2200,9 +2196,9 @@ intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>:
                     ),
                 )
             });
-            <<() as
-             intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ExternOutputType
-                as ErrorValue>::from_error(intercom::store_error(err))
+            <<() as intercom::type_system::ExternOutput<
+                intercom::type_system::AutomationTypeSystem,
+            >>::ForeignType as ErrorValue>::from_error(intercom::store_error(err))
         }
     }
 }

--- a/intercom-attributes/tests/data/ui/span-externtype-error.rs.stderr
+++ b/intercom-attributes/tests/data/ui/span-externtype-error.rs.stderr
@@ -1,15 +1,27 @@
-error[E0277]: the trait bound `NotExternType: intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>` is not satisfied
+error[E0277]: the trait bound `NotExternType: intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>` is not satisfied
   --> span-externtype-error.rs:12:5
    |
 12 |     fn arg_type(&self, bad_type: NotExternType);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>` is not implemented for `NotExternType`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>` is not implemented for `NotExternType`
 
-error[E0277]: the trait bound `NotExternType: intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>` is not satisfied
+error[E0277]: the trait bound `NotExternType: intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>` is not satisfied
+  --> span-externtype-error.rs:14:5
+   |
+14 |     fn ret_type(&self) -> ComResult<NotExternType>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>` is not implemented for `NotExternType`
+
+error[E0277]: the trait bound `NotExternType: intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>` is not satisfied
   --> span-externtype-error.rs:12:5
    |
 12 |     fn arg_type(&self, bad_type: NotExternType);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>` is not implemented for `NotExternType`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>` is not implemented for `NotExternType`
 
-error: aborting due to 2 previous errors
+error[E0277]: the trait bound `NotExternType: intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>` is not satisfied
+  --> span-externtype-error.rs:14:5
+   |
+14 |     fn ret_type(&self) -> ComResult<NotExternType>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>` is not implemented for `NotExternType`
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/intercom-cli/src/embed/setup_configuration.rs
+++ b/intercom-cli/src/embed/setup_configuration.rs
@@ -18,19 +18,11 @@ const CLSID_SetupConfiguration: GUID = GUID {
 };
 
 #[repr(C)]
-#[derive(Default, BidirectionalTypeInfo, Debug)]
+#[derive(Default, ForeignType, ExternOutput, ExternInput, Debug)]
 pub struct FILETIME
 {
     low_part: u32,
     high_part: u32,
-}
-
-impl<TS: intercom::type_system::TypeSystem> intercom::type_system::ExternType<TS> for FILETIME
-{
-    type ExternInputType = Self;
-    type ExternOutputType = Self;
-    type OwnedExternType = Self;
-    type OwnedNativeType = Self;
 }
 
 #[com_interface(com_iid = "B41463C3-8866-43B5-BC33-2B0676F7F42E")]

--- a/intercom-common/src/attributes/com_impl.rs
+++ b/intercom-common/src/attributes/com_impl.rs
@@ -61,7 +61,7 @@ pub fn expand_com_impl(
             #[doc(hidden)]
             unsafe extern "system" fn #query_interface_ident(
                 self_vtable : intercom::RawComPtr,
-                riid : <intercom::REFIID as intercom::type_system::ExternParameter<
+                riid : <intercom::REFIID as intercom::type_system::ExternInput<
                         intercom::type_system::AutomationTypeSystem>>
                             ::ForeignType,
                 out : *mut <intercom::RawComPtr as intercom::type_system::ExternOutput<

--- a/intercom-common/src/attributes/com_impl.rs
+++ b/intercom-common/src/attributes/com_impl.rs
@@ -61,15 +61,15 @@ pub fn expand_com_impl(
             #[doc(hidden)]
             unsafe extern "system" fn #query_interface_ident(
                 self_vtable : intercom::RawComPtr,
-                riid : <intercom::REFIID as intercom::type_system::ExternType<
+                riid : <intercom::REFIID as intercom::type_system::ExternParameter<
                         intercom::type_system::AutomationTypeSystem>>
-                            ::ExternInputType,
-                out : *mut <intercom::RawComPtr as intercom::type_system::ExternType<
+                            ::ForeignType,
+                out : *mut <intercom::RawComPtr as intercom::type_system::ExternOutput<
                         intercom::type_system::AutomationTypeSystem>>
-                            ::ExternOutputType,
-            ) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
+                            ::ForeignType,
+            ) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
                     intercom::type_system::AutomationTypeSystem>>
-                        ::ExternOutputType
+                        ::ForeignType
             {
                 // Get the primary iunk interface by offsetting the current
                 // self_vtable with the vtable offset. Once we have the primary
@@ -93,9 +93,9 @@ pub fn expand_com_impl(
             #[doc(hidden)]
             unsafe extern "system" fn #add_ref_ident(
                 self_vtable : intercom::RawComPtr
-            ) -> <u32 as intercom::type_system::ExternType<
+            ) -> <u32 as intercom::type_system::ExternOutput<
                     intercom::type_system::AutomationTypeSystem>>
-                        ::ExternOutputType
+                        ::ForeignType
             {
                 let self_ptr = ( self_vtable as usize - #vtable_offset ) as *mut _;
                 intercom::logging::trace(|l| l(module_path!(), format_args!(
@@ -113,9 +113,9 @@ pub fn expand_com_impl(
             #[doc(hidden)]
             unsafe extern "system" fn #release_ident(
                 self_vtable : intercom::RawComPtr
-            ) -> <u32 as intercom::type_system::ExternType<
+            ) -> <u32 as intercom::type_system::ExternOutput<
                     intercom::type_system::AutomationTypeSystem>>
-                        ::ExternOutputType
+                        ::ForeignType
             {
                 let self_ptr = ( self_vtable as usize - #vtable_offset ) as *mut _;
                 intercom::logging::trace(|l| l(module_path!(), format_args!(
@@ -207,7 +207,6 @@ pub fn expand_com_impl(
                     let self_combox = ( self_vtable as usize - #vtable_offset )
                             as *mut intercom::ComBoxData< #struct_ident >;
 
-                    use intercom::type_system::{IntercomFrom, IntercomInto};
                     let result : Result< #ret_ty, intercom::ComError > = ( || {
                         intercom::logging::trace(|l| l(module_path!(), format_args!(
                             "[{:p}, through {:p}] Serving {}::{}",

--- a/intercom-common/src/attributes/com_interface.rs
+++ b/intercom-common/src/attributes/com_interface.rs
@@ -422,7 +422,6 @@ fn rust_to_com_delegate(
     // Construct the final method.
     quote_spanned!(method_info.signature_span =>
         #[allow(unused_imports)]
-        use intercom::type_system::{IntercomFrom, IntercomInto};
         let vtbl = comptr.ptr as *const *const <#maybe_dyn #itf_name as
             intercom::attributes::ComInterface<#ts_type>>::VTable;
 
@@ -499,11 +498,11 @@ fn create_typeinfo_for_variant(
                 intercom::typelib::Arg {
                     name: "".into(),
                     ty: <
-                        <#rt as intercom::type_system::ExternType<#ts_type>>::ExternOutputType
-                        as intercom::type_system::OutputTypeInfo>::type_name().into(),
+                        <#rt as intercom::type_system::ExternOutput<#ts_type>>::ForeignType
+                        as intercom::type_system::BidirectionalTypeInfo>::type_name().into(),
                     indirection_level: <
-                        <#rt as intercom::type_system::ExternType<#ts_type>>::ExternOutputType
-                        as intercom::type_system::OutputTypeInfo>::indirection_level(),
+                        <#rt as intercom::type_system::ExternOutput<#ts_type>>::ForeignType
+                        as intercom::type_system::BidirectionalTypeInfo>::indirection_level(),
                     direction: intercom::typelib::Direction::Return,
                 }),
             None => quote_spanned!(m.signature_span => intercom::typelib::Arg {
@@ -524,8 +523,8 @@ fn create_typeinfo_for_variant(
             }, arg.span);
 
             let ty_info_trait = Ident::new(match arg.dir {
-                Direction::Out | Direction::Retval => "OutputTypeInfo",
-                Direction::In => "InputTypeInfo",
+                Direction::Out | Direction::Retval => "BidirectionalTypeInfo",
+                Direction::In => "BidirectionalTypeInfo",
             }, arg.span);
 
             quote_spanned!(arg.span => intercom::typelib::Arg {

--- a/intercom-common/src/attributes/com_interface.rs
+++ b/intercom-common/src/attributes/com_interface.rs
@@ -217,7 +217,7 @@ pub fn expand_com_interface(
     // Implement type info for the interface.
     output.push(quote_spanned!(itf.span =>
 
-        impl intercom::type_system::BidirectionalTypeInfo for #maybe_dyn #itf_ident {
+        impl intercom::type_system::ForeignType for #maybe_dyn #itf_ident {
 
             /// The name of the type.
             fn type_name() -> &'static str { stringify!( #itf_ident )  }
@@ -499,10 +499,10 @@ fn create_typeinfo_for_variant(
                     name: "".into(),
                     ty: <
                         <#rt as intercom::type_system::ExternOutput<#ts_type>>::ForeignType
-                        as intercom::type_system::BidirectionalTypeInfo>::type_name().into(),
+                        as intercom::type_system::ForeignType>::type_name().into(),
                     indirection_level: <
                         <#rt as intercom::type_system::ExternOutput<#ts_type>>::ForeignType
-                        as intercom::type_system::BidirectionalTypeInfo>::indirection_level(),
+                        as intercom::type_system::ForeignType>::indirection_level(),
                     direction: intercom::typelib::Direction::Return,
                 }),
             None => quote_spanned!(m.signature_span => intercom::typelib::Arg {
@@ -523,8 +523,8 @@ fn create_typeinfo_for_variant(
             }, arg.span);
 
             let ty_info_trait = Ident::new(match arg.dir {
-                Direction::Out | Direction::Retval => "BidirectionalTypeInfo",
-                Direction::In => "BidirectionalTypeInfo",
+                Direction::Out | Direction::Retval => "ForeignType",
+                Direction::In => "ForeignType",
             }, arg.span);
 
             quote_spanned!(arg.span => intercom::typelib::Arg {

--- a/intercom-common/src/attributes/mod.rs
+++ b/intercom-common/src/attributes/mod.rs
@@ -14,4 +14,5 @@ pub use self::com_library::expand_com_library;
 
 mod type_info;
 pub use self::type_info::expand_bidirectional_type_info;
-pub use self::type_info::expand_derive_extern_type;
+pub use self::type_info::expand_derive_extern_output;
+pub use self::type_info::expand_derive_extern_parameter;

--- a/intercom-common/src/attributes/type_info.rs
+++ b/intercom-common/src/attributes/type_info.rs
@@ -24,11 +24,11 @@ pub fn expand_bidirectional_type_info(
     Ok(result.into())
 }
 
-/// Expands the `ExternParameter` derive attribute.
+/// Expands the `ExternInput` derive attribute.
 ///
 /// The attribute expansion results in the following items:
 ///
-/// - Implementation of the ExternParameter trait.
+/// - Implementation of the ExternInput trait.
 pub fn expand_derive_extern_parameter(
     item_tokens: TokenStreamNightly,
 ) -> Result<TokenStreamNightly, syn::Error>
@@ -39,20 +39,20 @@ pub fn expand_derive_extern_parameter(
 
     // Immpl requires the the generics in particular way.
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
-    let result = quote! { impl<TS: intercom::type_system::TypeSystem> #impl_generics intercom::type_system::ExternParameter<TS> for #name #ty_generics #where_clause {
+    let result = quote! { impl<TS: intercom::type_system::TypeSystem> #impl_generics intercom::type_system::ExternInput<TS> for #name #ty_generics #where_clause {
 
         type ForeignType = #name;
-        type IntoTemporary = ();
+        type Lease = ();
 
         #[inline(always)]
-        fn into_foreign_parameter(self) -> intercom::ComResult<(Self::ForeignType, Self::IntoTemporary)> {
+        fn into_foreign_parameter(self) -> intercom::ComResult<(Self::ForeignType, Self::Lease)> {
             Ok((self, ()))
         }
 
-        type OwnedParameter = #name;
+        type Owned = #name;
 
         #[inline(always)]
-        unsafe fn from_foreign_parameter(source: Self::ForeignType) -> intercom::ComResult<Self::OwnedParameter> {
+        unsafe fn from_foreign_parameter(source: Self::ForeignType) -> intercom::ComResult<Self::Owned> {
             Ok(source)
         }
     } };

--- a/intercom-common/src/attributes/type_info.rs
+++ b/intercom-common/src/attributes/type_info.rs
@@ -39,13 +39,13 @@ pub fn expand_derive_extern_parameter(
 
     // Immpl requires the the generics in particular way.
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
-    let result = quote! { impl<TS: intercom::type_system::TypeSystem> #impl_generics intercom::type_system::ExternInput<TS> for #name #ty_generics #where_clause {
+    let result = quote! { unsafe impl<TS: intercom::type_system::TypeSystem> #impl_generics intercom::type_system::ExternInput<TS> for #name #ty_generics #where_clause {
 
         type ForeignType = #name;
         type Lease = ();
 
         #[inline(always)]
-        fn into_foreign_parameter(self) -> intercom::ComResult<(Self::ForeignType, Self::Lease)> {
+        unsafe fn into_foreign_parameter(self) -> intercom::ComResult<(Self::ForeignType, Self::Lease)> {
             Ok((self, ()))
         }
 
@@ -73,9 +73,9 @@ pub fn expand_derive_extern_output(
     let input: syn::DeriveInput = syn::parse(item_tokens)?;
     let name = &input.ident;
 
-    // Immpl requires the the generics in particular way.
+    // Impl requires the the generics in particular way.
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
-    let result = quote! { impl<TS: intercom::type_system::TypeSystem> #impl_generics intercom::type_system::ExternOutput<TS> for #name #ty_generics #where_clause {
+    let result = quote! { unsafe impl<TS: intercom::type_system::TypeSystem> #impl_generics intercom::type_system::ExternOutput<TS> for #name #ty_generics #where_clause {
 
         type ForeignType = #name;
 

--- a/intercom-common/src/attributes/type_info.rs
+++ b/intercom-common/src/attributes/type_info.rs
@@ -1,10 +1,10 @@
 use crate::prelude::*;
 
-/// Expands the `BidirectionalTypeInfo` derive attribute.
+/// Expands the `ForeignType` derive attribute.
 ///
 /// The attribute expansion results in the following items:
 ///
-/// - Implementation of the BidirectionalTypeInfo trait.
+/// - Implementation of the ForeignType trait.
 pub fn expand_bidirectional_type_info(
     item_tokens: TokenStreamNightly,
 ) -> Result<TokenStreamNightly, syn::Error>
@@ -15,7 +15,7 @@ pub fn expand_bidirectional_type_info(
 
     // Immpl requires the the generics in particular way.
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
-    let result = quote! { impl #impl_generics intercom::type_system::BidirectionalTypeInfo for #name #ty_generics #where_clause {
+    let result = quote! { impl #impl_generics intercom::type_system::ForeignType for #name #ty_generics #where_clause {
 
         /// The default name is the name of the type.
         fn type_name() -> &'static str { stringify!( #name ) }

--- a/intercom-common/src/attributes/type_info.rs
+++ b/intercom-common/src/attributes/type_info.rs
@@ -24,12 +24,12 @@ pub fn expand_bidirectional_type_info(
     Ok(result.into())
 }
 
-/// Expands the `ExternType` derive attribute.
+/// Expands the `ExternParameter` derive attribute.
 ///
 /// The attribute expansion results in the following items:
 ///
-/// - Implementation of the ExternType trait.
-pub fn expand_derive_extern_type(
+/// - Implementation of the ExternParameter trait.
+pub fn expand_derive_extern_parameter(
     item_tokens: TokenStreamNightly,
 ) -> Result<TokenStreamNightly, syn::Error>
 {
@@ -39,12 +39,55 @@ pub fn expand_derive_extern_type(
 
     // Immpl requires the the generics in particular way.
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
-    let result = quote! { impl<TS: intercom::type_system::TypeSystem> #impl_generics intercom::type_system::ExternType<TS> for #name #ty_generics #where_clause {
+    let result = quote! { impl<TS: intercom::type_system::TypeSystem> #impl_generics intercom::type_system::ExternParameter<TS> for #name #ty_generics #where_clause {
 
-        type ExternInputType = #name;
-        type ExternOutputType = #name;
-        type OwnedExternType = #name;
-        type OwnedNativeType = #name;
+        type ForeignType = #name;
+        type IntoTemporary = ();
+
+        #[inline(always)]
+        fn into_foreign_parameter(self) -> intercom::ComResult<(Self::ForeignType, Self::IntoTemporary)> {
+            Ok((self, ()))
+        }
+
+        type OwnedParameter = #name;
+
+        #[inline(always)]
+        unsafe fn from_foreign_parameter(source: Self::ForeignType) -> intercom::ComResult<Self::OwnedParameter> {
+            Ok(source)
+        }
+    } };
+
+    Ok(result.into())
+}
+
+/// Expands the `ExternOutput` derive attribute.
+///
+/// The attribute expansion results in the following items:
+///
+/// - Implementation of the ExternOutput trait.
+pub fn expand_derive_extern_output(
+    item_tokens: TokenStreamNightly,
+) -> Result<TokenStreamNightly, syn::Error>
+{
+    // Get the name of the type we want to implement the trait for.
+    let input: syn::DeriveInput = syn::parse(item_tokens)?;
+    let name = &input.ident;
+
+    // Immpl requires the the generics in particular way.
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let result = quote! { impl<TS: intercom::type_system::TypeSystem> #impl_generics intercom::type_system::ExternOutput<TS> for #name #ty_generics #where_clause {
+
+        type ForeignType = #name;
+
+        #[inline(always)]
+        fn into_foreign_output(self) -> intercom::ComResult<Self::ForeignType> {
+            Ok(self)
+        }
+
+        #[inline(always)]
+        unsafe fn from_foreign_output(source: Self::ForeignType) -> intercom::ComResult<Self> {
+            Ok(source)
+        }
     } };
 
     Ok(result.into())

--- a/intercom-common/src/returnhandlers.rs
+++ b/intercom-common/src/returnhandlers.rs
@@ -142,8 +142,8 @@ impl ReturnHandler for ErrorResultHandler
         let ts = self.type_system.as_typesystem_type(self.span);
         syn::parse2(quote_spanned!(self.span=>
             < intercom::raw::HRESULT as
-                intercom::type_system::ExternType< #ts >>
-                    ::ExternOutputType ))
+                intercom::type_system::ExternOutput< #ts >>
+                    ::ForeignType ))
         .unwrap()
     }
 

--- a/intercom-common/src/tyhandlers.rs
+++ b/intercom-common/src/tyhandlers.rs
@@ -115,7 +115,7 @@ impl TypeHandler
 
         // Get the final type based on the parameter direction.
         let tr = match dir {
-            Direction::In => quote_spanned!(span => intercom::type_system::ExternParameter),
+            Direction::In => quote_spanned!(span => intercom::type_system::ExternInput),
             Direction::Out | Direction::Retval => {
                 quote_spanned!(span => intercom::type_system::ExternOutput)
             }
@@ -136,7 +136,7 @@ impl TypeHandler
         };
         match dir {
             Direction::In => quote_spanned!(span=>
-                    #maybe_ref <#ty as intercom::type_system::ExternParameter<#ts>>
+                    #maybe_ref <#ty as intercom::type_system::ExternInput<#ts>>
                         ::from_foreign_parameter(#ident)?),
             Direction::Out | Direction::Retval => quote_spanned!(span=>
                     <#ty as intercom::type_system::ExternOutput<#ts>>
@@ -152,7 +152,7 @@ impl TypeHandler
         let ts = self.context.type_system.as_typesystem_type(span);
         match dir {
             Direction::In => quote_spanned!(span=>
-                    <#ty as intercom::type_system::ExternParameter<#ts>>
+                    <#ty as intercom::type_system::ExternInput<#ts>>
                         ::into_foreign_parameter(#ident)?.0),
             Direction::Out | Direction::Retval => quote_spanned!(span=>
                     <#ty as intercom::type_system::ExternOutput<#ts>>

--- a/intercom-common/src/tyhandlers.rs
+++ b/intercom-common/src/tyhandlers.rs
@@ -112,18 +112,16 @@ impl TypeHandler
         // Construct bits for the quote.
         let ty = &self.ty;
         let ts = self.context.type_system.as_typesystem_type(span);
-        let ts_trait = quote_spanned!(
-            span=> <#ty as intercom::type_system::ExternType< #ts > > );
 
         // Get the final type based on the parameter direction.
-        match dir {
-            Direction::In => {
-                syn::parse2(quote_spanned!(span => #ts_trait::ExternInputType )).unwrap()
-            }
+        let tr = match dir {
+            Direction::In => quote_spanned!(span => intercom::type_system::ExternParameter),
             Direction::Out | Direction::Retval => {
-                syn::parse2(quote_spanned!(span => #ts_trait::ExternOutputType )).unwrap()
+                quote_spanned!(span => intercom::type_system::ExternOutput)
             }
-        }
+        };
+
+        syn::parse2(quote_spanned!(span => <#ty as #tr<#ts>>::ForeignType)).unwrap()
     }
 
     /// Converts a COM parameter named by the ident into a Rust type.
@@ -132,21 +130,17 @@ impl TypeHandler
         // Construct bits for the quote.
         let ty = &self.ty;
         let ts = self.context.type_system.as_typesystem_type(span);
-        let ts_trait = quote_spanned!(
-            span=> <#ty as intercom::type_system::ExternType< #ts > > );
-
+        let maybe_ref = match ty {
+            syn::Type::Reference(..) => quote!(&),
+            _ => quote!(),
+        };
         match dir {
-            Direction::In => {
-                // Input arguments may use an intermediate type.
-                let intermediate = quote_spanned!(
-                    span=> #ts_trait::OwnedNativeType::intercom_from( #ident )? );
-                quote_spanned!(span=> ( & #intermediate ).intercom_into()? )
-            }
-            Direction::Out | Direction::Retval => {
-                // Output arguments must not use an intermediate type
-                // as these must outlive the current function.
-                quote_spanned!(span=> #ident.intercom_into()? )
-            }
+            Direction::In => quote_spanned!(span=>
+                    #maybe_ref <#ty as intercom::type_system::ExternParameter<#ts>>
+                        ::from_foreign_parameter(#ident)?),
+            Direction::Out | Direction::Retval => quote_spanned!(span=>
+                    <#ty as intercom::type_system::ExternOutput<#ts>>
+                        ::from_foreign_output(#ident)?),
         }
     }
 
@@ -156,16 +150,13 @@ impl TypeHandler
         // Construct bits for the quote.
         let ty = &self.ty;
         let ts = self.context.type_system.as_typesystem_type(span);
-        let ts_trait = quote_spanned!(
-            span=> <#ty as intercom::type_system::ExternType< #ts > > );
-
         match dir {
-            Direction::In => {
-                let intermediate = quote_spanned!(
-                    span=> #ts_trait::OwnedExternType::intercom_from( #ident )? );
-                quote_spanned!(span=> ( & #intermediate ).intercom_into()? )
-            }
-            Direction::Out | Direction::Retval => quote_spanned!(span=> #ident.intercom_into()? ),
+            Direction::In => quote_spanned!(span=>
+                    <#ty as intercom::type_system::ExternParameter<#ts>>
+                        ::into_foreign_parameter(#ident)?.0),
+            Direction::Out | Direction::Retval => quote_spanned!(span=>
+                    <#ty as intercom::type_system::ExternOutput<#ts>>
+                        ::into_foreign_output(#ident)?),
         }
     }
 

--- a/intercom/src/comitf.rs
+++ b/intercom/src/comitf.rs
@@ -288,14 +288,15 @@ impl<T: ComInterface + ?Sized> std::ops::Deref for ComItf<T>
     }
 }
 
-impl<'a, TS: TypeSystem, I: crate::ComInterface + ?Sized> ExternInput<TS> for &'a crate::ComItf<I>
+unsafe impl<'a, TS: TypeSystem, I: crate::ComInterface + ?Sized> ExternInput<TS>
+    for &'a crate::ComItf<I>
 where
     I: ForeignType,
 {
     type ForeignType = crate::raw::InterfacePtr<TS, I>;
 
     type Lease = ();
-    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
+    unsafe fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
     {
         Ok((ComItf::ptr(self), ()))
     }

--- a/intercom/src/comitf.rs
+++ b/intercom/src/comitf.rs
@@ -290,7 +290,7 @@ impl<T: ComInterface + ?Sized> std::ops::Deref for ComItf<T>
 
 impl<'a, TS: TypeSystem, I: crate::ComInterface + ?Sized> ExternInput<TS> for &'a crate::ComItf<I>
 where
-    I: BidirectionalTypeInfo,
+    I: ForeignType,
 {
     type ForeignType = crate::raw::InterfacePtr<TS, I>;
 

--- a/intercom/src/comitf.rs
+++ b/intercom/src/comitf.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::type_system::{AutomationTypeSystem, ExternParameter, RawTypeSystem, TypeSystem};
+use crate::type_system::{AutomationTypeSystem, ExternInput, RawTypeSystem, TypeSystem};
 use std::marker::PhantomData;
 
 /// An incoming COM interface pointer.
@@ -288,21 +288,20 @@ impl<T: ComInterface + ?Sized> std::ops::Deref for ComItf<T>
     }
 }
 
-impl<'a, TS: TypeSystem, I: crate::ComInterface + ?Sized> ExternParameter<TS>
-    for &'a crate::ComItf<I>
+impl<'a, TS: TypeSystem, I: crate::ComInterface + ?Sized> ExternInput<TS> for &'a crate::ComItf<I>
 where
     I: BidirectionalTypeInfo,
 {
     type ForeignType = crate::raw::InterfacePtr<TS, I>;
 
-    type IntoTemporary = ();
-    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::IntoTemporary)>
+    type Lease = ();
+    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
     {
         Ok((ComItf::ptr(self), ()))
     }
 
-    type OwnedParameter = ComItf<I>;
-    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::OwnedParameter>
+    type Owned = ComItf<I>;
+    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::Owned>
     {
         crate::ComItf::maybe_wrap(source).ok_or_else(|| crate::ComError::E_INVALIDARG)
     }

--- a/intercom/src/comrc.rs
+++ b/intercom/src/comrc.rs
@@ -155,7 +155,7 @@ impl<T: ComInterface + ?Sized> std::borrow::Borrow<ComItf<T>> for ComRc<T>
 
 impl<TS: TypeSystem, I: crate::ComInterface + ?Sized> ExternInput<TS> for crate::ComRc<I>
 where
-    I: BidirectionalTypeInfo,
+    I: ForeignType,
 {
     type ForeignType = crate::raw::InterfacePtr<TS, I>;
 
@@ -174,7 +174,7 @@ where
 
 impl<TS: TypeSystem, I: crate::ComInterface + ?Sized> ExternOutput<TS> for crate::ComRc<I>
 where
-    I: BidirectionalTypeInfo,
+    I: ForeignType,
 {
     type ForeignType = crate::raw::InterfacePtr<TS, I>;
 

--- a/intercom/src/comrc.rs
+++ b/intercom/src/comrc.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::type_system::{ExternOutput, ExternParameter, TypeSystem};
+use crate::type_system::{ExternInput, ExternOutput, TypeSystem};
 
 /// Reference counted handle to the `ComBox` data.
 ///
@@ -153,19 +153,19 @@ impl<T: ComInterface + ?Sized> std::borrow::Borrow<ComItf<T>> for ComRc<T>
     }
 }
 
-impl<TS: TypeSystem, I: crate::ComInterface + ?Sized> ExternParameter<TS> for crate::ComRc<I>
+impl<TS: TypeSystem, I: crate::ComInterface + ?Sized> ExternInput<TS> for crate::ComRc<I>
 where
     I: BidirectionalTypeInfo,
 {
     type ForeignType = crate::raw::InterfacePtr<TS, I>;
 
-    type IntoTemporary = Self;
-    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::IntoTemporary)>
+    type Lease = Self;
+    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
     {
         Ok((ComItf::ptr(&self), self))
     }
 
-    type OwnedParameter = Self;
+    type Owned = Self;
     unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self>
     {
         ComRc::wrap(source).ok_or(ComError::E_POINTER)

--- a/intercom/src/comrc.rs
+++ b/intercom/src/comrc.rs
@@ -153,14 +153,14 @@ impl<T: ComInterface + ?Sized> std::borrow::Borrow<ComItf<T>> for ComRc<T>
     }
 }
 
-impl<TS: TypeSystem, I: crate::ComInterface + ?Sized> ExternInput<TS> for crate::ComRc<I>
+unsafe impl<TS: TypeSystem, I: crate::ComInterface + ?Sized> ExternInput<TS> for crate::ComRc<I>
 where
     I: ForeignType,
 {
     type ForeignType = crate::raw::InterfacePtr<TS, I>;
 
     type Lease = Self;
-    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
+    unsafe fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
     {
         Ok((ComItf::ptr(&self), self))
     }
@@ -172,7 +172,7 @@ where
     }
 }
 
-impl<TS: TypeSystem, I: crate::ComInterface + ?Sized> ExternOutput<TS> for crate::ComRc<I>
+unsafe impl<TS: TypeSystem, I: crate::ComInterface + ?Sized> ExternOutput<TS> for crate::ComRc<I>
 where
     I: ForeignType,
 {

--- a/intercom/src/comrc.rs
+++ b/intercom/src/comrc.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::type_system::TypeSystem;
+use crate::type_system::{ExternOutput, ExternParameter, TypeSystem};
 
 /// Reference counted handle to the `ComBox` data.
 ///
@@ -150,5 +150,43 @@ impl<T: ComInterface + ?Sized> std::borrow::Borrow<ComItf<T>> for ComRc<T>
     fn borrow(&self) -> &ComItf<T>
     {
         self.as_ref()
+    }
+}
+
+impl<TS: TypeSystem, I: crate::ComInterface + ?Sized> ExternParameter<TS> for crate::ComRc<I>
+where
+    I: BidirectionalTypeInfo,
+{
+    type ForeignType = crate::raw::InterfacePtr<TS, I>;
+
+    type IntoTemporary = Self;
+    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::IntoTemporary)>
+    {
+        Ok((ComItf::ptr(&self), self))
+    }
+
+    type OwnedParameter = Self;
+    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self>
+    {
+        ComRc::wrap(source).ok_or(ComError::E_POINTER)
+    }
+}
+
+impl<TS: TypeSystem, I: crate::ComInterface + ?Sized> ExternOutput<TS> for crate::ComRc<I>
+where
+    I: BidirectionalTypeInfo,
+{
+    type ForeignType = crate::raw::InterfacePtr<TS, I>;
+
+    fn into_foreign_output(self) -> ComResult<Self::ForeignType>
+    {
+        Ok(ComItf::ptr(&ComRc::detach(self)))
+    }
+
+    unsafe fn from_foreign_output(source: Self::ForeignType) -> ComResult<Self>
+    {
+        Ok(ComRc::attach(
+            ComItf::maybe_wrap(source).ok_or(ComError::E_POINTER)?,
+        ))
     }
 }

--- a/intercom/src/error.rs
+++ b/intercom/src/error.rs
@@ -40,7 +40,7 @@ impl std::fmt::Display for ComError
     }
 }
 
-impl<TS: TypeSystem> ExternOutput<TS> for ComError
+unsafe impl<TS: TypeSystem> ExternOutput<TS> for ComError
 {
     type ForeignType = raw::HRESULT;
 
@@ -58,7 +58,7 @@ impl<TS: TypeSystem> ExternOutput<TS> for ComError
     }
 }
 
-impl<TS: TypeSystem> ExternOutput<TS> for std::io::Error
+unsafe impl<TS: TypeSystem> ExternOutput<TS> for std::io::Error
 {
     type ForeignType = raw::HRESULT;
 

--- a/intercom/src/lib.rs
+++ b/intercom/src/lib.rs
@@ -142,9 +142,7 @@ pub type REFCLSID = *const IID;
 pub mod raw
 {
 
-    #[derive(
-        Clone, Copy, intercom_attributes::ExternInput, intercom_attributes::ForeignType,
-    )]
+    #[derive(Clone, Copy, intercom_attributes::ExternInput, intercom_attributes::ForeignType)]
     #[repr(transparent)]
     pub struct InBSTR(pub *const u16);
 

--- a/intercom/src/lib.rs
+++ b/intercom/src/lib.rs
@@ -100,7 +100,7 @@ mod variant;
 pub use crate::variant::{Variant, VariantError};
 pub mod type_system;
 pub mod typelib;
-pub use type_system::BidirectionalTypeInfo;
+pub use type_system::ForeignType;
 pub mod attributes;
 pub mod logging;
 
@@ -143,7 +143,7 @@ pub mod raw
 {
 
     #[derive(
-        Clone, Copy, intercom_attributes::ExternInput, intercom_attributes::BidirectionalTypeInfo,
+        Clone, Copy, intercom_attributes::ExternInput, intercom_attributes::ForeignType,
     )]
     #[repr(transparent)]
     pub struct InBSTR(pub *const u16);
@@ -153,7 +153,7 @@ pub mod raw
         Copy,
         intercom_attributes::ExternInput,
         intercom_attributes::ExternOutput,
-        intercom_attributes::BidirectionalTypeInfo,
+        intercom_attributes::ForeignType,
     )]
     #[repr(transparent)]
     pub struct OutBSTR(pub *mut u16);

--- a/intercom/src/lib.rs
+++ b/intercom/src/lib.rs
@@ -143,10 +143,7 @@ pub mod raw
 {
 
     #[derive(
-        Clone,
-        Copy,
-        intercom_attributes::ExternParameter,
-        intercom_attributes::BidirectionalTypeInfo,
+        Clone, Copy, intercom_attributes::ExternInput, intercom_attributes::BidirectionalTypeInfo,
     )]
     #[repr(transparent)]
     pub struct InBSTR(pub *const u16);
@@ -154,7 +151,7 @@ pub mod raw
     #[derive(
         Clone,
         Copy,
-        intercom_attributes::ExternParameter,
+        intercom_attributes::ExternInput,
         intercom_attributes::ExternOutput,
         intercom_attributes::BidirectionalTypeInfo,
     )]

--- a/intercom/src/lib.rs
+++ b/intercom/src/lib.rs
@@ -100,7 +100,7 @@ mod variant;
 pub use crate::variant::{Variant, VariantError};
 pub mod type_system;
 pub mod typelib;
-pub use type_system::{BidirectionalTypeInfo, InputTypeInfo, OutputTypeInfo};
+pub use type_system::BidirectionalTypeInfo;
 pub mod attributes;
 pub mod logging;
 
@@ -143,13 +143,20 @@ pub mod raw
 {
 
     #[derive(
-        Clone, Copy, intercom_attributes::ExternType, intercom_attributes::BidirectionalTypeInfo,
+        Clone,
+        Copy,
+        intercom_attributes::ExternParameter,
+        intercom_attributes::BidirectionalTypeInfo,
     )]
     #[repr(transparent)]
     pub struct InBSTR(pub *const u16);
 
     #[derive(
-        Clone, Copy, intercom_attributes::ExternType, intercom_attributes::BidirectionalTypeInfo,
+        Clone,
+        Copy,
+        intercom_attributes::ExternParameter,
+        intercom_attributes::ExternOutput,
+        intercom_attributes::BidirectionalTypeInfo,
     )]
     #[repr(transparent)]
     pub struct OutBSTR(pub *mut u16);

--- a/intercom/src/strings.rs
+++ b/intercom/src/strings.rs
@@ -523,12 +523,12 @@ impl TryFrom<IntercomString> for String
 }
 
 // String
-impl ExternInput<AutomationTypeSystem> for String
+unsafe impl ExternInput<AutomationTypeSystem> for String
 {
     type ForeignType = OutBSTR;
 
     type Lease = BString;
-    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
+    unsafe fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
     {
         log::trace!("String::into_foreign_parameter<Automation>");
         let bstring = BString::from_str(&self).expect("Error type is never type");
@@ -544,12 +544,12 @@ impl ExternInput<AutomationTypeSystem> for String
     }
 }
 
-impl ExternInput<RawTypeSystem> for String
+unsafe impl ExternInput<RawTypeSystem> for String
 {
     type ForeignType = *mut c_char;
 
     type Lease = CString;
-    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
+    unsafe fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
     {
         log::trace!("String::into_foreign_parameter<Raw>");
         let cstring = CString::new(self).map_err(|_| ComError::E_INVALIDARG)?;
@@ -568,7 +568,7 @@ impl ExternInput<RawTypeSystem> for String
     }
 }
 
-impl ExternOutput<AutomationTypeSystem> for String
+unsafe impl ExternOutput<AutomationTypeSystem> for String
 {
     type ForeignType = OutBSTR;
 
@@ -587,7 +587,7 @@ impl ExternOutput<AutomationTypeSystem> for String
     }
 }
 
-impl ExternOutput<RawTypeSystem> for String
+unsafe impl ExternOutput<RawTypeSystem> for String
 {
     type ForeignType = *mut c_char;
 
@@ -607,12 +607,12 @@ impl ExternOutput<RawTypeSystem> for String
 }
 
 // &str
-impl<'a> ExternInput<AutomationTypeSystem> for &'a str
+unsafe impl<'a> ExternInput<AutomationTypeSystem> for &'a str
 {
     type ForeignType = OutBSTR;
 
     type Lease = BString;
-    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
+    unsafe fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
     {
         log::trace!("&str::into_foreign_parameter<Automation>");
         let bstring = BString::from_str(self).expect("Error type is never type");
@@ -628,12 +628,12 @@ impl<'a> ExternInput<AutomationTypeSystem> for &'a str
     }
 }
 
-impl<'a> ExternInput<RawTypeSystem> for &'a str
+unsafe impl<'a> ExternInput<RawTypeSystem> for &'a str
 {
     type ForeignType = *const c_char;
 
     type Lease = CString;
-    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
+    unsafe fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
     {
         log::trace!("&str::into_foreign_parameter<Raw>");
         let cstring = CString::new(self).map_err(|_| ComError::E_INVALIDARG)?;
@@ -650,12 +650,12 @@ impl<'a> ExternInput<RawTypeSystem> for &'a str
 }
 
 // BString
-impl ExternInput<AutomationTypeSystem> for BString
+unsafe impl ExternInput<AutomationTypeSystem> for BString
 {
     type ForeignType = OutBSTR;
 
     type Lease = BString;
-    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
+    unsafe fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
     {
         log::trace!("BString::into_foreign_parameter<Automation>");
         Ok((OutBSTR(self.as_ptr() as *mut _), self))
@@ -669,12 +669,12 @@ impl ExternInput<AutomationTypeSystem> for BString
     }
 }
 
-impl ExternInput<RawTypeSystem> for BString
+unsafe impl ExternInput<RawTypeSystem> for BString
 {
     type ForeignType = *mut c_char;
 
     type Lease = CString;
-    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
+    unsafe fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
     {
         log::trace!("BString::into_foreign_parameter<Raw>");
         self.to_string()
@@ -689,12 +689,12 @@ impl ExternInput<RawTypeSystem> for BString
         log::trace!("BString::from_foreign_parameter<Raw>");
         CStr::from_ptr(source)
             .to_str()
-            .map(|string| BString::from(string))
+            .map(BString::from)
             .map_err(|_| ComError::E_INVALIDARG)
     }
 }
 
-impl ExternOutput<AutomationTypeSystem> for BString
+unsafe impl ExternOutput<AutomationTypeSystem> for BString
 {
     type ForeignType = OutBSTR;
 
@@ -711,7 +711,7 @@ impl ExternOutput<AutomationTypeSystem> for BString
     }
 }
 
-impl ExternOutput<RawTypeSystem> for BString
+unsafe impl ExternOutput<RawTypeSystem> for BString
 {
     type ForeignType = *mut c_char;
 
@@ -729,18 +729,18 @@ impl ExternOutput<RawTypeSystem> for BString
         log::trace!("BString::from_foreign_output<Raw>");
         CString::from_raw(source)
             .into_string()
-            .map(|string| BString::from(string))
+            .map(BString::from)
             .map_err(|_| ComError::E_INVALIDARG)
     }
 }
 
 // CString
-impl ExternInput<AutomationTypeSystem> for CString
+unsafe impl ExternInput<AutomationTypeSystem> for CString
 {
     type ForeignType = OutBSTR;
 
     type Lease = BString;
-    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
+    unsafe fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
     {
         log::trace!("CString::into_foreign_parameter<Automation>");
         let cstring = self.into_string().map_err(|_| ComError::E_INVALIDARG)?;
@@ -761,12 +761,12 @@ impl ExternInput<AutomationTypeSystem> for CString
     }
 }
 
-impl ExternInput<RawTypeSystem> for CString
+unsafe impl ExternInput<RawTypeSystem> for CString
 {
     type ForeignType = *mut c_char;
 
     type Lease = CString;
-    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
+    unsafe fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
     {
         log::trace!("CString::into_foreign_parameter<Raw>");
         Ok((self.as_ptr() as *mut _, self))
@@ -780,7 +780,7 @@ impl ExternInput<RawTypeSystem> for CString
     }
 }
 
-impl ExternOutput<AutomationTypeSystem> for CString
+unsafe impl ExternOutput<AutomationTypeSystem> for CString
 {
     type ForeignType = OutBSTR;
 
@@ -803,7 +803,7 @@ impl ExternOutput<AutomationTypeSystem> for CString
     }
 }
 
-impl ExternOutput<RawTypeSystem> for CString
+unsafe impl ExternOutput<RawTypeSystem> for CString
 {
     type ForeignType = *mut c_char;
 
@@ -821,12 +821,12 @@ impl ExternOutput<RawTypeSystem> for CString
 }
 
 // &CStr
-impl<'a> ExternInput<AutomationTypeSystem> for &'a CStr
+unsafe impl<'a> ExternInput<AutomationTypeSystem> for &'a CStr
 {
     type ForeignType = OutBSTR;
 
     type Lease = BString;
-    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
+    unsafe fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
     {
         log::trace!("&CStr::into_foreign_parameter<Automation>");
         let string = self.to_str().map_err(|_| ComError::E_INVALIDARG)?;
@@ -845,12 +845,12 @@ impl<'a> ExternInput<AutomationTypeSystem> for &'a CStr
     }
 }
 
-impl<'a> ExternInput<RawTypeSystem> for &'a CStr
+unsafe impl<'a> ExternInput<RawTypeSystem> for &'a CStr
 {
     type ForeignType = *mut c_char;
 
     type Lease = ();
-    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
+    unsafe fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
     {
         log::trace!("&CStr::into_foreign_parameter<Raw>");
         Ok((self.as_ptr() as *mut _, ()))
@@ -865,12 +865,12 @@ impl<'a> ExternInput<RawTypeSystem> for &'a CStr
 }
 
 // &BStr
-impl<'a> ExternInput<AutomationTypeSystem> for &'a BStr
+unsafe impl<'a> ExternInput<AutomationTypeSystem> for &'a BStr
 {
     type ForeignType = OutBSTR;
 
     type Lease = ();
-    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
+    unsafe fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
     {
         log::trace!("&BStr::into_foreign_parameter<Automation>");
         Ok((OutBSTR(self.as_ptr() as *mut _), ()))
@@ -884,12 +884,12 @@ impl<'a> ExternInput<AutomationTypeSystem> for &'a BStr
     }
 }
 
-impl<'a> ExternInput<RawTypeSystem> for &'a BStr
+unsafe impl<'a> ExternInput<RawTypeSystem> for &'a BStr
 {
     type ForeignType = *mut c_char;
 
     type Lease = CString;
-    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
+    unsafe fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
     {
         log::trace!("&BStr::into_foreign_parameter<Raw>");
         let string = self.to_string().map_err(|_| ComError::E_INVALIDARG)?;

--- a/intercom/src/strings.rs
+++ b/intercom/src/strings.rs
@@ -359,6 +359,7 @@ pub type CString = std::ffi::CString;
 #[cfg(windows)]
 mod os
 {
+    use crate::raw::OutBSTR;
 
     #[link(name = "oleaut32")]
     extern "system" {

--- a/intercom/src/strings.rs
+++ b/intercom/src/strings.rs
@@ -14,7 +14,7 @@ use std::{
 
 use crate::intercom::{ComError, ComResult};
 use crate::raw::OutBSTR;
-use crate::type_system::{AutomationTypeSystem, ExternOutput, ExternParameter, RawTypeSystem};
+use crate::type_system::{AutomationTypeSystem, ExternInput, ExternOutput, RawTypeSystem};
 
 #[derive(Debug)]
 pub struct FormatError;
@@ -523,20 +523,20 @@ impl TryFrom<IntercomString> for String
 }
 
 // String
-impl ExternParameter<AutomationTypeSystem> for String
+impl ExternInput<AutomationTypeSystem> for String
 {
     type ForeignType = OutBSTR;
 
-    type IntoTemporary = BString;
-    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::IntoTemporary)>
+    type Lease = BString;
+    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
     {
         log::trace!("String::into_foreign_parameter<Automation>");
         let bstring = BString::from_str(&self).expect("Error type is never type");
         Ok((OutBSTR(bstring.as_ptr() as *mut _), bstring))
     }
 
-    type OwnedParameter = Self;
-    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::OwnedParameter>
+    type Owned = Self;
+    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::Owned>
     {
         log::trace!("String::from_foreign_parameter<Automation>");
         let bstring = BStr::from_ptr(source.0);
@@ -544,20 +544,20 @@ impl ExternParameter<AutomationTypeSystem> for String
     }
 }
 
-impl ExternParameter<RawTypeSystem> for String
+impl ExternInput<RawTypeSystem> for String
 {
     type ForeignType = *mut c_char;
 
-    type IntoTemporary = CString;
-    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::IntoTemporary)>
+    type Lease = CString;
+    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
     {
         log::trace!("String::into_foreign_parameter<Raw>");
         let cstring = CString::new(self).map_err(|_| ComError::E_INVALIDARG)?;
         Ok((cstring.as_ptr() as *mut _, cstring))
     }
 
-    type OwnedParameter = Self;
-    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::OwnedParameter>
+    type Owned = Self;
+    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::Owned>
     {
         log::trace!("String::from_foreign_parameter<Raw>");
         let cstring = CStr::from_ptr(source);
@@ -607,20 +607,20 @@ impl ExternOutput<RawTypeSystem> for String
 }
 
 // &str
-impl<'a> ExternParameter<AutomationTypeSystem> for &'a str
+impl<'a> ExternInput<AutomationTypeSystem> for &'a str
 {
     type ForeignType = OutBSTR;
 
-    type IntoTemporary = BString;
-    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::IntoTemporary)>
+    type Lease = BString;
+    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
     {
         log::trace!("&str::into_foreign_parameter<Automation>");
         let bstring = BString::from_str(self).expect("Error type is never type");
         Ok((OutBSTR(bstring.as_ptr() as *mut _), bstring))
     }
 
-    type OwnedParameter = String;
-    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::OwnedParameter>
+    type Owned = String;
+    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::Owned>
     {
         log::trace!("&str::from_foreign_parameter<Automation>");
         let bstr = BStr::from_ptr(source.0);
@@ -628,20 +628,20 @@ impl<'a> ExternParameter<AutomationTypeSystem> for &'a str
     }
 }
 
-impl<'a> ExternParameter<RawTypeSystem> for &'a str
+impl<'a> ExternInput<RawTypeSystem> for &'a str
 {
     type ForeignType = *const c_char;
 
-    type IntoTemporary = CString;
-    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::IntoTemporary)>
+    type Lease = CString;
+    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
     {
         log::trace!("&str::into_foreign_parameter<Raw>");
         let cstring = CString::new(self).map_err(|_| ComError::E_INVALIDARG)?;
         Ok((cstring.as_ptr(), cstring))
     }
 
-    type OwnedParameter = Self;
-    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::OwnedParameter>
+    type Owned = Self;
+    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::Owned>
     {
         log::trace!("&str::from_foreign_parameter<Raw>");
         let cstr = CStr::from_ptr(source);
@@ -650,31 +650,31 @@ impl<'a> ExternParameter<RawTypeSystem> for &'a str
 }
 
 // BString
-impl ExternParameter<AutomationTypeSystem> for BString
+impl ExternInput<AutomationTypeSystem> for BString
 {
     type ForeignType = OutBSTR;
 
-    type IntoTemporary = BString;
-    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::IntoTemporary)>
+    type Lease = BString;
+    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
     {
         log::trace!("BString::into_foreign_parameter<Automation>");
         Ok((OutBSTR(self.as_ptr() as *mut _), self))
     }
 
-    type OwnedParameter = Self;
-    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::OwnedParameter>
+    type Owned = Self;
+    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::Owned>
     {
         log::trace!("BString::from_foreign_parameter<Automation>");
         Ok(BStr::from_ptr(source.0).to_owned())
     }
 }
 
-impl ExternParameter<RawTypeSystem> for BString
+impl ExternInput<RawTypeSystem> for BString
 {
     type ForeignType = *mut c_char;
 
-    type IntoTemporary = CString;
-    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::IntoTemporary)>
+    type Lease = CString;
+    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
     {
         log::trace!("BString::into_foreign_parameter<Raw>");
         self.to_string()
@@ -683,8 +683,8 @@ impl ExternParameter<RawTypeSystem> for BString
             .map(|cstring| (cstring.as_ptr() as *mut _, cstring))
     }
 
-    type OwnedParameter = Self;
-    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::OwnedParameter>
+    type Owned = Self;
+    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::Owned>
     {
         log::trace!("BString::from_foreign_parameter<Raw>");
         CStr::from_ptr(source)
@@ -735,12 +735,12 @@ impl ExternOutput<RawTypeSystem> for BString
 }
 
 // CString
-impl ExternParameter<AutomationTypeSystem> for CString
+impl ExternInput<AutomationTypeSystem> for CString
 {
     type ForeignType = OutBSTR;
 
-    type IntoTemporary = BString;
-    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::IntoTemporary)>
+    type Lease = BString;
+    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
     {
         log::trace!("CString::into_foreign_parameter<Automation>");
         let cstring = self.into_string().map_err(|_| ComError::E_INVALIDARG)?;
@@ -748,8 +748,8 @@ impl ExternParameter<AutomationTypeSystem> for CString
         Ok((OutBSTR(bstring.as_ptr() as *mut _), bstring))
     }
 
-    type OwnedParameter = Self;
-    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::OwnedParameter>
+    type Owned = Self;
+    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::Owned>
     {
         log::trace!("CString::from_foreign_parameter<Automation>");
         CString::new(
@@ -761,19 +761,19 @@ impl ExternParameter<AutomationTypeSystem> for CString
     }
 }
 
-impl ExternParameter<RawTypeSystem> for CString
+impl ExternInput<RawTypeSystem> for CString
 {
     type ForeignType = *mut c_char;
 
-    type IntoTemporary = CString;
-    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::IntoTemporary)>
+    type Lease = CString;
+    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
     {
         log::trace!("CString::into_foreign_parameter<Raw>");
         Ok((self.as_ptr() as *mut _, self))
     }
 
-    type OwnedParameter = Self;
-    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::OwnedParameter>
+    type Owned = Self;
+    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::Owned>
     {
         log::trace!("CString::from_foreign_parameter<Raw>");
         Ok(CStr::from_ptr(source).to_owned())
@@ -821,12 +821,12 @@ impl ExternOutput<RawTypeSystem> for CString
 }
 
 // &CStr
-impl<'a> ExternParameter<AutomationTypeSystem> for &'a CStr
+impl<'a> ExternInput<AutomationTypeSystem> for &'a CStr
 {
     type ForeignType = OutBSTR;
 
-    type IntoTemporary = BString;
-    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::IntoTemporary)>
+    type Lease = BString;
+    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
     {
         log::trace!("&CStr::into_foreign_parameter<Automation>");
         let string = self.to_str().map_err(|_| ComError::E_INVALIDARG)?;
@@ -834,8 +834,8 @@ impl<'a> ExternParameter<AutomationTypeSystem> for &'a CStr
         Ok((OutBSTR(bstring.as_ptr() as *mut _), bstring))
     }
 
-    type OwnedParameter = CString;
-    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::OwnedParameter>
+    type Owned = CString;
+    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::Owned>
     {
         log::trace!("&CStr::from_foreign_parameter<Automation>");
         let string = BStr::from_ptr(source.0)
@@ -845,19 +845,19 @@ impl<'a> ExternParameter<AutomationTypeSystem> for &'a CStr
     }
 }
 
-impl<'a> ExternParameter<RawTypeSystem> for &'a CStr
+impl<'a> ExternInput<RawTypeSystem> for &'a CStr
 {
     type ForeignType = *mut c_char;
 
-    type IntoTemporary = ();
-    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::IntoTemporary)>
+    type Lease = ();
+    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
     {
         log::trace!("&CStr::into_foreign_parameter<Raw>");
         Ok((self.as_ptr() as *mut _, ()))
     }
 
-    type OwnedParameter = Self;
-    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::OwnedParameter>
+    type Owned = Self;
+    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::Owned>
     {
         log::trace!("&CStr::from_foreign_parameter<Raw>");
         Ok(CStr::from_ptr(source))
@@ -865,31 +865,31 @@ impl<'a> ExternParameter<RawTypeSystem> for &'a CStr
 }
 
 // &BStr
-impl<'a> ExternParameter<AutomationTypeSystem> for &'a BStr
+impl<'a> ExternInput<AutomationTypeSystem> for &'a BStr
 {
     type ForeignType = OutBSTR;
 
-    type IntoTemporary = ();
-    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::IntoTemporary)>
+    type Lease = ();
+    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
     {
         log::trace!("&BStr::into_foreign_parameter<Automation>");
         Ok((OutBSTR(self.as_ptr() as *mut _), ()))
     }
 
-    type OwnedParameter = Self;
-    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::OwnedParameter>
+    type Owned = Self;
+    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::Owned>
     {
         log::trace!("&BStr::from_foreign_parameter<Automation>");
         Ok(BStr::from_ptr(source.0))
     }
 }
 
-impl<'a> ExternParameter<RawTypeSystem> for &'a BStr
+impl<'a> ExternInput<RawTypeSystem> for &'a BStr
 {
     type ForeignType = *mut c_char;
 
-    type IntoTemporary = CString;
-    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::IntoTemporary)>
+    type Lease = CString;
+    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
     {
         log::trace!("&BStr::into_foreign_parameter<Raw>");
         let string = self.to_string().map_err(|_| ComError::E_INVALIDARG)?;
@@ -897,8 +897,8 @@ impl<'a> ExternParameter<RawTypeSystem> for &'a BStr
         Ok((cstring.as_ptr() as *mut c_char, cstring))
     }
 
-    type OwnedParameter = BString;
-    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::OwnedParameter>
+    type Owned = BString;
+    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::Owned>
     {
         log::trace!("&BStr::from_foreign_parameter<Raw>");
         let string = CStr::from_ptr(source)

--- a/intercom/src/strings.rs
+++ b/intercom/src/strings.rs
@@ -5,6 +5,7 @@
 use std::{
     self,
     borrow::Borrow,
+    convert::TryFrom,
     ffi,
     ops::Deref,
     os::raw::c_char,
@@ -12,9 +13,8 @@ use std::{
 };
 
 use crate::intercom::{ComError, ComResult};
-use crate::type_system::{
-    AutomationTypeSystem, ExternType, IntercomFrom, IntercomInto, RawTypeSystem,
-};
+use crate::raw::OutBSTR;
+use crate::type_system::{AutomationTypeSystem, ExternOutput, ExternParameter, RawTypeSystem};
 
 #[derive(Debug)]
 pub struct FormatError;
@@ -350,21 +350,6 @@ impl Drop for BString
     }
 }
 
-impl IntercomFrom<BString> for String
-{
-    unsafe fn intercom_from(source: BString) -> Result<Self, ComError>
-    {
-        source.to_string().map_err(|_| ComError::E_INVALIDARG)
-    }
-}
-
-impl IntercomFrom<CString> for String
-{
-    unsafe fn intercom_from(source: CString) -> Result<Self, ComError>
-    {
-        source.into_string().map_err(|_| ComError::E_INVALIDARG)
-    }
-}
 pub type CStr = std::ffi::CStr;
 pub type CString = std::ffi::CString;
 
@@ -378,7 +363,7 @@ mod os
     #[link(name = "oleaut32")]
     extern "system" {
         #[doc(hidden)]
-        pub fn SysAllocStringLen(psz: *const u16, len: u32) -> crate::raw::OutBSTR;
+        pub fn SysAllocStringLen(psz: *const u16, len: u32) -> OutBSTR;
 
         #[doc(hidden)]
         pub fn SysFreeString(bstr: *mut u16);
@@ -392,15 +377,16 @@ mod os
 #[allow(non_snake_case)]
 mod os
 {
+    use crate::raw::OutBSTR;
     use libc;
 
     #[doc(hidden)]
-    pub unsafe fn SysAllocStringLen(psz: *const u16, len: u32) -> crate::raw::OutBSTR
+    pub unsafe fn SysAllocStringLen(psz: *const u16, len: u32) -> OutBSTR
     {
         // Match the SysAllocStringLen implementation on Windows when
         // psz is null.
         if psz.is_null() {
-            return crate::raw::OutBSTR(std::ptr::null_mut());
+            return OutBSTR(std::ptr::null_mut());
         }
 
         // Length prefix + data length + null-terminator.
@@ -409,7 +395,7 @@ mod os
         let buffer_length: usize = 4 + data_length + 2;
         let buffer = libc::malloc(buffer_length);
         if buffer.is_null() {
-            return crate::raw::OutBSTR(std::ptr::null_mut());
+            return OutBSTR(std::ptr::null_mut());
         }
 
         // Set the length prefix.
@@ -426,7 +412,7 @@ mod os
         libc::memcpy(buffer.offset(4 + data_length as isize), null_terminator, 2);
 
         let buffer = buffer.offset(4) as *mut u16;
-        crate::raw::OutBSTR(buffer)
+        OutBSTR(buffer)
     }
 
     #[doc(hidden)]
@@ -483,182 +469,289 @@ impl From<CString> for IntercomString
     }
 }
 
-impl IntercomFrom<IntercomString> for BString
+impl TryFrom<IntercomString> for BString
 {
-    unsafe fn intercom_from(source: IntercomString) -> Result<Self, ComError>
+    type Error = ComError;
+    fn try_from(source: IntercomString) -> Result<BString, ComError>
     {
         match source {
-            IntercomString::BString(bstring) => bstring.intercom_into(),
-            IntercomString::CString(cstring) => cstring.intercom_into(),
-            IntercomString::String(string) => string.intercom_into(),
+            IntercomString::BString(bstring) => Ok(bstring),
+            IntercomString::CString(cstring) => {
+                BString::from_str(&cstring.into_string().map_err(|_| ComError::E_INVALIDARG)?)
+                    .map_err(|_| ComError::E_INVALIDARG)
+            }
+            IntercomString::String(string) => {
+                BString::from_str(&string).map_err(|_| ComError::E_INVALIDARG)
+            }
         }
     }
 }
 
-impl IntercomFrom<IntercomString> for CString
+impl TryFrom<IntercomString> for CString
 {
-    unsafe fn intercom_from(source: IntercomString) -> Result<Self, ComError>
+    type Error = ComError;
+    fn try_from(source: IntercomString) -> Result<CString, ComError>
     {
         match source {
-            IntercomString::BString(bstring) => bstring.intercom_into(),
-            IntercomString::CString(cstring) => cstring.intercom_into(),
-            IntercomString::String(string) => string.intercom_into(),
+            IntercomString::BString(bstring) => bstring
+                .to_string()
+                .map_err(|_| ComError::E_INVALIDARG)
+                .and_then(|string| CString::new(string).map_err(|_| ComError::E_INVALIDARG)),
+            IntercomString::CString(cstring) => Ok(cstring),
+            IntercomString::String(string) => {
+                CString::new(string).map_err(|_| ComError::E_INVALIDARG)
+            }
         }
     }
 }
 
-impl IntercomFrom<IntercomString> for String
+impl TryFrom<IntercomString> for String
 {
-    unsafe fn intercom_from(source: IntercomString) -> Result<Self, ComError>
+    type Error = ComError;
+    fn try_from(source: IntercomString) -> Result<String, ComError>
     {
         match source {
-            IntercomString::BString(bstring) => bstring.intercom_into(),
-            IntercomString::CString(cstring) => cstring.intercom_into(),
-            IntercomString::String(string) => string.intercom_into(),
+            IntercomString::BString(bstring) => {
+                bstring.to_string().map_err(|_| ComError::E_INVALIDARG)
+            }
+            IntercomString::CString(cstring) => {
+                cstring.into_string().map_err(|_| ComError::E_INVALIDARG)
+            }
+            IntercomString::String(string) => Ok(string),
         }
     }
 }
 
-// Automation type system.
-
-impl ExternType<AutomationTypeSystem> for &str
+// String
+impl ExternParameter<AutomationTypeSystem> for String
 {
-    type ExternInputType = crate::raw::InBSTR;
-    type ExternOutputType = crate::raw::OutBSTR;
-    type OwnedExternType = BString;
-    type OwnedNativeType = String;
-}
+    type ForeignType = OutBSTR;
 
-impl ExternType<AutomationTypeSystem> for String
-{
-    type ExternInputType = crate::raw::InBSTR;
-    type ExternOutputType = crate::raw::OutBSTR;
-    type OwnedExternType = BString;
-    type OwnedNativeType = String;
-}
-
-impl ExternType<AutomationTypeSystem> for &BStr
-{
-    type ExternInputType = crate::raw::InBSTR;
-    type ExternOutputType = crate::raw::OutBSTR;
-    type OwnedExternType = crate::raw::InBSTR;
-    type OwnedNativeType = crate::raw::InBSTR;
-}
-
-impl ExternType<AutomationTypeSystem> for BString
-{
-    type ExternInputType = crate::raw::InBSTR;
-    type ExternOutputType = crate::raw::OutBSTR;
-    type OwnedExternType = BString;
-    type OwnedNativeType = BString;
-}
-
-impl ExternType<AutomationTypeSystem> for &CStr
-{
-    type ExternInputType = crate::raw::InBSTR;
-    type ExternOutputType = crate::raw::OutBSTR;
-    type OwnedExternType = BString;
-    type OwnedNativeType = CString;
-}
-
-impl ExternType<AutomationTypeSystem> for CString
-{
-    type ExternInputType = crate::raw::InBSTR;
-    type ExternOutputType = crate::raw::OutBSTR;
-    type OwnedExternType = BString;
-    type OwnedNativeType = CString;
-}
-
-// Raw type system.
-
-impl ExternType<RawTypeSystem> for &str
-{
-    type ExternInputType = *const c_char;
-    type ExternOutputType = *mut c_char;
-    type OwnedExternType = CString;
-    type OwnedNativeType = String;
-}
-
-impl ExternType<RawTypeSystem> for String
-{
-    type ExternInputType = *const c_char;
-    type ExternOutputType = *mut c_char;
-    type OwnedExternType = CString;
-    type OwnedNativeType = String;
-}
-
-impl ExternType<RawTypeSystem> for &BStr
-{
-    type ExternInputType = *const c_char;
-    type ExternOutputType = *mut c_char;
-    type OwnedExternType = CString;
-    type OwnedNativeType = BString;
-}
-
-impl ExternType<RawTypeSystem> for BString
-{
-    type ExternInputType = *const c_char;
-    type ExternOutputType = *mut c_char;
-    type OwnedExternType = CString;
-    type OwnedNativeType = BString;
-}
-
-impl ExternType<RawTypeSystem> for &CStr
-{
-    type ExternInputType = *const c_char;
-    type ExternOutputType = *mut c_char;
-    type OwnedExternType = *const c_char;
-    type OwnedNativeType = *const c_char;
-}
-
-impl ExternType<RawTypeSystem> for CString
-{
-    type ExternInputType = *const c_char;
-    type ExternOutputType = *mut c_char;
-    type OwnedExternType = CString;
-    type OwnedNativeType = CString;
-}
-
-// InBSTR -> X
-
-impl IntercomFrom<crate::raw::InBSTR> for String
-{
-    unsafe fn intercom_from(source: crate::raw::InBSTR) -> ComResult<Self>
+    type IntoTemporary = BString;
+    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::IntoTemporary)>
     {
-        Ok(BStr::from_ptr(source.0)
-            .to_string()
-            .map_err(|_| ComError::E_INVALIDARG)?)
+        log::trace!("String::into_foreign_parameter<Automation>");
+        let bstring = BString::from_str(&self).expect("Error type is never type");
+        Ok((OutBSTR(bstring.as_ptr() as *mut _), bstring))
+    }
+
+    type OwnedParameter = Self;
+    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::OwnedParameter>
+    {
+        log::trace!("String::from_foreign_parameter<Automation>");
+        let bstring = BStr::from_ptr(source.0);
+        bstring.to_string().map_err(|_| ComError::E_INVALIDARG)
     }
 }
 
-impl IntercomFrom<crate::raw::InBSTR> for BString
+impl ExternParameter<RawTypeSystem> for String
 {
-    unsafe fn intercom_from(source: crate::raw::InBSTR) -> ComResult<Self>
+    type ForeignType = *mut c_char;
+
+    type IntoTemporary = CString;
+    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::IntoTemporary)>
     {
+        log::trace!("String::into_foreign_parameter<Raw>");
+        let cstring = CString::new(self).map_err(|_| ComError::E_INVALIDARG)?;
+        Ok((cstring.as_ptr() as *mut _, cstring))
+    }
+
+    type OwnedParameter = Self;
+    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::OwnedParameter>
+    {
+        log::trace!("String::from_foreign_parameter<Raw>");
+        let cstring = CStr::from_ptr(source);
+        cstring
+            .to_str()
+            .map_err(|_| ComError::E_INVALIDARG)
+            .map(|s| s.to_string())
+    }
+}
+
+impl ExternOutput<AutomationTypeSystem> for String
+{
+    type ForeignType = OutBSTR;
+
+    fn into_foreign_output(self) -> ComResult<Self::ForeignType>
+    {
+        log::trace!("String::from_foreign_output<Automation>");
+        let bstring = BString::from_str(&self).expect("Error type is never type");
+        Ok(OutBSTR(bstring.into_ptr()))
+    }
+
+    unsafe fn from_foreign_output(source: Self::ForeignType) -> ComResult<Self>
+    {
+        log::trace!("String::from_foreign_output<Automation>");
+        let bstring = BString::from_ptr(source.0);
+        bstring.to_string().map_err(|_| ComError::E_INVALIDARG)
+    }
+}
+
+impl ExternOutput<RawTypeSystem> for String
+{
+    type ForeignType = *mut c_char;
+
+    fn into_foreign_output(self) -> ComResult<Self::ForeignType>
+    {
+        log::trace!("String::into_foreign_output<Raw>");
+        let cstring = CString::new(self).map_err(|_| ComError::E_INVALIDARG)?;
+        Ok(cstring.into_raw())
+    }
+
+    unsafe fn from_foreign_output(source: Self::ForeignType) -> ComResult<Self>
+    {
+        log::trace!("String::from_foreign_output<Raw>");
+        let cstring = CString::from_raw(source);
+        cstring.into_string().map_err(|_| ComError::E_INVALIDARG)
+    }
+}
+
+// &str
+impl<'a> ExternParameter<AutomationTypeSystem> for &'a str
+{
+    type ForeignType = OutBSTR;
+
+    type IntoTemporary = BString;
+    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::IntoTemporary)>
+    {
+        log::trace!("&str::into_foreign_parameter<Automation>");
+        let bstring = BString::from_str(self).expect("Error type is never type");
+        Ok((OutBSTR(bstring.as_ptr() as *mut _), bstring))
+    }
+
+    type OwnedParameter = String;
+    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::OwnedParameter>
+    {
+        log::trace!("&str::from_foreign_parameter<Automation>");
+        let bstr = BStr::from_ptr(source.0);
+        bstr.to_string().map_err(|_| ComError::E_INVALIDARG)
+    }
+}
+
+impl<'a> ExternParameter<RawTypeSystem> for &'a str
+{
+    type ForeignType = *const c_char;
+
+    type IntoTemporary = CString;
+    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::IntoTemporary)>
+    {
+        log::trace!("&str::into_foreign_parameter<Raw>");
+        let cstring = CString::new(self).map_err(|_| ComError::E_INVALIDARG)?;
+        Ok((cstring.as_ptr(), cstring))
+    }
+
+    type OwnedParameter = Self;
+    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::OwnedParameter>
+    {
+        log::trace!("&str::from_foreign_parameter<Raw>");
+        let cstr = CStr::from_ptr(source);
+        cstr.to_str().map_err(|_| ComError::E_INVALIDARG)
+    }
+}
+
+// BString
+impl ExternParameter<AutomationTypeSystem> for BString
+{
+    type ForeignType = OutBSTR;
+
+    type IntoTemporary = BString;
+    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::IntoTemporary)>
+    {
+        log::trace!("BString::into_foreign_parameter<Automation>");
+        Ok((OutBSTR(self.as_ptr() as *mut _), self))
+    }
+
+    type OwnedParameter = Self;
+    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::OwnedParameter>
+    {
+        log::trace!("BString::from_foreign_parameter<Automation>");
         Ok(BStr::from_ptr(source.0).to_owned())
     }
 }
 
-impl<'a> IntercomFrom<&'a crate::raw::InBSTR> for &'a BStr
+impl ExternParameter<RawTypeSystem> for BString
 {
-    unsafe fn intercom_from(source: &'a crate::raw::InBSTR) -> ComResult<Self>
+    type ForeignType = *mut c_char;
+
+    type IntoTemporary = CString;
+    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::IntoTemporary)>
     {
-        Ok(BStr::from_ptr(source.0))
+        log::trace!("BString::into_foreign_parameter<Raw>");
+        self.to_string()
+            .map_err(|_| ComError::E_INVALIDARG)
+            .and_then(|string| CString::new(string).map_err(|_| ComError::E_INVALIDARG))
+            .map(|cstring| (cstring.as_ptr() as *mut _, cstring))
+    }
+
+    type OwnedParameter = Self;
+    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::OwnedParameter>
+    {
+        log::trace!("BString::from_foreign_parameter<Raw>");
+        CStr::from_ptr(source)
+            .to_str()
+            .map(|string| BString::from(string))
+            .map_err(|_| ComError::E_INVALIDARG)
     }
 }
 
-impl<'a> IntercomFrom<crate::raw::InBSTR> for &'a BStr
+impl ExternOutput<AutomationTypeSystem> for BString
 {
-    unsafe fn intercom_from(source: crate::raw::InBSTR) -> ComResult<Self>
+    type ForeignType = OutBSTR;
+
+    fn into_foreign_output(self) -> ComResult<Self::ForeignType>
     {
-        Ok(BStr::from_ptr(source.0))
+        log::trace!("BString::into_foreign_output<Automation>");
+        Ok(OutBSTR(self.into_ptr() as *mut _))
+    }
+
+    unsafe fn from_foreign_output(source: Self::ForeignType) -> ComResult<Self>
+    {
+        log::trace!("BString::from_foreign_output<Automation>");
+        Ok(BString::from_ptr(source.0))
     }
 }
 
-impl IntercomFrom<crate::raw::InBSTR> for CString
+impl ExternOutput<RawTypeSystem> for BString
 {
-    unsafe fn intercom_from(source: crate::raw::InBSTR) -> ComResult<Self>
+    type ForeignType = *mut c_char;
+
+    fn into_foreign_output(self) -> ComResult<Self::ForeignType>
     {
+        log::trace!("BString::into_foreign_output<Raw>");
+        self.to_string()
+            .map_err(|_| ComError::E_INVALIDARG)
+            .and_then(|string| CString::new(string).map_err(|_| ComError::E_INVALIDARG))
+            .map(|cstring| cstring.into_raw())
+    }
+
+    unsafe fn from_foreign_output(source: Self::ForeignType) -> ComResult<Self>
+    {
+        log::trace!("BString::from_foreign_output<Raw>");
+        CString::from_raw(source)
+            .into_string()
+            .map(|string| BString::from(string))
+            .map_err(|_| ComError::E_INVALIDARG)
+    }
+}
+
+// CString
+impl ExternParameter<AutomationTypeSystem> for CString
+{
+    type ForeignType = OutBSTR;
+
+    type IntoTemporary = BString;
+    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::IntoTemporary)>
+    {
+        log::trace!("CString::into_foreign_parameter<Automation>");
+        let cstring = self.into_string().map_err(|_| ComError::E_INVALIDARG)?;
+        let bstring = BString::from(cstring);
+        Ok((OutBSTR(bstring.as_ptr() as *mut _), bstring))
+    }
+
+    type OwnedParameter = Self;
+    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::OwnedParameter>
+    {
+        log::trace!("CString::from_foreign_parameter<Automation>");
         CString::new(
             BStr::from_ptr(source.0)
                 .to_string()
@@ -668,364 +761,150 @@ impl IntercomFrom<crate::raw::InBSTR> for CString
     }
 }
 
-impl<TPtr, TTarget> IntercomFrom<*mut TPtr> for TTarget
-where
-    TTarget: IntercomFrom<*const TPtr>,
+impl ExternParameter<RawTypeSystem> for CString
 {
-    default unsafe fn intercom_from(source: *mut TPtr) -> ComResult<Self>
+    type ForeignType = *mut c_char;
+
+    type IntoTemporary = CString;
+    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::IntoTemporary)>
     {
-        let bstring: ComResult<TTarget> = (source as *const TPtr).intercom_into();
+        log::trace!("CString::into_foreign_parameter<Raw>");
+        Ok((self.as_ptr() as *mut _, self))
+    }
 
-        // Free the buffer.
-        crate::alloc::free(source as *mut _);
-
-        bstring
+    type OwnedParameter = Self;
+    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::OwnedParameter>
+    {
+        log::trace!("CString::from_foreign_parameter<Raw>");
+        Ok(CStr::from_ptr(source).to_owned())
     }
 }
 
-// The *mut u16 strings should be BSTRs and must not be freed using the
-// normal `alloc::free`.
-
-impl IntercomFrom<intercom::raw::OutBSTR> for BString
+impl ExternOutput<AutomationTypeSystem> for CString
 {
-    unsafe fn intercom_from(source: intercom::raw::OutBSTR) -> ComResult<Self>
+    type ForeignType = OutBSTR;
+
+    fn into_foreign_output(self) -> ComResult<Self::ForeignType>
     {
-        Ok(BString::from_ptr(source.0))
+        log::trace!("CString::into_foreign_output<Automation>");
+        let cstring = self.into_string().map_err(|_| ComError::E_INVALIDARG)?;
+        Ok(OutBSTR(BString::from(cstring).into_ptr()))
     }
-}
 
-impl IntercomFrom<intercom::raw::OutBSTR> for String
-{
-    unsafe fn intercom_from(source: intercom::raw::OutBSTR) -> ComResult<Self>
+    unsafe fn from_foreign_output(source: Self::ForeignType) -> ComResult<Self>
     {
-        BString::from_ptr(source.0)
-            .to_string()
-            .map_err(|_| ComError::E_INVALIDARG)
-    }
-}
-
-impl IntercomFrom<intercom::raw::OutBSTR> for CString
-{
-    unsafe fn intercom_from(source: intercom::raw::OutBSTR) -> ComResult<Self>
-    {
-        CString::new(String::intercom_from(source)?).map_err(|_| ComError::E_INVALIDARG)
-    }
-}
-
-// *c_char -> X
-
-impl IntercomFrom<*const c_char> for String
-{
-    unsafe fn intercom_from(source: *const c_char) -> ComResult<Self>
-    {
-        Ok(CStr::from_ptr(source)
-            .to_str()
-            .map_err(|_| ComError::E_INVALIDARG)?
-            .to_string())
-    }
-}
-
-/*
-impl IntercomFrom<*mut c_char> for String {
-    unsafe fn intercom_from( source: *mut c_char ) -> ComResult<String> {
-
-        // TODO:
-        // We really shouldn't blanket unsafe here.
-        // The intercom_from should turn into an unsafe function instead.
-        unsafe {
-
-            // Convert the string. Maintain the result for now.
-            let result = CStr::from_ptr( source )
-                .to_str().map( |s| s.to_string() )
-                .map_err( |_| ComError::E_INVALIDARG );
-
-            // Free the buffer.
-            ::alloc::free( source as *mut _ );
-
-            result
-        }
-    }
-}
-*/
-
-impl IntercomFrom<*const c_char> for BString
-{
-    unsafe fn intercom_from(source: *const c_char) -> ComResult<Self>
-    {
-        Ok(BString::from(
-            CStr::from_ptr(source)
-                .to_str()
+        log::trace!("CString::from_foreign_output<Automation>");
+        CString::new(
+            BString::from_ptr(source.0)
+                .to_string()
                 .map_err(|_| ComError::E_INVALIDARG)?,
-        ))
+        )
+        .map_err(|_| ComError::E_INVALIDARG)
     }
 }
 
-/*
-impl IntercomFrom<*mut c_char> for BString {
-    unsafe fn intercom_from( source: *mut c_char ) -> ComResult<Self> {
-        unsafe {
-            let bstring : ComResult<BString> =
-                    ( source as *const c_char ).intercom_into();
-
-            // Free the buffer.
-            ::alloc::free( source as *mut _ );
-
-            bstring
-        }
-    }
-}
-*/
-
-impl<'a> IntercomFrom<*const c_char> for CString
+impl ExternOutput<RawTypeSystem> for CString
 {
-    unsafe fn intercom_from(source: *const c_char) -> ComResult<Self>
-    {
-        Ok(CStr::from_ptr(source).into())
-    }
-}
+    type ForeignType = *mut c_char;
 
-/* We don't know where the *mut c_char is coming from so we shouldn't really
- * give it to CString given CString assumes it has reserved the memory on
- * its own.
- * */
-impl IntercomFrom<*mut c_char> for CString
-{
-    unsafe fn intercom_from(source: *mut c_char) -> ComResult<CString>
+    fn into_foreign_output(self) -> ComResult<Self::ForeignType>
     {
+        log::trace!("CString::into_foreign_output<Raw>");
+        Ok(self.into_raw())
+    }
+
+    unsafe fn from_foreign_output(source: Self::ForeignType) -> ComResult<Self>
+    {
+        log::trace!("CString::from_foreign_output<Raw>");
         Ok(CString::from_raw(source))
     }
 }
 
-impl<'a> IntercomFrom<*const c_char> for &'a CStr
+// &CStr
+impl<'a> ExternParameter<AutomationTypeSystem> for &'a CStr
 {
-    unsafe fn intercom_from(source: *const c_char) -> ComResult<Self>
+    type ForeignType = OutBSTR;
+
+    type IntoTemporary = BString;
+    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::IntoTemporary)>
     {
+        log::trace!("&CStr::into_foreign_parameter<Automation>");
+        let string = self.to_str().map_err(|_| ComError::E_INVALIDARG)?;
+        let bstring = BString::from(string);
+        Ok((OutBSTR(bstring.as_ptr() as *mut _), bstring))
+    }
+
+    type OwnedParameter = CString;
+    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::OwnedParameter>
+    {
+        log::trace!("&CStr::from_foreign_parameter<Automation>");
+        let string = BStr::from_ptr(source.0)
+            .to_string()
+            .map_err(|_| ComError::E_INVALIDARG)?;
+        CString::new(string).map_err(|_| ComError::E_INVALIDARG)
+    }
+}
+
+impl<'a> ExternParameter<RawTypeSystem> for &'a CStr
+{
+    type ForeignType = *mut c_char;
+
+    type IntoTemporary = ();
+    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::IntoTemporary)>
+    {
+        log::trace!("&CStr::into_foreign_parameter<Raw>");
+        Ok((self.as_ptr() as *mut _, ()))
+    }
+
+    type OwnedParameter = Self;
+    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::OwnedParameter>
+    {
+        log::trace!("&CStr::from_foreign_parameter<Raw>");
         Ok(CStr::from_ptr(source))
     }
 }
 
-impl<'a> IntercomFrom<&*const c_char> for &'a CStr
+// &BStr
+impl<'a> ExternParameter<AutomationTypeSystem> for &'a BStr
 {
-    unsafe fn intercom_from(source: &*const c_char) -> ComResult<Self>
+    type ForeignType = OutBSTR;
+
+    type IntoTemporary = ();
+    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::IntoTemporary)>
     {
-        Ok(CStr::from_ptr(*source))
+        log::trace!("&BStr::into_foreign_parameter<Automation>");
+        Ok((OutBSTR(self.as_ptr() as *mut _), ()))
+    }
+
+    type OwnedParameter = Self;
+    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::OwnedParameter>
+    {
+        log::trace!("&BStr::from_foreign_parameter<Automation>");
+        Ok(BStr::from_ptr(source.0))
     }
 }
 
-// X -> BSTR
-
-impl IntercomFrom<&BStr> for crate::raw::InBSTR
+impl<'a> ExternParameter<RawTypeSystem> for &'a BStr
 {
-    unsafe fn intercom_from(source: &BStr) -> ComResult<Self>
+    type ForeignType = *mut c_char;
+
+    type IntoTemporary = CString;
+    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::IntoTemporary)>
     {
-        Ok(crate::raw::InBSTR(source.as_ptr()))
+        log::trace!("&BStr::into_foreign_parameter<Raw>");
+        let string = self.to_string().map_err(|_| ComError::E_INVALIDARG)?;
+        let cstring = CString::new(string).map_err(|_| ComError::E_INVALIDARG)?;
+        Ok((cstring.as_ptr() as *mut c_char, cstring))
     }
-}
 
-impl IntercomFrom<&BString> for crate::raw::InBSTR
-{
-    unsafe fn intercom_from(source: &BString) -> ComResult<Self>
+    type OwnedParameter = BString;
+    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::OwnedParameter>
     {
-        Ok(crate::raw::InBSTR(source.as_ptr()))
-    }
-}
-
-impl IntercomFrom<BString> for crate::raw::OutBSTR
-{
-    unsafe fn intercom_from(source: BString) -> ComResult<Self>
-    {
-        Ok(crate::raw::OutBSTR(source.into_ptr()))
-    }
-}
-
-impl IntercomFrom<CString> for crate::raw::OutBSTR
-{
-    unsafe fn intercom_from(source: CString) -> ComResult<Self>
-    {
-        let bstr: BString = source.intercom_into()?;
-        Ok(crate::raw::OutBSTR(bstr.into_ptr()))
-    }
-}
-
-// X -> *c_char
-
-impl IntercomFrom<&CStr> for *const c_char
-{
-    unsafe fn intercom_from(source: &CStr) -> ComResult<Self>
-    {
-        Ok(source.as_ptr())
-    }
-}
-
-impl IntercomFrom<&CString> for *const c_char
-{
-    unsafe fn intercom_from(source: &CString) -> ComResult<Self>
-    {
-        Ok(source.as_ptr())
-    }
-}
-
-impl IntercomFrom<CString> for *mut c_char
-{
-    unsafe fn intercom_from(source: CString) -> ComResult<Self>
-    {
-        let ptr = source.as_ptr();
-        std::mem::forget(source);
-        Ok(ptr as _)
-
-        /* We really should do the following I believe:
-        let bytes = source.as_bytes();
-
-        // We just allocated the memory. This is safe.
-        unsafe {
-            let buffer = crate::alloc::allocate( bytes.len() + 1 ) as *mut u8;
-            std::ptr::copy_nonoverlapping(
-                bytes.as_ptr(),
-                buffer,
-                bytes.len() );
-            *buffer.offset( ( bytes.len() + 1 ) as isize ) = 0;
-
-            Ok( buffer as *mut c_char )
-        }
-        */
-    }
-}
-
-impl IntercomFrom<BString> for *mut c_char
-{
-    unsafe fn intercom_from(source: BString) -> ComResult<Self>
-    {
-        let cstring: CString = source.intercom_into()?;
-        cstring.intercom_into()
-    }
-}
-
-// String -> X
-
-impl IntercomFrom<String> for CString
-{
-    unsafe fn intercom_from(source: String) -> ComResult<Self>
-    {
-        CString::new(source).map_err(|_| ComError::E_INVALIDARG)
-    }
-}
-
-impl IntercomFrom<&str> for CString
-{
-    unsafe fn intercom_from(source: &str) -> ComResult<Self>
-    {
-        CString::new(source).map_err(|_| ComError::E_INVALIDARG)
-    }
-}
-
-impl IntercomFrom<String> for BString
-{
-    unsafe fn intercom_from(source: String) -> ComResult<Self>
-    {
-        Ok(BString::from(source.as_ref()))
-    }
-}
-
-impl<'a> IntercomFrom<&'a str> for BString
-{
-    unsafe fn intercom_from(source: &str) -> ComResult<Self>
-    {
-        Ok(BString::from(source))
-    }
-}
-
-// CString -> X
-
-impl IntercomFrom<CString> for BString
-{
-    unsafe fn intercom_from(source: CString) -> ComResult<Self>
-    {
-        Ok(BString::from(
-            source
-                .to_str()
-                .map_err(|_| ComError::E_INVALIDARG)?
-                .to_string(),
-        ))
-    }
-}
-
-impl<'a> IntercomFrom<&'a CString> for &'a CStr
-{
-    unsafe fn intercom_from(source: &'a CString) -> ComResult<Self>
-    {
-        Ok(source.as_ref())
-    }
-}
-
-// BString -> X
-
-impl IntercomFrom<BString> for CString
-{
-    unsafe fn intercom_from(source: BString) -> ComResult<Self>
-    {
-        CString::new(source.to_string().map_err(|_| ComError::E_INVALIDARG)?)
-            .map_err(|_| ComError::E_INVALIDARG)
-    }
-}
-
-impl<'a> IntercomFrom<&'a BString> for &'a BStr
-{
-    unsafe fn intercom_from(source: &'a BString) -> ComResult<Self>
-    {
-        Ok(source.as_ref())
-    }
-}
-
-impl IntercomFrom<&BStr> for CString
-{
-    unsafe fn intercom_from(source: &BStr) -> ComResult<Self>
-    {
-        CString::new(source.to_string().map_err(|_| ComError::E_INVALIDARG)?)
-            .map_err(|_| ComError::E_INVALIDARG)
-    }
-}
-
-impl IntercomFrom<&CStr> for BString
-{
-    unsafe fn intercom_from(source: &CStr) -> ComResult<Self>
-    {
-        Ok(BString::from(
-            source
-                .to_str()
-                .map_err(|_| ComError::E_INVALIDARG)?
-                .to_string(),
-        ))
-    }
-}
-
-impl<'a> IntercomFrom<&'a String> for &'a str
-{
-    unsafe fn intercom_from(source: &'a String) -> ComResult<Self>
-    {
-        Ok(source.as_ref())
-    }
-}
-
-impl IntercomFrom<String> for *mut c_char
-{
-    unsafe fn intercom_from(source: String) -> ComResult<Self>
-    {
-        let bytes = source.as_bytes();
-
-        // We just allocated the memory. This is safe.
-        let buffer = crate::alloc::allocate(bytes.len() + 1) as *mut u8;
-        std::ptr::copy_nonoverlapping(bytes.as_ptr(), buffer, bytes.len());
-        *buffer.add(bytes.len()) = 0;
-
-        Ok(buffer as *mut c_char)
-    }
-}
-
-impl IntercomFrom<String> for intercom::raw::OutBSTR
-{
-    unsafe fn intercom_from(source: String) -> ComResult<Self>
-    {
-        Ok(intercom::raw::OutBSTR(BString::from(source).into_ptr()))
+        log::trace!("&BStr::from_foreign_parameter<Raw>");
+        let string = CStr::from_ptr(source)
+            .to_str()
+            .map_err(|_| ComError::E_INVALIDARG)?;
+        Ok(BString::from(string))
     }
 }
 

--- a/intercom/src/type_system.rs
+++ b/intercom/src/type_system.rs
@@ -51,15 +51,15 @@ pub trait BidirectionalTypeInfo
 }
 
 /// Defines a type that is compatible with Intercom interfaces.
-pub trait ExternParameter<TS: TypeSystem>: Sized
+pub trait ExternInput<TS: TypeSystem>: Sized
 {
     type ForeignType: BidirectionalTypeInfo;
 
-    type IntoTemporary;
-    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::IntoTemporary)>;
+    type Lease;
+    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>;
 
-    type OwnedParameter;
-    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::OwnedParameter>;
+    type Owned;
+    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::Owned>;
 }
 
 pub trait ExternOutput<TS: TypeSystem>: Sized
@@ -71,7 +71,7 @@ pub trait ExternOutput<TS: TypeSystem>: Sized
     unsafe fn from_foreign_output(source: Self::ForeignType) -> ComResult<Self>;
 }
 
-/// A quick macro for implementing ExternParameter/etc. for various basic types
+/// A quick macro for implementing ExternInput/etc. for various basic types
 /// that should represent themselves.
 macro_rules! self_extern {
     ( $t:ty ) => {
@@ -84,19 +84,17 @@ macro_rules! self_extern {
             }
         }
 
-        impl<TS: TypeSystem> ExternParameter<TS> for $t
+        impl<TS: TypeSystem> ExternInput<TS> for $t
         {
             type ForeignType = $t;
-            type IntoTemporary = ();
+            type Lease = ();
             fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, ())>
             {
                 Ok((self, ()))
             }
 
-            type OwnedParameter = Self;
-            unsafe fn from_foreign_parameter(
-                source: Self::ForeignType,
-            ) -> ComResult<Self::OwnedParameter>
+            type Owned = Self;
+            unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::Owned>
             {
                 Ok(source)
             }
@@ -178,33 +176,33 @@ impl<TS: TypeSystem, TPtr: BidirectionalTypeInfo + ?Sized> ExternOutput<TS> for 
     }
 }
 
-impl<TS: TypeSystem, TPtr: BidirectionalTypeInfo + ?Sized> ExternParameter<TS> for *mut TPtr
+impl<TS: TypeSystem, TPtr: BidirectionalTypeInfo + ?Sized> ExternInput<TS> for *mut TPtr
 {
     type ForeignType = Self;
-    type IntoTemporary = ();
+    type Lease = ();
     fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, ())>
     {
         Ok((self, ()))
     }
 
-    type OwnedParameter = Self;
-    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::OwnedParameter>
+    type Owned = Self;
+    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::Owned>
     {
         Ok(source)
     }
 }
 
-impl<TS: TypeSystem, TPtr: BidirectionalTypeInfo + ?Sized> ExternParameter<TS> for *const TPtr
+impl<TS: TypeSystem, TPtr: BidirectionalTypeInfo + ?Sized> ExternInput<TS> for *const TPtr
 {
     type ForeignType = Self;
-    type IntoTemporary = ();
+    type Lease = ();
     fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, ())>
     {
         Ok((self, ()))
     }
 
-    type OwnedParameter = Self;
-    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::OwnedParameter>
+    type Owned = Self;
+    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::Owned>
     {
         Ok(source)
     }

--- a/intercom/src/type_system.rs
+++ b/intercom/src/type_system.rs
@@ -172,13 +172,7 @@ self_extern!(GUID);
 
 self_extern!(TypeSystemName);
 
-impl ForeignType for libc::c_void
-{
-    fn type_name() -> &'static str
-    {
-        "void"
-    }
-}
+self_extern!(std::ffi::c_void);
 
 unsafe impl<TS: TypeSystem, TPtr: ForeignType + ?Sized> ExternOutput<TS> for *mut TPtr
 {

--- a/intercom/src/type_system.rs
+++ b/intercom/src/type_system.rs
@@ -50,24 +50,56 @@ pub trait ForeignType
     }
 }
 
-/// Defines a type that is compatible with Intercom interfaces.
-pub trait ExternInput<TS: TypeSystem>: Sized
+/// Defines a type that may be used as a parameter type in Intercom interfaces.
+///
+/// # Safety
+///
+/// Implementing this trait allows Intercom to use the type as an input type.
+/// This trait will be used within the code generated in the procedural macros.
+/// It is important to ensure this trait is implemented in such a way that its
+/// use in the macros is sound.
+pub unsafe trait ExternInput<TS: TypeSystem>: Sized
 {
     type ForeignType: ForeignType;
 
     type Lease;
-    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>;
+
+    /// # Safety
+    ///
+    /// The returned `ForeignType` value is valid only as long as the `Lease`
+    /// is held.
+    unsafe fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>;
 
     type Owned;
+
+    /// # Safety
+    ///
+    /// The validity of the returned `Owned` value depends on the source type.
+    /// In general it shouldn't be used past the lifetime of the `source`
+    /// reference.
     unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::Owned>;
 }
 
-pub trait ExternOutput<TS: TypeSystem>: Sized
+/// Defines a type that may be used as an output type in Intercom interfaces.
+///
+/// # Safety
+///
+/// Implementing this trait allows Intercom to use the type as an output type.
+/// This trait will be used within the code generated in the procedural macros.
+/// It is important to ensure this trait is implemented in such a way that its
+/// use in the macros is sound.
+pub unsafe trait ExternOutput<TS: TypeSystem>: Sized
 {
     type ForeignType: ForeignType;
 
     fn into_foreign_output(self) -> ComResult<Self::ForeignType>;
 
+    /// # Safety
+    ///
+    /// The source ownership is transferred to the function invoker. In case of
+    /// pointers, the function (or the `Self` type) is given the ownership of
+    /// the memory. The caller must ensure that it owns the source parameter
+    /// and is allowed to pass the ownership in this way.
     unsafe fn from_foreign_output(source: Self::ForeignType) -> ComResult<Self>;
 }
 
@@ -84,11 +116,11 @@ macro_rules! self_extern {
             }
         }
 
-        impl<TS: TypeSystem> ExternInput<TS> for $t
+        unsafe impl<TS: TypeSystem> ExternInput<TS> for $t
         {
             type ForeignType = $t;
             type Lease = ();
-            fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, ())>
+            unsafe fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, ())>
             {
                 Ok((self, ()))
             }
@@ -100,7 +132,7 @@ macro_rules! self_extern {
             }
         }
 
-        impl<TS: TypeSystem> ExternOutput<TS> for $t
+        unsafe impl<TS: TypeSystem> ExternOutput<TS> for $t
         {
             type ForeignType = $t;
             fn into_foreign_output(self) -> ComResult<Self::ForeignType>
@@ -148,7 +180,7 @@ impl ForeignType for libc::c_void
     }
 }
 
-impl<TS: TypeSystem, TPtr: ForeignType + ?Sized> ExternOutput<TS> for *mut TPtr
+unsafe impl<TS: TypeSystem, TPtr: ForeignType + ?Sized> ExternOutput<TS> for *mut TPtr
 {
     type ForeignType = Self;
     fn into_foreign_output(self) -> ComResult<Self::ForeignType>
@@ -162,7 +194,7 @@ impl<TS: TypeSystem, TPtr: ForeignType + ?Sized> ExternOutput<TS> for *mut TPtr
     }
 }
 
-impl<TS: TypeSystem, TPtr: ForeignType + ?Sized> ExternOutput<TS> for *const TPtr
+unsafe impl<TS: TypeSystem, TPtr: ForeignType + ?Sized> ExternOutput<TS> for *const TPtr
 {
     type ForeignType = Self;
     fn into_foreign_output(self) -> ComResult<Self::ForeignType>
@@ -176,11 +208,11 @@ impl<TS: TypeSystem, TPtr: ForeignType + ?Sized> ExternOutput<TS> for *const TPt
     }
 }
 
-impl<TS: TypeSystem, TPtr: ForeignType + ?Sized> ExternInput<TS> for *mut TPtr
+unsafe impl<TS: TypeSystem, TPtr: ForeignType + ?Sized> ExternInput<TS> for *mut TPtr
 {
     type ForeignType = Self;
     type Lease = ();
-    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, ())>
+    unsafe fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, ())>
     {
         Ok((self, ()))
     }
@@ -192,11 +224,11 @@ impl<TS: TypeSystem, TPtr: ForeignType + ?Sized> ExternInput<TS> for *mut TPtr
     }
 }
 
-impl<TS: TypeSystem, TPtr: ForeignType + ?Sized> ExternInput<TS> for *const TPtr
+unsafe impl<TS: TypeSystem, TPtr: ForeignType + ?Sized> ExternInput<TS> for *const TPtr
 {
     type ForeignType = Self;
     type Lease = ();
-    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, ())>
+    unsafe fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, ())>
     {
         Ok((self, ()))
     }

--- a/intercom/src/type_system.rs
+++ b/intercom/src/type_system.rs
@@ -50,133 +50,29 @@ pub trait BidirectionalTypeInfo
     }
 }
 
-/// Defines details of the type that specify how to pass it as an input parameter.
-pub trait InputTypeInfo
-{
-    /// The name of the type.
-    fn type_name() -> &'static str;
-    fn indirection_level() -> u32
-    {
-        0
-    }
-}
-
-/// Defines details of the type that specify how to pass it as an output parameter.
-pub trait OutputTypeInfo
-{
-    /// The name of the type.
-    fn type_name() -> &'static str;
-    fn indirection_level() -> u32
-    {
-        0
-    }
-}
-
 /// Defines a type that is compatible with Intercom interfaces.
-pub trait ExternType<TS: TypeSystem>: Sized
+pub trait ExternParameter<TS: TypeSystem>: Sized
 {
-    /// Type used when the Self type is encountered as an input parameter.
-    type ExternInputType: InputTypeInfo;
+    type ForeignType: BidirectionalTypeInfo;
 
-    /// Type used when the Self type is encountered as an output type.
-    type ExternOutputType: OutputTypeInfo;
+    type IntoTemporary;
+    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::IntoTemporary)>;
 
-    /// A possible temporary type used for converting `Self` into
-    /// `ExternInputType` when calling Intercom interfaces from Rust.
-    type OwnedExternType: IntercomFrom<Self> = Self;
-
-    /// A possible temporary type used for converting `ExternInputType` into
-    /// `Self` type when calling Rust through an Intercom interface.
-    type OwnedNativeType: IntercomFrom<Self::ExternInputType> = Self;
+    type OwnedParameter;
+    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::OwnedParameter>;
 }
 
-/// A conversion that may fail by resulting in a `ComError .
-pub trait IntercomFrom<TSource>: Sized
+pub trait ExternOutput<TS: TypeSystem>: Sized
 {
-    /// # Safety
-    ///
-    /// The use of this functions performs may perform pointer dereferencing
-    /// and other magic common with C-types. The caller is responsible for
-    /// ensuring the parameters fulfill the requirements of the target type.
-    unsafe fn intercom_from(source: TSource) -> ComResult<Self>;
+    type ForeignType: BidirectionalTypeInfo;
+
+    fn into_foreign_output(self) -> ComResult<Self::ForeignType>;
+
+    unsafe fn from_foreign_output(source: Self::ForeignType) -> ComResult<Self>;
 }
 
-/// Default identity blanket implementation.
-impl<T> IntercomFrom<T> for T
-{
-    default unsafe fn intercom_from(source: T) -> ComResult<T>
-    {
-        Ok(source)
-    }
-}
-
-/// Blanket implementation for all cloneable instance references.
-impl<TSource: Clone> IntercomFrom<&TSource> for TSource
-{
-    unsafe fn intercom_from(source: &TSource) -> ComResult<Self>
-    {
-        Ok(source.clone())
-    }
-}
-
-/// A conversion that may fail by resulting in a `ComError .
-pub trait IntercomInto<TTarget>
-{
-    /// # Safety
-    ///
-    /// The use of this functions performs may perform pointer dereferencing
-    /// and other magic common with C-types. The caller is responsible for
-    /// ensuring the parameters fulfill the requirements of the target type.
-    unsafe fn intercom_into(self: Self) -> ComResult<TTarget>;
-}
-
-/// Blanket implementation for reversing IntercomFrom into IntercomInto.
-impl<TSource, TTarget: IntercomFrom<TSource>> IntercomInto<TTarget> for TSource
-{
-    default unsafe fn intercom_into(self: Self) -> ComResult<TTarget>
-    {
-        TTarget::intercom_from(self)
-    }
-}
-
-/// Bidirectional types can be used as input types.
-impl<BT> InputTypeInfo for BT
-where
-    BT: BidirectionalTypeInfo,
-{
-    /// The name of the type.
-    fn type_name() -> &'static str
-    {
-        <BT as BidirectionalTypeInfo>::type_name()
-    }
-    fn indirection_level() -> u32
-    {
-        <BT as BidirectionalTypeInfo>::indirection_level()
-    }
-}
-
-/// Bidirectional types can be used as output types.
-impl<BT> OutputTypeInfo for BT
-where
-    BT: BidirectionalTypeInfo,
-{
-    /// The name of the type.
-    fn type_name() -> &'static str
-    {
-        <BT as BidirectionalTypeInfo>::type_name()
-    }
-    fn indirection_level() -> u32
-    {
-        <BT as BidirectionalTypeInfo>::indirection_level()
-    }
-}
-
-/// A quick macro for implementing ExternType for various basic types that
-/// should represent themselves.
-///
-/// Ideally we would use specialization here to implement ExternType for T,
-/// but that prevents other crates from implementing a specialized version for
-/// some reason.
+/// A quick macro for implementing ExternParameter/etc. for various basic types
+/// that should represent themselves.
 macro_rules! self_extern {
     ( $t:ty ) => {
         impl BidirectionalTypeInfo for $t
@@ -188,12 +84,36 @@ macro_rules! self_extern {
             }
         }
 
-        impl<TS: TypeSystem> ExternType<TS> for $t
+        impl<TS: TypeSystem> ExternParameter<TS> for $t
         {
-            type ExternInputType = $t;
-            type ExternOutputType = $t;
-            type OwnedExternType = $t;
-            type OwnedNativeType = $t;
+            type ForeignType = $t;
+            type IntoTemporary = ();
+            fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, ())>
+            {
+                Ok((self, ()))
+            }
+
+            type OwnedParameter = Self;
+            unsafe fn from_foreign_parameter(
+                source: Self::ForeignType,
+            ) -> ComResult<Self::OwnedParameter>
+            {
+                Ok(source)
+            }
+        }
+
+        impl<TS: TypeSystem> ExternOutput<TS> for $t
+        {
+            type ForeignType = $t;
+            fn into_foreign_output(self) -> ComResult<Self::ForeignType>
+            {
+                Ok(self)
+            }
+
+            unsafe fn from_foreign_output(source: Self::ForeignType) -> ComResult<Self>
+            {
+                Ok(source)
+            }
         }
     };
 }
@@ -220,122 +140,100 @@ self_extern!(HRESULT);
 use crate::GUID;
 self_extern!(GUID);
 
-self_extern!(std::ffi::c_void);
 self_extern!(TypeSystemName);
 
-// Any raw pointer is passed as is.
-
-impl<TPtr> BidirectionalTypeInfo for *mut TPtr
-where
-    TPtr: BidirectionalTypeInfo,
+impl BidirectionalTypeInfo for libc::c_void
 {
-    /// The name of the type.
+    fn type_name() -> &'static str
+    {
+        "void"
+    }
+}
+
+impl<TS: TypeSystem, TPtr: BidirectionalTypeInfo + ?Sized> ExternOutput<TS> for *mut TPtr
+{
+    type ForeignType = Self;
+    fn into_foreign_output(self) -> ComResult<Self::ForeignType>
+    {
+        Ok(self)
+    }
+
+    unsafe fn from_foreign_output(source: Self::ForeignType) -> ComResult<Self>
+    {
+        Ok(source)
+    }
+}
+
+impl<TS: TypeSystem, TPtr: BidirectionalTypeInfo + ?Sized> ExternOutput<TS> for *const TPtr
+{
+    type ForeignType = Self;
+    fn into_foreign_output(self) -> ComResult<Self::ForeignType>
+    {
+        Ok(self)
+    }
+
+    unsafe fn from_foreign_output(source: Self::ForeignType) -> ComResult<Self>
+    {
+        Ok(source)
+    }
+}
+
+impl<TS: TypeSystem, TPtr: BidirectionalTypeInfo + ?Sized> ExternParameter<TS> for *mut TPtr
+{
+    type ForeignType = Self;
+    type IntoTemporary = ();
+    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, ())>
+    {
+        Ok((self, ()))
+    }
+
+    type OwnedParameter = Self;
+    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::OwnedParameter>
+    {
+        Ok(source)
+    }
+}
+
+impl<TS: TypeSystem, TPtr: BidirectionalTypeInfo + ?Sized> ExternParameter<TS> for *const TPtr
+{
+    type ForeignType = Self;
+    type IntoTemporary = ();
+    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, ())>
+    {
+        Ok((self, ()))
+    }
+
+    type OwnedParameter = Self;
+    unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self::OwnedParameter>
+    {
+        Ok(source)
+    }
+}
+
+impl<TPtr: BidirectionalTypeInfo + ?Sized> BidirectionalTypeInfo for *mut TPtr
+{
     fn type_name() -> &'static str
     {
         <TPtr as BidirectionalTypeInfo>::type_name()
     }
+
     fn indirection_level() -> u32
     {
         <TPtr as BidirectionalTypeInfo>::indirection_level() + 1
     }
 }
 
-impl<TS: TypeSystem, TPtr> ExternType<TS> for *mut TPtr
-where
-    TPtr: BidirectionalTypeInfo,
+impl<TPtr: BidirectionalTypeInfo + ?Sized> BidirectionalTypeInfo for *const TPtr
 {
-    type ExternInputType = *mut TPtr;
-    type ExternOutputType = *mut TPtr;
-    type OwnedExternType = *mut TPtr;
-    type OwnedNativeType = *mut TPtr;
-}
-
-impl<TPtr> BidirectionalTypeInfo for *const TPtr
-where
-    TPtr: BidirectionalTypeInfo,
-{
-    /// The name of the type.
     fn type_name() -> &'static str
     {
         <TPtr as BidirectionalTypeInfo>::type_name()
     }
+
     fn indirection_level() -> u32
     {
         <TPtr as BidirectionalTypeInfo>::indirection_level() + 1
     }
-}
-
-impl<TS: TypeSystem, TPtr> ExternType<TS> for *const TPtr
-where
-    TPtr: BidirectionalTypeInfo,
-{
-    type ExternInputType = *const TPtr;
-    type ExternOutputType = *const TPtr;
-    type OwnedExternType = *const TPtr;
-    type OwnedNativeType = *const TPtr;
-}
-
-/// `ComItf` extern type implementation.
-
-impl<I: crate::ComInterface + ?Sized> BidirectionalTypeInfo for &crate::ComItf<I>
-where
-    I: BidirectionalTypeInfo,
-{
-    /// The name of the type.
-    fn type_name() -> &'static str
-    {
-        <I as BidirectionalTypeInfo>::type_name()
-    }
-    fn indirection_level() -> u32
-    {
-        <I as BidirectionalTypeInfo>::indirection_level() + 1
-    }
-}
-
-impl<'a, TS: TypeSystem, I: crate::ComInterface + ?Sized> ExternType<TS> for &'a crate::ComItf<I>
-where
-    I: BidirectionalTypeInfo,
-{
-    type ExternInputType = crate::raw::InterfacePtr<TS, I>;
-    type ExternOutputType = crate::raw::InterfacePtr<TS, I>;
-    type OwnedExternType = &'a crate::ComItf<I>;
-    type OwnedNativeType = crate::ComItf<I>;
-}
-
-impl<TS: TypeSystem, I: crate::ComInterface + ?Sized> ExternType<TS>
-    for crate::raw::InterfacePtr<TS, I>
-where
-    I: BidirectionalTypeInfo,
-{
-    type ExternInputType = crate::raw::InterfacePtr<TS, I>;
-    type ExternOutputType = crate::raw::InterfacePtr<TS, I>;
-    type OwnedExternType = crate::raw::InterfacePtr<TS, I>;
-    type OwnedNativeType = crate::raw::InterfacePtr<TS, I>;
-}
-
-impl<I: crate::ComInterface + ?Sized> BidirectionalTypeInfo for crate::ComRc<I>
-where
-    I: BidirectionalTypeInfo,
-{
-    /// The name of the type.
-    fn type_name() -> &'static str
-    {
-        <I as BidirectionalTypeInfo>::type_name()
-    }
-    fn indirection_level() -> u32
-    {
-        <I as BidirectionalTypeInfo>::indirection_level() + 1
-    }
-}
-
-impl<TS: TypeSystem, I: crate::ComInterface + ?Sized> ExternType<TS> for crate::ComRc<I>
-where
-    I: BidirectionalTypeInfo,
-{
-    type ExternInputType = crate::raw::InterfacePtr<TS, I>;
-    type ExternOutputType = crate::raw::InterfacePtr<TS, I>;
-    type OwnedExternType = crate::raw::InterfacePtr<TS, I>;
-    type OwnedNativeType = crate::raw::InterfacePtr<TS, I>;
 }
 
 impl<TS: TypeSystem, I: crate::ComInterface + ?Sized> BidirectionalTypeInfo
@@ -351,71 +249,6 @@ where
     fn indirection_level() -> u32
     {
         <I as BidirectionalTypeInfo>::indirection_level() + 1
-    }
-}
-
-impl<TS: TypeSystem, I: crate::ComInterface + ?Sized> IntercomFrom<crate::ComItf<I>>
-    for crate::raw::InterfacePtr<TS, I>
-{
-    unsafe fn intercom_from(source: crate::ComItf<I>) -> ComResult<Self>
-    {
-        Ok(crate::ComItf::ptr(&source))
-    }
-}
-
-impl<TS: TypeSystem, I: crate::ComInterface + ?Sized> IntercomFrom<&crate::ComItf<I>>
-    for crate::raw::InterfacePtr<TS, I>
-{
-    unsafe fn intercom_from(source: &crate::ComItf<I>) -> ComResult<Self>
-    {
-        Ok(crate::ComItf::ptr(source))
-    }
-}
-
-impl<TS: TypeSystem, I: crate::ComInterface + ?Sized> IntercomFrom<&&crate::ComItf<I>>
-    for crate::raw::InterfacePtr<TS, I>
-{
-    unsafe fn intercom_from(source: &&crate::ComItf<I>) -> ComResult<Self>
-    {
-        Ok(crate::ComItf::ptr(*source))
-    }
-}
-
-impl<TS: TypeSystem, I: crate::ComInterface + ?Sized> IntercomFrom<crate::ComRc<I>>
-    for crate::raw::InterfacePtr<TS, I>
-{
-    unsafe fn intercom_from(source: crate::ComRc<I>) -> ComResult<Self>
-    {
-        Ok(crate::ComItf::ptr(&crate::ComRc::detach(source)))
-    }
-}
-
-impl<TS: TypeSystem, I: crate::ComInterface + ?Sized> IntercomFrom<crate::raw::InterfacePtr<TS, I>>
-    for crate::ComRc<I>
-{
-    unsafe fn intercom_from(source: crate::raw::InterfacePtr<TS, I>) -> ComResult<Self>
-    {
-        Ok(crate::ComRc::attach(
-            crate::ComItf::maybe_wrap(source).ok_or_else(|| crate::ComError::E_INVALIDARG)?,
-        ))
-    }
-}
-
-impl<TS: TypeSystem, I: crate::ComInterface + ?Sized> IntercomFrom<crate::raw::InterfacePtr<TS, I>>
-    for crate::ComItf<I>
-{
-    unsafe fn intercom_from(source: crate::raw::InterfacePtr<TS, I>) -> ComResult<Self>
-    {
-        crate::ComItf::maybe_wrap(source).ok_or_else(|| crate::ComError::E_INVALIDARG)
-    }
-}
-
-impl<TS: TypeSystem, I: crate::ComInterface + ?Sized> IntercomFrom<&crate::raw::InterfacePtr<TS, I>>
-    for crate::ComItf<I>
-{
-    unsafe fn intercom_from(source: &crate::raw::InterfacePtr<TS, I>) -> ComResult<Self>
-    {
-        crate::ComItf::maybe_wrap(*source).ok_or_else(|| crate::ComError::E_INVALIDARG)
     }
 }
 

--- a/intercom/src/typelib/mod.rs
+++ b/intercom/src/typelib/mod.rs
@@ -62,7 +62,7 @@ pub enum TypeInfo
     Interface(ComBox<Interface>),
 }
 
-#[derive(intercom::ExternType, intercom::BidirectionalTypeInfo, Debug)]
+#[derive(intercom::ExternOutput, intercom::BidirectionalTypeInfo, Debug)]
 #[repr(C)]
 pub enum TypeInfoKind
 {
@@ -110,7 +110,7 @@ pub struct Interface
     pub options: InterfaceOptions,
 }
 
-#[derive(Debug, Clone, Default, intercom::ExternType, intercom::BidirectionalTypeInfo)]
+#[derive(Debug, Clone, Default, intercom::ExternOutput, intercom::BidirectionalTypeInfo)]
 #[repr(C)]
 pub struct InterfaceOptions
 {
@@ -168,7 +168,7 @@ pub struct Arg
 }
 
 #[derive(
-    Debug, Clone, Copy, intercom::ExternType, intercom::BidirectionalTypeInfo, PartialEq, Eq,
+    Debug, Clone, Copy, intercom::ExternOutput, intercom::BidirectionalTypeInfo, PartialEq, Eq,
 )]
 #[repr(C)]
 pub enum Direction

--- a/intercom/src/typelib/mod.rs
+++ b/intercom/src/typelib/mod.rs
@@ -167,9 +167,7 @@ pub struct Arg
     pub direction: Direction,
 }
 
-#[derive(
-    Debug, Clone, Copy, intercom::ExternOutput, intercom::ForeignType, PartialEq, Eq,
-)]
+#[derive(Debug, Clone, Copy, intercom::ExternOutput, intercom::ForeignType, PartialEq, Eq)]
 #[repr(C)]
 pub enum Direction
 {

--- a/intercom/src/typelib/mod.rs
+++ b/intercom/src/typelib/mod.rs
@@ -62,7 +62,7 @@ pub enum TypeInfo
     Interface(ComBox<Interface>),
 }
 
-#[derive(intercom::ExternOutput, intercom::BidirectionalTypeInfo, Debug)]
+#[derive(intercom::ExternOutput, intercom::ForeignType, Debug)]
 #[repr(C)]
 pub enum TypeInfoKind
 {
@@ -110,7 +110,7 @@ pub struct Interface
     pub options: InterfaceOptions,
 }
 
-#[derive(Debug, Clone, Default, intercom::ExternOutput, intercom::BidirectionalTypeInfo)]
+#[derive(Debug, Clone, Default, intercom::ExternOutput, intercom::ForeignType)]
 #[repr(C)]
 pub struct InterfaceOptions
 {
@@ -168,7 +168,7 @@ pub struct Arg
 }
 
 #[derive(
-    Debug, Clone, Copy, intercom::ExternOutput, intercom::BidirectionalTypeInfo, PartialEq, Eq,
+    Debug, Clone, Copy, intercom::ExternOutput, intercom::ForeignType, PartialEq, Eq,
 )]
 #[repr(C)]
 pub enum Direction

--- a/intercom/src/variant.rs
+++ b/intercom/src/variant.rs
@@ -1,13 +1,13 @@
 use crate::type_system::{ExternInput, ExternOutput, TypeSystem};
 use crate::*;
-use intercom_attributes::BidirectionalTypeInfo;
+use intercom_attributes::ForeignType;
 use std::convert::TryFrom;
 use std::time::SystemTime;
 
 #[derive(Debug, Clone, Copy)]
 pub struct Currency(i64);
 
-#[derive(Debug, Clone, BidirectionalTypeInfo)]
+#[derive(Debug, Clone, ForeignType)]
 pub enum Variant
 {
     None,
@@ -622,7 +622,7 @@ impl<T: Into<IntercomString>> From<T> for Variant
 pub mod raw
 {
 
-    use super::intercom_attributes::BidirectionalTypeInfo;
+    use super::intercom_attributes::ForeignType;
     use crate::type_system::TypeSystem;
     use std;
     use std::time::{Duration, SystemTime};
@@ -794,7 +794,7 @@ pub mod raw
     }
 
     #[repr(C)]
-    #[derive(Copy, Clone, BidirectionalTypeInfo)]
+    #[derive(Copy, Clone, ForeignType)]
     pub struct Variant<TS: TypeSystem>
     {
         pub vt: VariantType,

--- a/intercom/src/variant.rs
+++ b/intercom/src/variant.rs
@@ -1,4 +1,4 @@
-use crate::type_system::{ExternOutput, ExternParameter, TypeSystem};
+use crate::type_system::{ExternInput, ExternOutput, TypeSystem};
 use crate::*;
 use intercom_attributes::BidirectionalTypeInfo;
 use std::convert::TryFrom;
@@ -116,18 +116,18 @@ impl Default for Variant
     }
 }
 
-impl<TS: TypeSystem> ExternParameter<TS> for Variant
+impl<TS: TypeSystem> ExternInput<TS> for Variant
 {
     type ForeignType = raw::Variant<TS>;
 
-    type IntoTemporary = ();
+    type Lease = ();
     fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, ())>
     {
         Self::ForeignType::try_from(self).map(|variant| (variant, ()))
     }
 
-    type OwnedParameter = Self;
-    unsafe fn from_foreign_parameter(src: Self::ForeignType) -> ComResult<Self::OwnedParameter>
+    type Owned = Self;
+    unsafe fn from_foreign_parameter(src: Self::ForeignType) -> ComResult<Self::Owned>
     {
         Self::from_raw(src)
     }

--- a/intercom/src/variant.rs
+++ b/intercom/src/variant.rs
@@ -52,6 +52,9 @@ impl Variant
         }
     }
 
+    /// # Safety
+    ///
+    /// The source variant must be a valid variant.
     pub unsafe fn from_raw<TS: TypeSystem>(src: raw::Variant<TS>) -> ComResult<Self>
     {
         Ok(if src.vt.0 & raw::var_type::BYREF == 0 {
@@ -116,12 +119,12 @@ impl Default for Variant
     }
 }
 
-impl<TS: TypeSystem> ExternInput<TS> for Variant
+unsafe impl<TS: TypeSystem> ExternInput<TS> for Variant
 {
     type ForeignType = raw::Variant<TS>;
 
     type Lease = ();
-    fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, ())>
+    unsafe fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, ())>
     {
         Self::ForeignType::try_from(self).map(|variant| (variant, ()))
     }
@@ -133,7 +136,7 @@ impl<TS: TypeSystem> ExternInput<TS> for Variant
     }
 }
 
-impl<TS: TypeSystem> ExternOutput<TS> for Variant
+unsafe impl<TS: TypeSystem> ExternOutput<TS> for Variant
 {
     type ForeignType = raw::Variant<TS>;
 

--- a/test/multilib/src/lib.rs
+++ b/test/multilib/src/lib.rs
@@ -1,4 +1,4 @@
-#![crate_type="dylib"]
+#![crate_type = "dylib"]
 #![feature(type_ascription)]
 
 extern crate intercom;
@@ -6,32 +6,37 @@ use intercom::*;
 extern crate winapi;
 
 // Declare available COM classes.
-com_library!( HelloWorld );
+com_library!(HelloWorld);
 
 #[com_interface]
 trait IHelloWorld
 {
-    fn get_hello( &self ) -> String;
+    fn get_hello(&self) -> String;
 }
 
-#[com_class( clsid = "{25ccb3f6-b782-4b2d-933e-54ab447da0aa}", IHelloWorld )]
-pub struct HelloWorld { }
+#[com_class(clsid = "{25ccb3f6-b782-4b2d-933e-54ab447da0aa}", IHelloWorld)]
+pub struct HelloWorld {}
 
 impl HelloWorld
 {
-    pub fn new() -> HelloWorld {
-        HelloWorld { }
+    pub fn new() -> HelloWorld
+    {
+        HelloWorld {}
     }
 }
 
 #[com_impl]
-impl IHelloWorld for HelloWorld {
-    fn get_hello( &self ) -> String { "Hello World!".to_string() }
+impl IHelloWorld for HelloWorld
+{
+    fn get_hello(&self) -> String
+    {
+        "Hello World!".to_string()
+    }
 }
 
 #[test]
 fn hello_world_returns_hello_world()
 {
     let hello = HelloWorld::new();
-    assert_eq!( hello.get_hello(), "Hello World!" );
+    assert_eq!(hello.get_hello(), "Hello World!");
 }

--- a/test/testlib/Cargo.toml
+++ b/test/testlib/Cargo.toml
@@ -10,3 +10,4 @@ crate-type = [ "cdylib" ]
 intercom = { path = "../../intercom" }
 winapi = "0.2.8"
 chrono = "0.4"
+env_logger = "*"

--- a/test/testlib/Cargo.toml
+++ b/test/testlib/Cargo.toml
@@ -10,4 +10,3 @@ crate-type = [ "cdylib" ]
 intercom = { path = "../../intercom" }
 winapi = "0.2.8"
 chrono = "0.4"
-env_logger = "*"

--- a/test/testlib/src/alloc.rs
+++ b/test/testlib/src/alloc.rs
@@ -1,20 +1,24 @@
-
 use intercom::*;
 
-#[com_class( AllocTests)]
+#[com_class(AllocTests)]
 pub struct AllocTests;
 
 #[com_interface]
 #[com_impl]
 impl AllocTests
 {
-    pub fn new() -> AllocTests { AllocTests }
-
-    pub fn get_bstr( &self, value: u32 ) -> String {
-        format!( "{}", value )
+    pub fn new() -> AllocTests
+    {
+        AllocTests
     }
 
-    pub fn get_bstr_result( &self, value: u32 ) -> ComResult<String> {
-        Ok( format!( "{}", value ) )
+    pub fn get_bstr(&self, value: u32) -> String
+    {
+        format!("{}", value)
+    }
+
+    pub fn get_bstr_result(&self, value: u32) -> ComResult<String>
+    {
+        Ok(format!("{}", value))
     }
 }

--- a/test/testlib/src/error_info.rs
+++ b/test/testlib/src/error_info.rs
@@ -1,55 +1,42 @@
-
 use intercom::*;
 
 #[com_interface]
 pub trait IErrorSource
 {
-    fn return_comerror(
-        &self,
-        hr : raw::HRESULT,
-        desc : &str
-    ) -> ComResult<()>;
+    fn return_comerror(&self, hr: raw::HRESULT, desc: &str) -> ComResult<()>;
 
-    fn return_testerror(
-        &self,
-        hr : raw::HRESULT,
-        desc : &str
-    ) -> Result<(), TestError>;
+    fn return_testerror(&self, hr: raw::HRESULT, desc: &str) -> Result<(), TestError>;
 
-    fn return_ioerror(
-        &self,
-        hr : raw::HRESULT,
-        desc : &str
-    ) -> Result<(), std::io::Error>;
+    fn return_ioerror(&self, hr: raw::HRESULT, desc: &str) -> Result<(), std::io::Error>;
 }
 
-#[com_class( ErrorTests, IErrorSource )]
+#[com_class(ErrorTests, IErrorSource)]
 pub struct ErrorTests;
 
 #[com_interface]
 #[com_impl]
 impl ErrorTests
 {
-    pub fn new() -> ErrorTests { ErrorTests }
-
-    pub fn test_comerror( &self, source : &ComItf<dyn IErrorSource> ) -> ComResult<()>
+    pub fn new() -> ErrorTests
     {
-        let err = source.return_comerror(
-                raw::HRESULT::new( 123 ),
-                "Error message" );
+        ErrorTests
+    }
+
+    pub fn test_comerror(&self, source: &ComItf<dyn IErrorSource>) -> ComResult<()>
+    {
+        let err = source.return_comerror(raw::HRESULT::new(123), "Error message");
 
         match err {
-            Ok(..) => Err( ComError::E_FAIL ),
-            Err( e ) => {
-
+            Ok(..) => Err(ComError::E_FAIL),
+            Err(e) => {
                 if e.hresult.hr != 123 {
-                    return Err( ComError::E_INVALIDARG
-                            .with_message( format!( "Bad HRESULT: {}", e.hresult.hr ) ) );
+                    return Err(ComError::E_INVALIDARG
+                        .with_message(format!("Bad HRESULT: {}", e.hresult.hr)));
                 }
 
-                if e.description() != Some( "Error message" ) {
-                    return Err( ComError::E_INVALIDARG
-                            .with_message( format!( "Bad message: {:?}", e.description() ) ) );
+                if e.description() != Some("Error message") {
+                    return Err(ComError::E_INVALIDARG
+                        .with_message(format!("Bad message: {:?}", e.description())));
                 }
 
                 Ok(())
@@ -57,24 +44,23 @@ impl ErrorTests
         }
     }
 
-    pub fn test_testerror( &self, source : &ComItf<dyn IErrorSource> ) -> ComResult<()>
+    pub fn test_testerror(&self, source: &ComItf<dyn IErrorSource>) -> ComResult<()>
     {
-        let err = source.return_testerror(
-                raw::HRESULT::new( 123 ),
-                "Error message" );
+        let err = source.return_testerror(raw::HRESULT::new(123), "Error message");
 
         match err {
-            Ok(..) => Err( ComError::E_FAIL ),
-            Err( e ) => {
-
+            Ok(..) => Err(ComError::E_FAIL),
+            Err(e) => {
                 if e.0.hr != 123 {
-                    return Err( ComError::E_INVALIDARG
-                            .with_message( format!( "Bad HRESULT: {}", e.0.hr ) ) );
+                    return Err(
+                        ComError::E_INVALIDARG.with_message(format!("Bad HRESULT: {}", e.0.hr))
+                    );
                 }
 
                 if e.1 != "Error message" {
-                    return Err( ComError::E_INVALIDARG
-                            .with_message( format!( "Bad message: {:?}", e.1 ) ) );
+                    return Err(
+                        ComError::E_INVALIDARG.with_message(format!("Bad message: {:?}", e.1))
+                    );
                 }
 
                 Ok(())
@@ -82,25 +68,23 @@ impl ErrorTests
         }
     }
 
-    pub fn test_ioerror( &self, source : &ComItf<dyn IErrorSource> ) -> ComResult<()>
+    pub fn test_ioerror(&self, source: &ComItf<dyn IErrorSource>) -> ComResult<()>
     {
-        let err = source.return_ioerror(
-                raw::HRESULT::new( raw::E_ACCESSDENIED.hr ),
-                "Access denied" );
+        let err = source.return_ioerror(raw::HRESULT::new(raw::E_ACCESSDENIED.hr), "Access denied");
 
         match err {
-            Ok(..) => Err( ComError::E_FAIL ),
-            Err( e ) => {
-
+            Ok(..) => Err(ComError::E_FAIL),
+            Err(e) => {
                 if e.kind() != std::io::ErrorKind::PermissionDenied {
-                    return Err( ComError::E_INVALIDARG
-                            .with_message( format!( "Bad kind: {:?}", e.kind() ) ) );
+                    return Err(
+                        ComError::E_INVALIDARG.with_message(format!("Bad kind: {:?}", e.kind()))
+                    );
                 }
 
                 use std::error::Error;
                 if e.description() != "Access denied" {
-                    return Err( ComError::E_INVALIDARG
-                            .with_message( format!( "Bad message: {:?}", e.description() ) ) );
+                    return Err(ComError::E_INVALIDARG
+                        .with_message(format!("Bad message: {:?}", e.description())));
                 }
 
                 Ok(())
@@ -112,76 +96,78 @@ impl ErrorTests
 #[com_impl]
 impl IErrorSource for ErrorTests
 {
-    fn return_comerror(
-        &self,
-        hr : raw::HRESULT,
-        desc : &str
-    ) -> ComResult<()>
+    fn return_comerror(&self, hr: raw::HRESULT, desc: &str) -> ComResult<()>
     {
-        Err( ComError::new_message( hr, desc.to_string() ) )
+        Err(ComError::new_message(hr, desc.to_string()))
     }
 
-    fn return_testerror(
-        &self,
-        hr : raw::HRESULT,
-        desc : &str
-    ) -> Result<(), TestError>
+    fn return_testerror(&self, hr: raw::HRESULT, desc: &str) -> Result<(), TestError>
     {
-        Err( TestError( hr, desc.to_string() ) )
+        Err(TestError(hr, desc.to_string()))
     }
 
-    fn return_ioerror(
-        &self,
-        _hr : raw::HRESULT,
-        _desc : &str
-    ) -> Result<(), std::io::Error>
+    fn return_ioerror(&self, _hr: raw::HRESULT, _desc: &str) -> Result<(), std::io::Error>
     {
-        Err( std::io::Error::new(
-                std::io::ErrorKind::PermissionDenied,
-                "permission denied" ) )
+        Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "permission denied",
+        ))
     }
 }
 
 #[derive(Debug)]
-pub struct TestError( raw::HRESULT, String );
+pub struct TestError(raw::HRESULT, String);
 
-impl<TS: intercom::type_system::TypeSystem>
-        intercom::type_system::ExternOutput<TS> for TestError {
+impl<TS: intercom::type_system::TypeSystem> intercom::type_system::ExternOutput<TS> for TestError
+{
     type ForeignType = raw::HRESULT;
 
-    fn into_foreign_output(self) -> ComResult<Self::ForeignType> {
+    fn into_foreign_output(self) -> ComResult<Self::ForeignType>
+    {
         Ok(self.0)
     }
 
-    unsafe fn from_foreign_output(source: Self::ForeignType) -> ComResult<Self> {
+    unsafe fn from_foreign_output(source: Self::ForeignType) -> ComResult<Self>
+    {
         Ok(TestError(source, "".to_string()))
     }
 }
 
-impl std::error::Error for TestError {
-    fn description( &self ) -> &str { &self.1 }
-    fn cause( &self ) -> Option<&dyn std::error::Error> { None }
+impl std::error::Error for TestError
+{
+    fn description(&self) -> &str
+    {
+        &self.1
+    }
+    fn cause(&self) -> Option<&dyn std::error::Error>
+    {
+        None
+    }
 }
 
-impl std::fmt::Display for TestError {
-    fn fmt( &self, f : &mut std::fmt::Formatter ) -> std::fmt::Result
+impl std::fmt::Display for TestError
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result
     {
-        write!( f, "{}", self.1 )
+        write!(f, "{}", self.1)
     }
 }
 
 impl From<TestError> for intercom::ComError
 {
-    fn from( source : TestError ) -> intercom::ComError {
-        intercom::ComError::new_message( source.0, source.1 )
+    fn from(source: TestError) -> intercom::ComError
+    {
+        intercom::ComError::new_message(source.0, source.1)
     }
 }
 
 impl From<intercom::ComError> for TestError
 {
-    fn from( source : intercom::ComError ) -> TestError {
+    fn from(source: intercom::ComError) -> TestError
+    {
         TestError(
             source.hresult,
-            source.description().unwrap_or( "" ).to_owned() )
+            source.description().unwrap_or("").to_owned(),
+        )
     }
 }

--- a/test/testlib/src/error_info.rs
+++ b/test/testlib/src/error_info.rs
@@ -118,7 +118,8 @@ impl IErrorSource for ErrorTests
 #[derive(Debug)]
 pub struct TestError(raw::HRESULT, String);
 
-impl<TS: intercom::type_system::TypeSystem> intercom::type_system::ExternOutput<TS> for TestError
+unsafe impl<TS: intercom::type_system::TypeSystem> intercom::type_system::ExternOutput<TS>
+    for TestError
 {
     type ForeignType = raw::HRESULT;
 

--- a/test/testlib/src/error_info.rs
+++ b/test/testlib/src/error_info.rs
@@ -146,15 +146,14 @@ impl IErrorSource for ErrorTests
 pub struct TestError( raw::HRESULT, String );
 
 impl<TS: intercom::type_system::TypeSystem>
-        intercom::type_system::ExternType<TS> for TestError {
-    type ExternInputType = raw::HRESULT;
-    type ExternOutputType = raw::HRESULT;
-    type OwnedNativeType = TestError;
-    type OwnedExternType = TestError;
-}
+        intercom::type_system::ExternOutput<TS> for TestError {
+    type ForeignType = raw::HRESULT;
 
-impl intercom::type_system::IntercomFrom<error::raw::HRESULT> for TestError {
-    default unsafe fn intercom_from( source: error::raw::HRESULT ) -> ComResult<TestError> {
+    fn into_foreign_output(self) -> ComResult<Self::ForeignType> {
+        Ok(self.0)
+    }
+
+    unsafe fn from_foreign_output(source: Self::ForeignType) -> ComResult<Self> {
         Ok(TestError(source, "".to_string()))
     }
 }

--- a/test/testlib/src/interface_params.rs
+++ b/test/testlib/src/interface_params.rs
@@ -1,29 +1,44 @@
-
 use intercom::*;
 
 #[com_interface]
-pub trait ISharedInterface {
-    fn get_value( &self ) -> u32;
-    fn set_value( &mut self, v : u32 );
-    fn divide_by( &self, divisor: &ComItf<dyn ISharedInterface> ) -> ComResult<u32>;
+pub trait ISharedInterface
+{
+    fn get_value(&self) -> u32;
+    fn set_value(&mut self, v: u32);
+    fn divide_by(&self, divisor: &ComItf<dyn ISharedInterface>) -> ComResult<u32>;
 }
 
-#[com_class( ISharedInterface)]
-pub struct SharedImplementation { value: u32 }
+#[com_class(ISharedInterface)]
+pub struct SharedImplementation
+{
+    value: u32,
+}
 
-impl SharedImplementation {
-    pub fn new() -> SharedImplementation { SharedImplementation { value: 0 } }
+impl SharedImplementation
+{
+    pub fn new() -> SharedImplementation
+    {
+        SharedImplementation { value: 0 }
+    }
 }
 
 #[com_impl]
-impl ISharedInterface for SharedImplementation {
-    fn get_value( &self ) -> u32 { self.value }
-    fn set_value( &mut self, v : u32 ) { self.value = v }
-    fn divide_by( &self, other: &ComItf<dyn ISharedInterface> ) -> ComResult<u32> {
+impl ISharedInterface for SharedImplementation
+{
+    fn get_value(&self) -> u32
+    {
+        self.value
+    }
+    fn set_value(&mut self, v: u32)
+    {
+        self.value = v
+    }
+    fn divide_by(&self, other: &ComItf<dyn ISharedInterface>) -> ComResult<u32>
+    {
         let divisor = other.get_value();
         match divisor {
-            0 => Err( ComError::E_INVALIDARG ),
-            _ => Ok( self.value / divisor ),
+            0 => Err(ComError::E_INVALIDARG),
+            _ => Ok(self.value / divisor),
         }
     }
 }

--- a/test/testlib/src/lib.rs
+++ b/test/testlib/src/lib.rs
@@ -1,23 +1,22 @@
-#![crate_type="dylib"]
+#![crate_type = "dylib"]
 #![feature(type_ascription, specialization)]
-
 
 extern crate intercom;
 use intercom::*;
-extern crate winapi;
 extern crate chrono;
+extern crate winapi;
 
+pub mod alloc;
+pub mod error_info;
+pub mod interface_params;
 pub mod primitive;
+pub mod result;
 pub mod return_interfaces;
 pub mod stateful;
-pub mod result;
-pub mod interface_params;
-pub mod error_info;
-pub mod alloc;
 pub mod strings;
 pub mod type_system_callbacks;
-pub mod variant;
 pub mod unicode;
+pub mod variant;
 
 // Declare available COM classes.
 com_library!(

--- a/test/testlib/src/primitive.rs
+++ b/test/testlib/src/primitive.rs
@@ -1,32 +1,62 @@
-
 use intercom::*;
 
-#[com_class( clsid = "{12341234-1234-1234-1234-123412340001}", PrimitiveOperations )]
-pub struct PrimitiveOperations { }
+#[com_class(clsid = "{12341234-1234-1234-1234-123412340001}", PrimitiveOperations)]
+pub struct PrimitiveOperations {}
 
 #[com_interface(
-        com_iid = "{12341234-1234-1234-1234-123412340002}",
-        raw_iid = "{12341234-1234-1234-1234-123412340003}")]
+    com_iid = "{12341234-1234-1234-1234-123412340002}",
+    raw_iid = "{12341234-1234-1234-1234-123412340003}"
+)]
 #[com_impl]
 impl PrimitiveOperations
 {
-    pub fn new() -> PrimitiveOperations {
-        PrimitiveOperations { }
+    pub fn new() -> PrimitiveOperations
+    {
+        PrimitiveOperations {}
     }
 
-    pub fn i8( &self, v : i8 ) -> i8 { !( v.wrapping_add( 1 ) ) }
-    pub fn u8( &self, v : u8 ) -> u8 { !( v.wrapping_add( 1 ) ) }
+    pub fn i8(&self, v: i8) -> i8
+    {
+        !(v.wrapping_add(1))
+    }
+    pub fn u8(&self, v: u8) -> u8
+    {
+        !(v.wrapping_add(1))
+    }
 
-    pub fn u16( &self, v : u16 ) -> u16 { !( v.wrapping_add( 1 ) ) }
-    pub fn i16( &self, v : i16 ) -> i16 { !( v.wrapping_add( 1 ) ) }
+    pub fn u16(&self, v: u16) -> u16
+    {
+        !(v.wrapping_add(1))
+    }
+    pub fn i16(&self, v: i16) -> i16
+    {
+        !(v.wrapping_add(1))
+    }
 
-    pub fn i32( &self, v : i32 ) -> i32 { !( v.wrapping_add( 1 ) ) }
-    pub fn u32( &self, v : u32 ) -> u32 { !( v.wrapping_add( 1 ) ) }
+    pub fn i32(&self, v: i32) -> i32
+    {
+        !(v.wrapping_add(1))
+    }
+    pub fn u32(&self, v: u32) -> u32
+    {
+        !(v.wrapping_add(1))
+    }
 
-    pub fn i64( &self, v : i64 ) -> i64 { !( v.wrapping_add( 1 ) ) }
-    pub fn u64( &self, v : u64 ) -> u64 { !( v.wrapping_add( 1 ) ) }
+    pub fn i64(&self, v: i64) -> i64
+    {
+        !(v.wrapping_add(1))
+    }
+    pub fn u64(&self, v: u64) -> u64
+    {
+        !(v.wrapping_add(1))
+    }
 
-    pub fn f64( &self, v : f64 ) -> f64 { 1f64 / v }
-    pub fn f32( &self, v : f32 ) -> f32 { 1f32 / v }
+    pub fn f64(&self, v: f64) -> f64
+    {
+        1f64 / v
+    }
+    pub fn f32(&self, v: f32) -> f32
+    {
+        1f32 / v
+    }
 }
-

--- a/test/testlib/src/result.rs
+++ b/test/testlib/src/result.rs
@@ -1,32 +1,41 @@
-
 use intercom::*;
 use std::convert::TryFrom;
 
-#[com_class( ResultOperations )]
-pub struct ResultOperations { }
+#[com_class(ResultOperations)]
+pub struct ResultOperations {}
 
 #[com_interface]
 #[com_impl]
-impl ResultOperations {
-    pub fn new() -> ResultOperations { ResultOperations {} }
+impl ResultOperations
+{
+    pub fn new() -> ResultOperations
+    {
+        ResultOperations {}
+    }
 
-    pub fn s_ok( &mut self ) -> raw::HRESULT {
+    pub fn s_ok(&mut self) -> raw::HRESULT
+    {
         raw::S_OK
     }
 
-    pub fn not_impl( &mut self ) -> raw::HRESULT {
+    pub fn not_impl(&mut self) -> raw::HRESULT
+    {
         raw::E_NOTIMPL
     }
 
-    pub fn sqrt( &mut self, value : f64 ) -> ComResult<f64> {
-        if value < 0.0 { return Err( ComError::E_INVALIDARG ) }
-        Ok( value.sqrt() )
+    pub fn sqrt(&mut self, value: f64) -> ComResult<f64>
+    {
+        if value < 0.0 {
+            return Err(ComError::E_INVALIDARG);
+        }
+        Ok(value.sqrt())
     }
 
-    pub fn tuple( &self, value : u32 ) -> ComResult<( u16, u16 )> {
-        let first = u16::try_from( ( value & 0xffff_0000 ) >> 16 ).unwrap();
-        let second = u16::try_from( value & 0xffff ).unwrap();
+    pub fn tuple(&self, value: u32) -> ComResult<(u16, u16)>
+    {
+        let first = u16::try_from((value & 0xffff_0000) >> 16).unwrap();
+        let second = u16::try_from(value & 0xffff).unwrap();
 
-        Ok( ( first, second ) )
+        Ok((first, second))
     }
 }

--- a/test/testlib/src/return_interfaces.rs
+++ b/test/testlib/src/return_interfaces.rs
@@ -1,84 +1,120 @@
-
 use intercom::*;
 
 #[com_interface]
 trait IRefCount
 {
-    fn get_ref_count( &self ) -> u32;
+    fn get_ref_count(&self) -> u32;
 }
 
-#[com_class( ClassCreator )]
-pub struct ClassCreator { }
+#[com_class(ClassCreator)]
+pub struct ClassCreator {}
 
 #[com_interface]
 #[com_impl]
-impl ClassCreator {
-    pub fn new() -> ClassCreator { ClassCreator {} }
+impl ClassCreator
+{
+    pub fn new() -> ClassCreator
+    {
+        ClassCreator {}
+    }
 
-    pub fn create_root( &self, id : i32 ) -> ComResult<ComRc<CreatedClass>> {
-        Ok( ComRc::from( &ComBox::new( CreatedClass::new_with_id( id ) ) ) )
+    pub fn create_root(&self, id: i32) -> ComResult<ComRc<CreatedClass>>
+    {
+        Ok(ComRc::from(&ComBox::new(CreatedClass::new_with_id(id))))
     }
 
     pub fn create_child(
         &self,
-        id : i32,
-        parent : &ComItf<dyn IParent>
+        id: i32,
+        parent: &ComItf<dyn IParent>,
     ) -> ComResult<ComRc<CreatedClass>>
     {
-        Ok( ComRc::from( &ComBox::new(
-            CreatedClass::new_child( id, parent.get_id() )
-        ) ) )
+        Ok(ComRc::from(&ComBox::new(CreatedClass::new_child(
+            id,
+            parent.get_id(),
+        ))))
     }
 }
 
-#[com_class( CreatedClass, IParent, IRefCount )]
-pub struct CreatedClass { id : i32, parent: i32 }
+#[com_class(CreatedClass, IParent, IRefCount)]
+pub struct CreatedClass
+{
+    id: i32,
+    parent: i32,
+}
 
 #[com_interface]
 #[com_impl]
-impl CreatedClass {
-    pub fn new() -> CreatedClass { unreachable!() }
-    pub fn new_with_id( id : i32 ) -> CreatedClass { CreatedClass { id, parent: 0 } }
-    pub fn new_child( id : i32, parent : i32 ) -> CreatedClass { CreatedClass { id, parent } }
+impl CreatedClass
+{
+    pub fn new() -> CreatedClass
+    {
+        unreachable!()
+    }
+    pub fn new_with_id(id: i32) -> CreatedClass
+    {
+        CreatedClass { id, parent: 0 }
+    }
+    pub fn new_child(id: i32, parent: i32) -> CreatedClass
+    {
+        CreatedClass { id, parent }
+    }
 
-    pub fn get_id( &self ) -> ComResult<i32> { Ok( self.id ) }
-    pub fn get_parent_id( &self ) -> ComResult<i32> { Ok( self.parent ) }
+    pub fn get_id(&self) -> ComResult<i32>
+    {
+        Ok(self.id)
+    }
+    pub fn get_parent_id(&self) -> ComResult<i32>
+    {
+        Ok(self.parent)
+    }
 }
 
 #[com_impl]
-impl IRefCount for CreatedClass {
-    fn get_ref_count( &self ) -> u32
+impl IRefCount for CreatedClass
+{
+    fn get_ref_count(&self) -> u32
     {
-        let combox = unsafe { ComBoxData::of( self ) };
+        let combox = unsafe { ComBoxData::of(self) };
         combox.get_ref_count()
     }
 }
 
 #[com_interface]
-pub trait IParent {
-    fn get_id( &self ) -> i32;
+pub trait IParent
+{
+    fn get_id(&self) -> i32;
 }
 
 #[com_impl]
-impl IParent for CreatedClass {
-    fn get_id( &self ) -> i32 { self.id }
+impl IParent for CreatedClass
+{
+    fn get_id(&self) -> i32
+    {
+        self.id
+    }
 }
 
-#[com_class( RefCountOperations )]
+#[com_class(RefCountOperations)]
 pub struct RefCountOperations {}
 
 #[com_interface]
 #[com_impl]
-impl RefCountOperations {
-    pub fn new() -> RefCountOperations { RefCountOperations { } }
-
-    pub fn get_new( &self ) -> ComResult<ComRc<RefCountOperations>> {
-        Ok( ComRc::from( &ComBox::new( RefCountOperations::new() ) ) )
+impl RefCountOperations
+{
+    pub fn new() -> RefCountOperations
+    {
+        RefCountOperations {}
     }
 
-    pub fn get_ref_count( &self ) -> u32 {
-        let combox = unsafe { ComBoxData::of( self ) };
+    pub fn get_new(&self) -> ComResult<ComRc<RefCountOperations>>
+    {
+        Ok(ComRc::from(&ComBox::new(RefCountOperations::new())))
+    }
+
+    pub fn get_ref_count(&self) -> u32
+    {
+        let combox = unsafe { ComBoxData::of(self) };
         combox.get_ref_count()
     }
 }
-

--- a/test/testlib/src/stateful.rs
+++ b/test/testlib/src/stateful.rs
@@ -1,17 +1,25 @@
-
 use intercom::*;
 
-#[com_class(StatefulOperations )]
-pub struct StatefulOperations {
-    state : i32
+#[com_class(StatefulOperations)]
+pub struct StatefulOperations
+{
+    state: i32,
 }
 
 #[com_interface]
 #[com_impl]
-impl StatefulOperations {
-    pub fn new() -> StatefulOperations { StatefulOperations { state : 0xABBACD } }
-    pub fn put_value( &mut self, v : i32 ) {
+impl StatefulOperations
+{
+    pub fn new() -> StatefulOperations
+    {
+        StatefulOperations { state: 0xABBACD }
+    }
+    pub fn put_value(&mut self, v: i32)
+    {
         self.state = v;
     }
-    pub fn get_value( &mut self ) -> i32 { self.state }
+    pub fn get_value(&mut self) -> i32
+    {
+        self.state
+    }
 }

--- a/test/testlib/src/strings.rs
+++ b/test/testlib/src/strings.rs
@@ -1,144 +1,139 @@
-
 use intercom::*;
 
-pub static STRING_DATA: &[ &str ] = &[
-    "",
-    "Test",
-    "öäå",
-    "\u{1F980}",
-];
+pub static STRING_DATA: &[&str] = &["", "Test", "öäå", "\u{1F980}"];
 
 #[com_interface]
 pub trait IStringTests
 {
-    fn string_to_index( &self, s : &str ) -> ComResult<u32>;
+    fn string_to_index(&self, s: &str) -> ComResult<u32>;
 
-    fn index_to_string( &self, i : u32 ) -> ComResult<String>;
+    fn index_to_string(&self, i: u32) -> ComResult<String>;
 
-    fn bstr_parameter( &self, s : &BStr, ptr : usize ) -> ComResult<()>;
+    fn bstr_parameter(&self, s: &BStr, ptr: usize) -> ComResult<()>;
 
-    fn bstring_parameter( &self, s : BString ) -> ComResult<()>;
+    fn bstring_parameter(&self, s: BString) -> ComResult<()>;
 
-    fn bstring_return_value( &self ) -> ComResult<( BString, usize )>;
+    fn bstring_return_value(&self) -> ComResult<(BString, usize)>;
 
-    fn cstr_parameter( &self, s : &CStr, ptr : usize ) -> ComResult<()>;
+    fn cstr_parameter(&self, s: &CStr, ptr: usize) -> ComResult<()>;
 
-    fn cstring_parameter( &self, s : CString ) -> ComResult<()>;
+    fn cstring_parameter(&self, s: CString) -> ComResult<()>;
 
-    fn cstring_return_value( &self ) -> ComResult<( CString, usize )>;
+    fn cstring_return_value(&self) -> ComResult<(CString, usize)>;
 
-    fn invalid_string( &self, s : &str ) -> ComResult<()>;
+    fn invalid_string(&self, s: &str) -> ComResult<()>;
 }
 
-#[com_class( IStringTests )]
+#[com_class(IStringTests)]
 pub struct StringTests;
 
-impl StringTests {
-    pub fn new() -> StringTests { StringTests }
+impl StringTests
+{
+    pub fn new() -> StringTests
+    {
+        StringTests
+    }
 }
 
 #[com_impl]
 impl IStringTests for StringTests
 {
-    fn string_to_index( &self, s : &str ) -> ComResult<u32> {
-
+    fn string_to_index(&self, s: &str) -> ComResult<u32>
+    {
         for candidate in 0..STRING_DATA.len() {
-            if s == STRING_DATA[ candidate ] {
-                return Ok( candidate as u32 )
+            if s == STRING_DATA[candidate] {
+                return Ok(candidate as u32);
             }
         }
 
-        println!( "Unrecognized string: {}", s );
-        Err( ComError::E_FAIL )
+        println!("Unrecognized string: {}", s);
+        Err(ComError::E_FAIL)
     }
 
-    fn index_to_string( &self, i : u32 ) -> ComResult<String> {
-
+    fn index_to_string(&self, i: u32) -> ComResult<String>
+    {
         for candidate in 0..STRING_DATA.len() {
             if i as usize == candidate {
-                return Ok( STRING_DATA[ candidate ].to_owned() )
+                return Ok(STRING_DATA[candidate].to_owned());
             }
         }
 
-        println!( "Unrecognized index: {}", i );
-        Err( ComError::E_FAIL )
+        println!("Unrecognized index: {}", i);
+        Err(ComError::E_FAIL)
     }
 
-    fn bstr_parameter( &self, s : &BStr, ptr : usize ) -> ComResult<()> {
-
-        let string = s.to_string()
-                .map_err( |_| ComError::E_INVALIDARG )?;
+    fn bstr_parameter(&self, s: &BStr, ptr: usize) -> ComResult<()>
+    {
+        let string = s.to_string().map_err(|_| ComError::E_INVALIDARG)?;
 
         if string != "\u{1F600}" {
-            return Err( ComError::E_FAIL );
+            return Err(ComError::E_FAIL);
         }
 
         if s.as_ptr() as usize == ptr {
             Ok(())
         } else {
-            Err( ComError::E_POINTER )
+            Err(ComError::E_POINTER)
         }
     }
 
-    fn bstring_parameter( &self, s : BString ) -> ComResult<()> {
-
-        let string = s.to_string()
-                .map_err( |_| ComError::E_INVALIDARG )?;
+    fn bstring_parameter(&self, s: BString) -> ComResult<()>
+    {
+        let string = s.to_string().map_err(|_| ComError::E_INVALIDARG)?;
 
         if string != "\u{1F600}" {
-            Err( ComError::E_FAIL )
+            Err(ComError::E_FAIL)
         } else {
             Ok(())
         }
     }
 
-    fn bstring_return_value( &self ) -> ComResult<( BString, usize )> {
-
-        let bs : BString = BString::from( "\u{1F600}" );
+    fn bstring_return_value(&self) -> ComResult<(BString, usize)>
+    {
+        let bs: BString = BString::from("\u{1F600}");
         let ptr = bs.as_ptr() as usize;
 
-        Ok( ( bs, ptr ) )
+        Ok((bs, ptr))
     }
 
-    fn cstr_parameter( &self, s : &CStr, ptr : usize ) -> ComResult<()> {
-
+    fn cstr_parameter(&self, s: &CStr, ptr: usize) -> ComResult<()>
+    {
         if s.to_string_lossy() != "\u{1F600}" {
-            return Err( ComError::E_FAIL );
+            return Err(ComError::E_FAIL);
         }
 
         if s.as_ptr() as usize == ptr {
             Ok(())
         } else {
-            Err( ComError::E_POINTER )
+            Err(ComError::E_POINTER)
         }
     }
 
-    fn cstring_parameter( &self, s : CString ) -> ComResult<()> {
-
+    fn cstring_parameter(&self, s: CString) -> ComResult<()>
+    {
         if s.to_string_lossy() != "\u{1F600}" {
-            Err( ComError::E_FAIL )
+            Err(ComError::E_FAIL)
         } else {
             Ok(())
         }
     }
 
-    fn cstring_return_value( &self ) -> ComResult<( CString, usize )> {
-
-        let bs : CString = CString::new( "\u{1F600}" ).unwrap();
+    fn cstring_return_value(&self) -> ComResult<(CString, usize)>
+    {
+        let bs: CString = CString::new("\u{1F600}").unwrap();
         let ptr = bs.as_ptr() as usize;
 
-        Ok( ( bs, ptr ) )
+        Ok((bs, ptr))
     }
 
-    fn invalid_string( &self, s : &str ) -> ComResult<()> {
-
+    fn invalid_string(&self, s: &str) -> ComResult<()>
+    {
         // Don't do any validation here.
         // Intercom should do validation automatically.
-        println!( "String parameter was not invalid: {}", s );
+        println!("String parameter was not invalid: {}", s);
 
         // Caller expects E_INVALIDARG, use E_FAIL to indicate something
         // went wrong.
-        Err( ComError::E_FAIL )
+        Err(ComError::E_FAIL)
     }
 }
-

--- a/test/testlib/src/type_system_callbacks.rs
+++ b/test/testlib/src/type_system_callbacks.rs
@@ -10,11 +10,6 @@ pub struct TypeSystemCaller;
 impl TypeSystemCaller
 {
     pub fn new() -> Self {
-        static init : std::sync::Once = std::sync::Once::new();
-        init.call_once(|| {
-            env_logger::init()
-        });
-
         TypeSystemCaller
     }
 

--- a/test/testlib/src/type_system_callbacks.rs
+++ b/test/testlib/src/type_system_callbacks.rs
@@ -9,7 +9,14 @@ pub struct TypeSystemCaller;
 #[com_impl]
 impl TypeSystemCaller
 {
-    pub fn new() -> Self { TypeSystemCaller }
+    pub fn new() -> Self {
+        static init : std::sync::Once = std::sync::Once::new();
+        init.call_once(|| {
+            env_logger::init()
+        });
+
+        TypeSystemCaller
+    }
 
     pub fn call_string( &self, i: u32, callback : &ComItf<dyn IStringTests> ) -> ComResult<()> {
 

--- a/test/testlib/src/type_system_callbacks.rs
+++ b/test/testlib/src/type_system_callbacks.rs
@@ -1,86 +1,91 @@
-
 use intercom::*;
-use strings::{STRING_DATA, IStringTests};
+use strings::{IStringTests, STRING_DATA};
 
-#[com_class( TypeSystemCaller )]
+#[com_class(TypeSystemCaller)]
 pub struct TypeSystemCaller;
 
 #[com_interface]
 #[com_impl]
 impl TypeSystemCaller
 {
-    pub fn new() -> Self {
+    pub fn new() -> Self
+    {
         TypeSystemCaller
     }
 
-    pub fn call_string( &self, i: u32, callback : &ComItf<dyn IStringTests> ) -> ComResult<()> {
-
-        let actual = callback.string_to_index( STRING_DATA[ i as usize ] )?;
+    pub fn call_string(&self, i: u32, callback: &ComItf<dyn IStringTests>) -> ComResult<()>
+    {
+        let actual = callback.string_to_index(STRING_DATA[i as usize])?;
         if actual == i {
             Ok(())
         } else {
-            Err( ComError::E_FAIL )
+            Err(ComError::E_FAIL)
         }
     }
 
-    fn receive_string( &self, i : u32, callback : &ComItf<dyn IStringTests> ) -> ComResult<()> {
-
-        let actual = callback.index_to_string( i )?;
-        let expected = STRING_DATA[ i as usize ];
+    fn receive_string(&self, i: u32, callback: &ComItf<dyn IStringTests>) -> ComResult<()>
+    {
+        let actual = callback.index_to_string(i)?;
+        let expected = STRING_DATA[i as usize];
 
         if actual == expected {
             Ok(())
         } else {
-            Err( ComError::E_FAIL )
+            Err(ComError::E_FAIL)
         }
     }
 
-    fn pass_bstr( &self, callback : &ComItf<dyn IStringTests> ) -> ComResult<()> {
-        let bstr = BString::from( "\u{1F4A9}" );
-        callback.bstr_parameter( &bstr, bstr.as_ptr() as usize )
+    fn pass_bstr(&self, callback: &ComItf<dyn IStringTests>) -> ComResult<()>
+    {
+        let bstr = BString::from("\u{1F4A9}");
+        callback.bstr_parameter(&bstr, bstr.as_ptr() as usize)
     }
 
-    fn pass_bstring( &self, callback : &ComItf<dyn IStringTests> ) -> ComResult<()> {
-        let bstr = BString::from( "\u{1F4A9}" );
-        callback.bstring_parameter( bstr )
+    fn pass_bstring(&self, callback: &ComItf<dyn IStringTests>) -> ComResult<()>
+    {
+        let bstr = BString::from("\u{1F4A9}");
+        callback.bstring_parameter(bstr)
     }
 
-    fn receive_bstring( &self, callback : &ComItf<dyn IStringTests> ) -> ComResult<()> {
-        let ( bstr, ptr ) = callback.bstring_return_value()?;
+    fn receive_bstring(&self, callback: &ComItf<dyn IStringTests>) -> ComResult<()>
+    {
+        let (bstr, ptr) = callback.bstring_return_value()?;
 
         if bstr.to_string().unwrap() != "\u{1F4A9}" {
-            return Err( ComError::E_FAIL );
+            return Err(ComError::E_FAIL);
         }
 
         if bstr.as_ptr() as usize != ptr {
-            return Err( ComError::E_POINTER );
+            return Err(ComError::E_POINTER);
         }
 
         Ok(())
     }
 
-    fn pass_cstr( &self, callback : &ComItf<dyn IStringTests> ) -> ComResult<()> {
-        let cstr = CString::new( "\u{1F4A9}" ).unwrap();
-        callback.cstr_parameter( &cstr, cstr.as_ptr() as usize )
+    fn pass_cstr(&self, callback: &ComItf<dyn IStringTests>) -> ComResult<()>
+    {
+        let cstr = CString::new("\u{1F4A9}").unwrap();
+        callback.cstr_parameter(&cstr, cstr.as_ptr() as usize)
     }
 
-    fn pass_cstring( &self, callback : &ComItf<dyn IStringTests> ) -> ComResult<()> {
-        let cstr = CString::new( "\u{1F4A9}" ).unwrap();
-        callback.cstring_parameter( cstr )
+    fn pass_cstring(&self, callback: &ComItf<dyn IStringTests>) -> ComResult<()>
+    {
+        let cstr = CString::new("\u{1F4A9}").unwrap();
+        callback.cstring_parameter(cstr)
     }
 
-    fn receive_cstring( &self, callback : &ComItf<dyn IStringTests> ) -> ComResult<()> {
-        let ( cstr, ptr ) = callback.cstring_return_value()?;
+    fn receive_cstring(&self, callback: &ComItf<dyn IStringTests>) -> ComResult<()>
+    {
+        let (cstr, ptr) = callback.cstring_return_value()?;
 
         if cstr.to_string_lossy() != "\u{1F4A9}" {
-            return Err( ComError::E_FAIL );
+            return Err(ComError::E_FAIL);
         }
 
         if cstr.as_ptr() as usize != ptr {
-            return Err( ComError::E_POINTER );
+            return Err(ComError::E_POINTER);
         }
 
         Ok(())
     }
 }
-

--- a/test/testlib/src/unicode.rs
+++ b/test/testlib/src/unicode.rs
@@ -1,74 +1,69 @@
-
-use std::os::raw::c_char;
 use intercom::*;
+use std::os::raw::c_char;
 
-#[com_class( UnicodeConversion )]
+#[com_class(UnicodeConversion)]
 pub struct UnicodeConversion;
 
 #[com_interface]
 #[com_impl]
-impl UnicodeConversion {
+impl UnicodeConversion
+{
+    pub fn new() -> UnicodeConversion
+    {
+        UnicodeConversion
+    }
 
-    pub fn new() -> UnicodeConversion { UnicodeConversion }
-
-    fn utf8_to_utf16(
-        &self,
-        input : *const c_char,
-    ) -> ComResult<*mut u16>
+    fn utf8_to_utf16(&self, input: *const c_char) -> ComResult<*mut u16>
     {
         if input.is_null() {
-            return Ok( std::ptr::null_mut() )
+            return Ok(std::ptr::null_mut());
         }
 
-        let cstr = unsafe {
-            CStr::from_ptr( input )
-        };
-        let rust_str = cstr.to_str().map_err( |_| ComError::E_INVALIDARG )?;
+        let cstr = unsafe { CStr::from_ptr(input) };
+        let rust_str = cstr.to_str().map_err(|_| ComError::E_INVALIDARG)?;
 
-        let utf16 : Vec<_> = rust_str.encode_utf16().collect();
-        let buffer_len = ( utf16.len() + 1 ) * 2;
+        let utf16: Vec<_> = rust_str.encode_utf16().collect();
+        let buffer_len = (utf16.len() + 1) * 2;
 
         unsafe {
-            let buffer = intercom::alloc::allocate( ( utf16.len() + 1 ) * 2 ) as *mut u16;
+            let buffer = intercom::alloc::allocate((utf16.len() + 1) * 2) as *mut u16;
             std::ptr::copy_nonoverlapping(
-                    utf16.as_ptr() as *const c_char,
-                    buffer as *mut c_char,
-                    buffer_len );
-            Ok( buffer )
+                utf16.as_ptr() as *const c_char,
+                buffer as *mut c_char,
+                buffer_len,
+            );
+            Ok(buffer)
         }
     }
 
-    fn utf16_to_utf8(
-        &self,
-        input : *const u16,
-    ) -> ComResult<*mut c_char>
+    fn utf16_to_utf8(&self, input: *const u16) -> ComResult<*mut c_char>
     {
         if input.is_null() {
-            return Ok( std::ptr::null_mut() )
+            return Ok(std::ptr::null_mut());
         }
 
         let slice = unsafe {
-
             // Find the first zero byte.
             let mut len = 0usize;
-            while *input.offset( len as isize ) != 0 {
+            while *input.offset(len as isize) != 0 {
                 len += 1;
             }
 
-            std::slice::from_raw_parts( input, len )
+            std::slice::from_raw_parts(input, len)
         };
 
-        let s = String::from_utf16( slice ).map_err( |_| ComError::E_INVALIDARG )?;
-        let cstring = CString::new( s ).map_err( |_| ComError::E_INVALIDARG )?;
+        let s = String::from_utf16(slice).map_err(|_| ComError::E_INVALIDARG)?;
+        let cstring = CString::new(s).map_err(|_| ComError::E_INVALIDARG)?;
         let utf8bytes = cstring.to_bytes();
 
         unsafe {
-            let buffer = intercom::alloc::allocate( utf8bytes.len() + 1 ) as *mut c_char;
+            let buffer = intercom::alloc::allocate(utf8bytes.len() + 1) as *mut c_char;
             std::ptr::copy_nonoverlapping(
-                    utf8bytes.as_ptr() as *const c_char,
-                    buffer as *mut c_char,
-                    utf8bytes.len() + 1 );
-            Ok( buffer )
+                utf8bytes.as_ptr() as *const c_char,
+                buffer as *mut c_char,
+                utf8bytes.len() + 1,
+            );
+            Ok(buffer)
         }
     }
 }

--- a/test/testlib/src/variant.rs
+++ b/test/testlib/src/variant.rs
@@ -1,6 +1,5 @@
 
 use intercom::*;
-use intercom::type_system::IntercomFrom;
 use std::time::SystemTime;
 use std::convert::TryFrom;
 use chrono::prelude::*;
@@ -93,7 +92,7 @@ impl VariantTests
             } ),
             8 => Ok( {
                 let bstr : BString = BString::try_from( variant )?;
-                let string = unsafe { String::intercom_from(bstr)? };
+                let string = bstr.to_string().map_err(|_| ComError::E_INVALIDARG)?;
                 "text" == string
             } ),
             9 => Ok( true ),

--- a/test/testlib/src/variant.rs
+++ b/test/testlib/src/variant.rs
@@ -1,27 +1,33 @@
-
-use intercom::*;
-use std::time::SystemTime;
-use std::convert::TryFrom;
 use chrono::prelude::*;
+use intercom::*;
+use std::convert::TryFrom;
+use std::time::SystemTime;
 
-#[com_class( VariantTests )]
+#[com_class(VariantTests)]
 pub struct VariantTests;
 
 #[com_interface]
-pub trait IVariantInterface {
-    fn do_stuff( &self ) -> Result<Variant, ComError>;
+pub trait IVariantInterface
+{
+    fn do_stuff(&self) -> Result<Variant, ComError>;
 }
 
-#[com_class( IVariantInterface )]
+#[com_class(IVariantInterface)]
 pub struct VariantImpl;
-impl VariantImpl { pub fn new() -> Self { VariantImpl } }
+impl VariantImpl
+{
+    pub fn new() -> Self
+    {
+        VariantImpl
+    }
+}
 
 #[com_impl]
 impl IVariantInterface for VariantImpl
 {
-    fn do_stuff( &self ) -> Result<Variant, ComError>
+    fn do_stuff(&self) -> Result<Variant, ComError>
     {
-        Ok( Variant::from( 1.0 / 3.0 ) )
+        Ok(Variant::from(1.0 / 3.0))
     }
 }
 
@@ -29,181 +35,209 @@ impl IVariantInterface for VariantImpl
 #[com_impl]
 impl VariantTests
 {
-    pub fn new() -> VariantTests { VariantTests }
+    pub fn new() -> VariantTests
+    {
+        VariantTests
+    }
 
-    pub fn variant_parameter(
-        &self,
-        vt : u16,
-        variant : Variant
-    ) -> Result<(), ComError> {
-
+    pub fn variant_parameter(&self, vt: u16, variant: Variant) -> Result<(), ComError>
+    {
         let vt_type = if vt > 100 { vt / 100 } else { vt };
         if variant.raw_type() != vt_type {
-            return Err( ComError::E_INVALIDARG.with_message(
-                    format!( "Expected type {}, got {}", vt, variant.raw_type() ) ) );
+            return Err(ComError::E_INVALIDARG.with_message(format!(
+                "Expected type {}, got {}",
+                vt,
+                variant.raw_type()
+            )));
         }
 
         // Format the data into string first so we can use it as debug message
         // if the value is wrong.
         //
         // We need to do this before because the match below deconstructs the variant.
-        let mut data = format!( "{:?}", variant );
+        let mut data = format!("{:?}", variant);
         let r = match vt {
-            0 => Ok( true ),
-            1 => Ok( true ),
-            2 => Ok( -1i16 == i16::try_from( variant )? ),
-            3 => Ok( -1i32 == i32::try_from( variant )? ),
-            4 => Ok( -1.234f32 == f32::try_from( variant )? ),
-            5 => Ok( -1.234f64 == f64::try_from( variant )? ),
-            6 => Ok( true ),
-            701 => Ok( {
-                let st = DateTime::<Utc>::from( SystemTime::try_from( variant )? );
-                let expected = DateTime::<Utc>::from( raw::VariantDate::com_epoch() );
+            0 => Ok(true),
+            1 => Ok(true),
+            2 => Ok(-1i16 == i16::try_from(variant)?),
+            3 => Ok(-1i32 == i32::try_from(variant)?),
+            4 => Ok(-1.234f32 == f32::try_from(variant)?),
+            5 => Ok(-1.234f64 == f64::try_from(variant)?),
+            6 => Ok(true),
+            701 => Ok({
+                let st = DateTime::<Utc>::from(SystemTime::try_from(variant)?);
+                let expected = DateTime::<Utc>::from(raw::VariantDate::com_epoch());
                 data = st.to_string();
-                DateTime::<Utc>::from( st ) == expected
-            } ),
-            702 => Ok( {
-                let st = DateTime::<Utc>::from( SystemTime::try_from( variant )? );
-                let expected = DateTime::parse_from_rfc3339( "2000-01-02T03:04:05-00:00" )
-                        .unwrap();
+                DateTime::<Utc>::from(st) == expected
+            }),
+            702 => Ok({
+                let st = DateTime::<Utc>::from(SystemTime::try_from(variant)?);
+                let expected = DateTime::parse_from_rfc3339("2000-01-02T03:04:05-00:00").unwrap();
                 data = st.to_string();
-                DateTime::<Utc>::from( st ) == expected
-            } ),
-            703 => Ok( {
-                let st = DateTime::<Utc>::from( SystemTime::try_from( variant )? );
-                let expected = DateTime::parse_from_rfc3339( "2000-01-01T00:00:00-00:00" )
-                        .unwrap();
+                DateTime::<Utc>::from(st) == expected
+            }),
+            703 => Ok({
+                let st = DateTime::<Utc>::from(SystemTime::try_from(variant)?);
+                let expected = DateTime::parse_from_rfc3339("2000-01-01T00:00:00-00:00").unwrap();
                 data = st.to_string();
-                DateTime::<Utc>::from( st ) == expected
-            } ),
-            704 => Ok( {
-                let st = DateTime::<Utc>::from( SystemTime::try_from( variant )? );
-                let expected = DateTime::parse_from_rfc3339( "1800-01-02T03:04:05-00:00" )
-                        .unwrap();
+                DateTime::<Utc>::from(st) == expected
+            }),
+            704 => Ok({
+                let st = DateTime::<Utc>::from(SystemTime::try_from(variant)?);
+                let expected = DateTime::parse_from_rfc3339("1800-01-02T03:04:05-00:00").unwrap();
                 data = st.to_string();
-                DateTime::<Utc>::from( st ) == expected
-            } ),
-            705 => Ok( {
-                let st = DateTime::<Utc>::from( SystemTime::try_from( variant )? );
-                let expected = DateTime::parse_from_rfc3339( "1800-01-01T00:00:00-00:00" )
-                        .unwrap();
+                DateTime::<Utc>::from(st) == expected
+            }),
+            705 => Ok({
+                let st = DateTime::<Utc>::from(SystemTime::try_from(variant)?);
+                let expected = DateTime::parse_from_rfc3339("1800-01-01T00:00:00-00:00").unwrap();
                 data = st.to_string();
-                DateTime::<Utc>::from( st ) == expected
-            } ),
-            8 => Ok( {
-                let bstr : BString = BString::try_from( variant )?;
+                DateTime::<Utc>::from(st) == expected
+            }),
+            8 => Ok({
+                let bstr: BString = BString::try_from(variant)?;
                 let string = bstr.to_string().map_err(|_| ComError::E_INVALIDARG)?;
                 "text" == string
-            } ),
-            9 => Ok( true ),
-            10 => Ok( true ),
-            11 => Ok( true == bool::try_from( variant )? ),
-            12 => Ok( true ),
-            13 => Ok( true ),
-            14 => Ok( true ),  // DECIMAL
-            16 => Ok( -1i8 == i8::try_from( variant )? ),
-            17 => Ok( 129u8 == u8::try_from( variant )? ),
-            18 => Ok( 12929u16 == u16::try_from( variant )? ),
-            19 => Ok( 1292929u32 == u32::try_from( variant )? ),
-            20 => Ok( -1i64 == i64::try_from( variant )? ),
-            21 => Ok( 129292929u64 == u64::try_from( variant )? ),
-            _ => Err( ComError::E_NOTIMPL )?,
+            }),
+            9 => Ok(true),
+            10 => Ok(true),
+            11 => Ok(true == bool::try_from(variant)?),
+            12 => Ok(true),
+            13 => Ok(true),
+            14 => Ok(true), // DECIMAL
+            16 => Ok(-1i8 == i8::try_from(variant)?),
+            17 => Ok(129u8 == u8::try_from(variant)?),
+            18 => Ok(12929u16 == u16::try_from(variant)?),
+            19 => Ok(1292929u32 == u32::try_from(variant)?),
+            20 => Ok(-1i64 == i64::try_from(variant)?),
+            21 => Ok(129292929u64 == u64::try_from(variant)?),
+            _ => Err(ComError::E_NOTIMPL)?,
         };
 
         // Return the result depending on what we got.
         match r {
-            Ok( true ) => Ok(()),
-            Ok( false ) =>
-                    Err( ComError::E_INVALIDARG.with_message(
-                            format!( "Bad data: {}", data ) ) ),
-            Err( e ) => e
+            Ok(true) => Ok(()),
+            Ok(false) => Err(ComError::E_INVALIDARG.with_message(format!("Bad data: {}", data))),
+            Err(e) => e,
         }
     }
 
-    pub fn bad_variant_parameter(
-        &self,
-        vt : u16,
-        variant : Variant
-    ) -> ComResult<()> {
-
-        let r : ComResult<()> = ( || Ok( match vt {
-            0 => { <()>::try_from( variant )?; },
-            1 => { <()>::try_from( variant )?; },
-            2 => { i16::try_from( variant )?; },
-            3 => { i32::try_from( variant )?; },
-            4 => { f32::try_from( variant )?; },
-            5 => { f64::try_from( variant )?; },
-            7 => { SystemTime::try_from( variant )?; },
-            8 => { BString::try_from( variant )?; },
-            11 => { bool::try_from( variant )?; },
-            16 => { i8::try_from( variant )?; },
-            17 => { u8::try_from( variant )?; },
-            18 => { u16::try_from( variant )?; },
-            19 => { u32::try_from( variant )?; },
-            20 => { i64::try_from( variant )?; },
-            21 => { u64::try_from( variant )?; },
-            _ => Err( ComError::E_NOTIMPL )?,
-        } ) )();
+    pub fn bad_variant_parameter(&self, vt: u16, variant: Variant) -> ComResult<()>
+    {
+        let r: ComResult<()> = (|| {
+            Ok(match vt {
+                0 => {
+                    <()>::try_from(variant)?;
+                }
+                1 => {
+                    <()>::try_from(variant)?;
+                }
+                2 => {
+                    i16::try_from(variant)?;
+                }
+                3 => {
+                    i32::try_from(variant)?;
+                }
+                4 => {
+                    f32::try_from(variant)?;
+                }
+                5 => {
+                    f64::try_from(variant)?;
+                }
+                7 => {
+                    SystemTime::try_from(variant)?;
+                }
+                8 => {
+                    BString::try_from(variant)?;
+                }
+                11 => {
+                    bool::try_from(variant)?;
+                }
+                16 => {
+                    i8::try_from(variant)?;
+                }
+                17 => {
+                    u8::try_from(variant)?;
+                }
+                18 => {
+                    u16::try_from(variant)?;
+                }
+                19 => {
+                    u32::try_from(variant)?;
+                }
+                20 => {
+                    i64::try_from(variant)?;
+                }
+                21 => {
+                    u64::try_from(variant)?;
+                }
+                _ => Err(ComError::E_NOTIMPL)?,
+            })
+        })();
 
         match r {
-            Err( e ) => match e.hresult {
+            Err(e) => match e.hresult {
                 raw::E_INVALIDARG => Ok(()),
-                _ => Err( e ),
+                _ => Err(e),
             },
-            Ok(..) => Err( ComError::E_FAIL ),
+            Ok(..) => Err(ComError::E_FAIL),
         }
     }
 
-    pub fn variant_result( &self, vt : u16 ) -> ComResult<Variant> {
-
+    pub fn variant_result(&self, vt: u16) -> ComResult<Variant>
+    {
         match vt {
-            0 => Ok( Variant::None ),
-            2 => Ok( Variant::from( -1i16 ) ),
-            3 => Ok( Variant::from( -1i32 ) ),
-            4 => Ok( Variant::from( -1.234f32 ) ),
-            5 => Ok( Variant::from( -1.234f64 ) ),
-            701 => Ok( Variant::from( raw::VariantDate::com_epoch() ) ),
-            702 => Ok( Variant::from( SystemTime::from(
-                        DateTime::parse_from_rfc3339( "2000-01-02T03:04:05-00:00" ).unwrap() ) ) ),
-            703 => Ok( Variant::from( SystemTime::from(
-                        DateTime::parse_from_rfc3339( "2000-01-01T00:00:00-00:00" ).unwrap() ) ) ),
-            704 => Ok( Variant::from( SystemTime::from(
-                        DateTime::parse_from_rfc3339( "1800-01-02T03:04:05-00:00" ).unwrap() ) ) ),
-            705 => Ok( Variant::from( SystemTime::from(
-                        DateTime::parse_from_rfc3339( "1800-01-01T00:00:00-00:00" ).unwrap() ) ) ),
-            801 => Ok( Variant::from( BString::from( "text" ) ) ),
-            802 => Ok( Variant::from( String::from( "text" ) ) ),
-            803 => Ok( Variant::from( CString::new( "text" ).unwrap() ) ),
-            11 => Ok( Variant::from( true ) ),
-            1301 => Ok( Variant::from( ComBox::new( VariantImpl ) ) ),
-            1302 => Ok( Variant::from( ComRc::<dyn IUnknown>::from( &ComBox::new( VariantImpl ) ) ) ),
-            1303 => Ok( Variant::from( ComRc::<dyn IVariantInterface>::from( &ComBox::new( VariantImpl ) ) ) ),
-            16 => Ok( Variant::from( -1i8 ) ),
-            17 => Ok( Variant::from( 129u8 ) ),
-            18 => Ok( Variant::from( 12929u16 ) ),
-            19 => Ok( Variant::from( 1292929u32 ) ),
-            20 => Ok( Variant::from( -1i64 ) ),
-            21 => Ok( Variant::from( 129292929u64 ) ),
-            _ => Err( ComError::E_NOTIMPL )?,
+            0 => Ok(Variant::None),
+            2 => Ok(Variant::from(-1i16)),
+            3 => Ok(Variant::from(-1i32)),
+            4 => Ok(Variant::from(-1.234f32)),
+            5 => Ok(Variant::from(-1.234f64)),
+            701 => Ok(Variant::from(raw::VariantDate::com_epoch())),
+            702 => Ok(Variant::from(SystemTime::from(
+                DateTime::parse_from_rfc3339("2000-01-02T03:04:05-00:00").unwrap(),
+            ))),
+            703 => Ok(Variant::from(SystemTime::from(
+                DateTime::parse_from_rfc3339("2000-01-01T00:00:00-00:00").unwrap(),
+            ))),
+            704 => Ok(Variant::from(SystemTime::from(
+                DateTime::parse_from_rfc3339("1800-01-02T03:04:05-00:00").unwrap(),
+            ))),
+            705 => Ok(Variant::from(SystemTime::from(
+                DateTime::parse_from_rfc3339("1800-01-01T00:00:00-00:00").unwrap(),
+            ))),
+            801 => Ok(Variant::from(BString::from("text"))),
+            802 => Ok(Variant::from(String::from("text"))),
+            803 => Ok(Variant::from(CString::new("text").unwrap())),
+            11 => Ok(Variant::from(true)),
+            1301 => Ok(Variant::from(ComBox::new(VariantImpl))),
+            1302 => Ok(Variant::from(ComRc::<dyn IUnknown>::from(&ComBox::new(
+                VariantImpl,
+            )))),
+            1303 => Ok(Variant::from(ComRc::<dyn IVariantInterface>::from(
+                &ComBox::new(VariantImpl),
+            ))),
+            16 => Ok(Variant::from(-1i8)),
+            17 => Ok(Variant::from(129u8)),
+            18 => Ok(Variant::from(12929u16)),
+            19 => Ok(Variant::from(1292929u32)),
+            20 => Ok(Variant::from(-1i64)),
+            21 => Ok(Variant::from(129292929u64)),
+            _ => Err(ComError::E_NOTIMPL)?,
         }
     }
 
-    pub fn variant_interface(
-        &self,
-        variant : Variant
-    ) -> ComResult<Variant> {
-
+    pub fn variant_interface(&self, variant: Variant) -> ComResult<Variant>
+    {
         match variant {
-            Variant::IUnknown( iunk ) => {
-                match ComItf::query_interface::<dyn IVariantInterface>( &iunk ) {
-                    Ok( itf ) => itf.do_stuff(),
-                    Err( e ) => Err( e.with_message(
-                            "Interface not supported. IDispatch not supported by tests." ) ),
+            Variant::IUnknown(iunk) => {
+                match ComItf::query_interface::<dyn IVariantInterface>(&iunk) {
+                    Ok(itf) => itf.do_stuff(),
+                    Err(e) => Err(e.with_message(
+                        "Interface not supported. IDispatch not supported by tests.",
+                    )),
                 }
-            },
-            _ => {
-                Err( ComError::E_INVALIDARG )?
             }
+            _ => Err(ComError::E_INVALIDARG)?,
         }
     }
 }


### PR DESCRIPTION
The goal was to simplify `ExternType`, but I guess the result was the opposite.

Even so, the handling of input/output parameters and their memory is now in better hands.

In the past we had `ExternType` trait that defined various types and the actual memory management was left to the `IntercomFrom` trait, which had to guess about memory ownership based on types (such as `*const` pointers being borrows and `*mut` pointers being owned memory).

Now the `IntercomFrom` traits are gone and the `ExternType` (or rather the new `Externinput`/`ExternOutput`) traits contain the implementation that is responsible for converting values. This allows for better clarity concerning the memory ownership: In general Output parameters pass memory, Input parameters reference memory.

This also clarified the needed conversions a lot. With the use of the old `ExternType` that had to specify temporary/owned types for some conversions, specifying all the required `IntercomFrom´ traits became painful. This change is best seen in the `strings.rs`, which has lost over 100 lines since it doesn't need all the `IntercomFrom` implementations.