### PR TITLE
Use Paths instead of Idents in codegen

### DIFF
--- a/intercom-attributes/tests/data/macro/com_impl.rs.stdout
+++ b/intercom-attributes/tests/data/macro/com_impl.rs.stdout
@@ -748,7 +748,7 @@ impl Foo {
 }
 #[allow(non_snake_case)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Automation_query_interface(
+unsafe extern "system" fn __Foo_Foo_query_interface_Automation(
     self_vtable: intercom::RawComPtr,
     riid: <intercom::REFIID as intercom::type_system::ExternInput<
         intercom::type_system::AutomationTypeSystem,
@@ -784,7 +784,7 @@ unsafe extern "system" fn __Foo_Foo_Automation_query_interface(
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Automation_add_ref(self_vtable:
+unsafe extern "system" fn __Foo_Foo_add_ref_Automation(self_vtable:
                                                            intercom::RawComPtr)
  ->
      <u32 as
@@ -814,7 +814,7 @@ intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Automation_release(self_vtable:
+unsafe extern "system" fn __Foo_Foo_release_Automation(self_vtable:
                                                            intercom::RawComPtr)
  ->
      <u32 as
@@ -844,8 +844,8 @@ intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Automation_simple_method_Automation(self_vtable:
-                                                                            intercom::RawComPtr)
+unsafe extern "system" fn __Foo_Foo_simple_method_Automation(self_vtable:
+                                                                 intercom::RawComPtr)
  ->
      <() as
 intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
@@ -936,12 +936,11 @@ intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Automation_arg_method_Automation(self_vtable:
-                                                                         intercom::RawComPtr,
-                                                                     a:
-                                                                         <u16
-                                                                         as
-                                                                         intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
+unsafe extern "system" fn __Foo_Foo_arg_method_Automation(self_vtable:
+                                                              intercom::RawComPtr,
+                                                          a:
+                                                              <u16 as
+                                                              intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
  ->
      <() as
 intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
@@ -1034,8 +1033,8 @@ intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Automation_simple_result_method_Automation(self_vtable:
-                                                                                   intercom::RawComPtr)
+unsafe extern "system" fn __Foo_Foo_simple_result_method_Automation(self_vtable:
+                                                                        intercom::RawComPtr)
  ->
      <u16 as
 intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
@@ -1129,7 +1128,7 @@ intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Automation_com_result_method_Automation(
+unsafe extern "system" fn __Foo_Foo_com_result_method_Automation(
     self_vtable: intercom::RawComPtr,
     __out: *mut <u16 as intercom::type_system::ExternOutput<
         intercom::type_system::AutomationTypeSystem,
@@ -1228,7 +1227,7 @@ unsafe extern "system" fn __Foo_Foo_Automation_com_result_method_Automation(
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Automation_rust_result_method_Automation(
+unsafe extern "system" fn __Foo_Foo_rust_result_method_Automation(
     self_vtable: intercom::RawComPtr,
     __out: *mut <u16 as intercom::type_system::ExternOutput<
         intercom::type_system::AutomationTypeSystem,
@@ -1327,7 +1326,7 @@ unsafe extern "system" fn __Foo_Foo_Automation_rust_result_method_Automation(
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Automation_tuple_result_method_Automation(
+unsafe extern "system" fn __Foo_Foo_tuple_result_method_Automation(
     self_vtable: intercom::RawComPtr,
     __out1: *mut <u8 as intercom::type_system::ExternOutput<
         intercom::type_system::AutomationTypeSystem,
@@ -1440,12 +1439,11 @@ unsafe extern "system" fn __Foo_Foo_Automation_tuple_result_method_Automation(
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Automation_string_method_Automation(self_vtable:
-                                                                            intercom::RawComPtr,
-                                                                        input:
-                                                                            <String
-                                                                            as
-                                                                            intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
+unsafe extern "system" fn __Foo_Foo_string_method_Automation(self_vtable:
+                                                                 intercom::RawComPtr,
+                                                             input:
+                                                                 <String as
+                                                                 intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
  ->
      <String as
 intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
@@ -1533,7 +1531,7 @@ intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Automation_string_result_method_Automation(
+unsafe extern "system" fn __Foo_Foo_string_result_method_Automation(
     self_vtable: intercom::RawComPtr,
     input: <String as intercom::type_system::ExternInput<
         intercom::type_system::AutomationTypeSystem,
@@ -1638,16 +1636,14 @@ unsafe extern "system" fn __Foo_Foo_Automation_string_result_method_Automation(
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Automation_complete_method_Automation(
+unsafe extern "system" fn __Foo_Foo_complete_method_Automation(
     self_vtable: intercom::RawComPtr,
     a:
-                                                                              <u16
-                                                                              as
-                                                                              intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
+                                                                   <u16 as
+                                                                   intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
     b:
-                                                                              <i16
-                                                                              as
-                                                                              intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
+                                                                   <i16 as
+                                                                   intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
     __out: *mut <bool as intercom::type_system::ExternOutput<
         intercom::type_system::AutomationTypeSystem,
     >>::ForeignType,
@@ -1752,7 +1748,7 @@ unsafe extern "system" fn __Foo_Foo_Automation_complete_method_Automation(
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Automation_bool_method_Automation(
+unsafe extern "system" fn __Foo_Foo_bool_method_Automation(
     self_vtable: intercom::RawComPtr,
     input: <bool as intercom::type_system::ExternInput<
         intercom::type_system::AutomationTypeSystem,
@@ -1856,7 +1852,7 @@ unsafe extern "system" fn __Foo_Foo_Automation_bool_method_Automation(
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Automation_variant_method_Automation(
+unsafe extern "system" fn __Foo_Foo_variant_method_Automation(
     self_vtable: intercom::RawComPtr,
     input: <Variant as intercom::type_system::ExternInput<
         intercom::type_system::AutomationTypeSystem,
@@ -1972,28 +1968,28 @@ impl intercom::attributes::ComImpl<Foo, intercom::type_system::AutomationTypeSys
                     intercom::type_system::AutomationTypeSystem,
                 >>::VTable;
                 TVtbl {
-                    query_interface: __Foo_Foo_Automation_query_interface,
-                    add_ref: __Foo_Foo_Automation_add_ref,
-                    release: __Foo_Foo_Automation_release,
+                    query_interface: __Foo_Foo_query_interface_Automation,
+                    add_ref: __Foo_Foo_add_ref_Automation,
+                    release: __Foo_Foo_release_Automation,
                 }
             },
-            simple_method: __Foo_Foo_Automation_simple_method_Automation,
-            arg_method: __Foo_Foo_Automation_arg_method_Automation,
-            simple_result_method: __Foo_Foo_Automation_simple_result_method_Automation,
-            com_result_method: __Foo_Foo_Automation_com_result_method_Automation,
-            rust_result_method: __Foo_Foo_Automation_rust_result_method_Automation,
-            tuple_result_method: __Foo_Foo_Automation_tuple_result_method_Automation,
-            string_method: __Foo_Foo_Automation_string_method_Automation,
-            string_result_method: __Foo_Foo_Automation_string_result_method_Automation,
-            complete_method: __Foo_Foo_Automation_complete_method_Automation,
-            bool_method: __Foo_Foo_Automation_bool_method_Automation,
-            variant_method: __Foo_Foo_Automation_variant_method_Automation,
+            simple_method: __Foo_Foo_simple_method_Automation,
+            arg_method: __Foo_Foo_arg_method_Automation,
+            simple_result_method: __Foo_Foo_simple_result_method_Automation,
+            com_result_method: __Foo_Foo_com_result_method_Automation,
+            rust_result_method: __Foo_Foo_rust_result_method_Automation,
+            tuple_result_method: __Foo_Foo_tuple_result_method_Automation,
+            string_method: __Foo_Foo_string_method_Automation,
+            string_result_method: __Foo_Foo_string_result_method_Automation,
+            complete_method: __Foo_Foo_complete_method_Automation,
+            bool_method: __Foo_Foo_bool_method_Automation,
+            variant_method: __Foo_Foo_variant_method_Automation,
         }
     }
 }
 #[allow(non_snake_case)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Raw_query_interface(
+unsafe extern "system" fn __Foo_Foo_query_interface_Raw(
     self_vtable: intercom::RawComPtr,
     riid: <intercom::REFIID as intercom::type_system::ExternInput<
         intercom::type_system::AutomationTypeSystem,
@@ -2030,7 +2026,7 @@ unsafe extern "system" fn __Foo_Foo_Raw_query_interface(
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Raw_add_ref(self_vtable:
+unsafe extern "system" fn __Foo_Foo_add_ref_Raw(self_vtable:
                                                     intercom::RawComPtr)
  ->
      <u32 as
@@ -2061,7 +2057,7 @@ intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Raw_release(self_vtable:
+unsafe extern "system" fn __Foo_Foo_release_Raw(self_vtable:
                                                     intercom::RawComPtr)
  ->
      <u32 as
@@ -2092,8 +2088,8 @@ intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Raw_simple_method_Raw(self_vtable:
-                                                              intercom::RawComPtr)
+unsafe extern "system" fn __Foo_Foo_simple_method_Raw(self_vtable:
+                                                          intercom::RawComPtr)
  ->
      <() as
 intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
@@ -2185,11 +2181,11 @@ intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Raw_arg_method_Raw(self_vtable:
-                                                           intercom::RawComPtr,
-                                                       a:
-                                                           <u16 as
-                                                           intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType)
+unsafe extern "system" fn __Foo_Foo_arg_method_Raw(self_vtable:
+                                                       intercom::RawComPtr,
+                                                   a:
+                                                       <u16 as
+                                                       intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType)
  ->
      <() as
 intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
@@ -2283,7 +2279,7 @@ intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Raw_simple_result_method_Raw(
+unsafe extern "system" fn __Foo_Foo_simple_result_method_Raw(
     self_vtable: intercom::RawComPtr,
 ) -> <u16 as intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
 {
@@ -2378,7 +2374,7 @@ unsafe extern "system" fn __Foo_Foo_Raw_simple_result_method_Raw(
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Raw_com_result_method_Raw(
+unsafe extern "system" fn __Foo_Foo_com_result_method_Raw(
     self_vtable: intercom::RawComPtr,
     __out: *mut <u16 as intercom::type_system::ExternOutput<
         intercom::type_system::RawTypeSystem,
@@ -2478,7 +2474,7 @@ unsafe extern "system" fn __Foo_Foo_Raw_com_result_method_Raw(
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Raw_rust_result_method_Raw(
+unsafe extern "system" fn __Foo_Foo_rust_result_method_Raw(
     self_vtable: intercom::RawComPtr,
     __out: *mut <u16 as intercom::type_system::ExternOutput<
         intercom::type_system::RawTypeSystem,
@@ -2578,7 +2574,7 @@ unsafe extern "system" fn __Foo_Foo_Raw_rust_result_method_Raw(
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Raw_tuple_result_method_Raw(
+unsafe extern "system" fn __Foo_Foo_tuple_result_method_Raw(
     self_vtable: intercom::RawComPtr,
     __out1: *mut <u8 as intercom::type_system::ExternOutput<
         intercom::type_system::RawTypeSystem,
@@ -2692,11 +2688,11 @@ unsafe extern "system" fn __Foo_Foo_Raw_tuple_result_method_Raw(
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Raw_string_method_Raw(self_vtable:
-                                                              intercom::RawComPtr,
-                                                          input:
-                                                              <String as
-                                                              intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType)
+unsafe extern "system" fn __Foo_Foo_string_method_Raw(self_vtable:
+                                                          intercom::RawComPtr,
+                                                      input:
+                                                          <String as
+                                                          intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType)
  ->
      <String as
 intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType{
@@ -2793,12 +2789,11 @@ intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::Fore
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Raw_string_result_method_Raw(
+unsafe extern "system" fn __Foo_Foo_string_result_method_Raw(
     self_vtable: intercom::RawComPtr,
     input:
-                                                                     <String
-                                                                     as
-                                                                     intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
+                                                                 <String as
+                                                                 intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
     __out: *mut <String as intercom::type_system::ExternOutput<
         intercom::type_system::RawTypeSystem,
     >>::ForeignType,
@@ -2900,14 +2895,14 @@ unsafe extern "system" fn __Foo_Foo_Raw_string_result_method_Raw(
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Raw_complete_method_Raw(
+unsafe extern "system" fn __Foo_Foo_complete_method_Raw(
     self_vtable: intercom::RawComPtr,
     a:
-                                                                <u16 as
-                                                                intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
+                                                            <u16 as
+                                                            intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
     b:
-                                                                <i16 as
-                                                                intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
+                                                            <i16 as
+                                                            intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
     __out: *mut <bool as intercom::type_system::ExternOutput<
         intercom::type_system::RawTypeSystem,
     >>::ForeignType,
@@ -3014,11 +3009,11 @@ unsafe extern "system" fn __Foo_Foo_Raw_complete_method_Raw(
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Raw_bool_method_Raw(
+unsafe extern "system" fn __Foo_Foo_bool_method_Raw(
     self_vtable: intercom::RawComPtr,
     input:
-                                                            <bool as
-                                                            intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
+                                                        <bool as
+                                                        intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
     __out: *mut <bool as intercom::type_system::ExternOutput<
         intercom::type_system::RawTypeSystem,
     >>::ForeignType,
@@ -3119,11 +3114,11 @@ unsafe extern "system" fn __Foo_Foo_Raw_bool_method_Raw(
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Raw_variant_method_Raw(
+unsafe extern "system" fn __Foo_Foo_variant_method_Raw(
     self_vtable: intercom::RawComPtr,
     input:
-                                                               <Variant as
-                                                               intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
+                                                           <Variant as
+                                                           intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
     __out: *mut <Variant as intercom::type_system::ExternOutput<
         intercom::type_system::RawTypeSystem,
     >>::ForeignType,
@@ -3237,22 +3232,22 @@ intercom::attributes::ComInterface<intercom::type_system::RawTypeSystem>>::VTabl
                     intercom::type_system::AutomationTypeSystem,
                 >>::VTable;
                 TVtbl {
-                    query_interface: __Foo_Foo_Raw_query_interface,
-                    add_ref: __Foo_Foo_Raw_add_ref,
-                    release: __Foo_Foo_Raw_release,
+                    query_interface: __Foo_Foo_query_interface_Raw,
+                    add_ref: __Foo_Foo_add_ref_Raw,
+                    release: __Foo_Foo_release_Raw,
                 }
             },
-            simple_method: __Foo_Foo_Raw_simple_method_Raw,
-            arg_method: __Foo_Foo_Raw_arg_method_Raw,
-            simple_result_method: __Foo_Foo_Raw_simple_result_method_Raw,
-            com_result_method: __Foo_Foo_Raw_com_result_method_Raw,
-            rust_result_method: __Foo_Foo_Raw_rust_result_method_Raw,
-            tuple_result_method: __Foo_Foo_Raw_tuple_result_method_Raw,
-            string_method: __Foo_Foo_Raw_string_method_Raw,
-            string_result_method: __Foo_Foo_Raw_string_result_method_Raw,
-            complete_method: __Foo_Foo_Raw_complete_method_Raw,
-            bool_method: __Foo_Foo_Raw_bool_method_Raw,
-            variant_method: __Foo_Foo_Raw_variant_method_Raw,
+            simple_method: __Foo_Foo_simple_method_Raw,
+            arg_method: __Foo_Foo_arg_method_Raw,
+            simple_result_method: __Foo_Foo_simple_result_method_Raw,
+            com_result_method: __Foo_Foo_com_result_method_Raw,
+            rust_result_method: __Foo_Foo_rust_result_method_Raw,
+            tuple_result_method: __Foo_Foo_tuple_result_method_Raw,
+            string_method: __Foo_Foo_string_method_Raw,
+            string_result_method: __Foo_Foo_string_result_method_Raw,
+            complete_method: __Foo_Foo_complete_method_Raw,
+            bool_method: __Foo_Foo_bool_method_Raw,
+            variant_method: __Foo_Foo_variant_method_Raw,
         }
     }
 }

--- a/intercom-attributes/tests/data/macro/private_item.rs.stdout
+++ b/intercom-attributes/tests/data/macro/private_item.rs.stdout
@@ -1212,7 +1212,7 @@ impl Foo {
 }
 #[allow(non_snake_case)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Automation_query_interface(
+unsafe extern "system" fn __Foo_Foo_query_interface_Automation(
     self_vtable: intercom::RawComPtr,
     riid: <intercom::REFIID as intercom::type_system::ExternInput<
         intercom::type_system::AutomationTypeSystem,
@@ -1248,7 +1248,7 @@ unsafe extern "system" fn __Foo_Foo_Automation_query_interface(
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Automation_add_ref(self_vtable:
+unsafe extern "system" fn __Foo_Foo_add_ref_Automation(self_vtable:
                                                            intercom::RawComPtr)
  ->
      <u32 as
@@ -1278,7 +1278,7 @@ intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Automation_release(self_vtable:
+unsafe extern "system" fn __Foo_Foo_release_Automation(self_vtable:
                                                            intercom::RawComPtr)
  ->
      <u32 as
@@ -1308,8 +1308,8 @@ intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Automation_struct_method_Automation(self_vtable:
-                                                                            intercom::RawComPtr)
+unsafe extern "system" fn __Foo_Foo_struct_method_Automation(self_vtable:
+                                                                 intercom::RawComPtr)
  ->
      <() as
 intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
@@ -1411,18 +1411,18 @@ impl intercom::attributes::ComImpl<Foo, intercom::type_system::AutomationTypeSys
                     intercom::type_system::AutomationTypeSystem,
                 >>::VTable;
                 TVtbl {
-                    query_interface: __Foo_Foo_Automation_query_interface,
-                    add_ref: __Foo_Foo_Automation_add_ref,
-                    release: __Foo_Foo_Automation_release,
+                    query_interface: __Foo_Foo_query_interface_Automation,
+                    add_ref: __Foo_Foo_add_ref_Automation,
+                    release: __Foo_Foo_release_Automation,
                 }
             },
-            struct_method: __Foo_Foo_Automation_struct_method_Automation,
+            struct_method: __Foo_Foo_struct_method_Automation,
         }
     }
 }
 #[allow(non_snake_case)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Raw_query_interface(
+unsafe extern "system" fn __Foo_Foo_query_interface_Raw(
     self_vtable: intercom::RawComPtr,
     riid: <intercom::REFIID as intercom::type_system::ExternInput<
         intercom::type_system::AutomationTypeSystem,
@@ -1459,7 +1459,7 @@ unsafe extern "system" fn __Foo_Foo_Raw_query_interface(
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Raw_add_ref(self_vtable:
+unsafe extern "system" fn __Foo_Foo_add_ref_Raw(self_vtable:
                                                     intercom::RawComPtr)
  ->
      <u32 as
@@ -1490,7 +1490,7 @@ intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Raw_release(self_vtable:
+unsafe extern "system" fn __Foo_Foo_release_Raw(self_vtable:
                                                     intercom::RawComPtr)
  ->
      <u32 as
@@ -1521,8 +1521,8 @@ intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_Raw_struct_method_Raw(self_vtable:
-                                                              intercom::RawComPtr)
+unsafe extern "system" fn __Foo_Foo_struct_method_Raw(self_vtable:
+                                                          intercom::RawComPtr)
  ->
      <() as
 intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
@@ -1626,12 +1626,12 @@ intercom::attributes::ComInterface<intercom::type_system::RawTypeSystem>>::VTabl
                     intercom::type_system::AutomationTypeSystem,
                 >>::VTable;
                 TVtbl {
-                    query_interface: __Foo_Foo_Raw_query_interface,
-                    add_ref: __Foo_Foo_Raw_add_ref,
-                    release: __Foo_Foo_Raw_release,
+                    query_interface: __Foo_Foo_query_interface_Raw,
+                    add_ref: __Foo_Foo_add_ref_Raw,
+                    release: __Foo_Foo_release_Raw,
                 }
             },
-            struct_method: __Foo_Foo_Raw_struct_method_Raw,
+            struct_method: __Foo_Foo_struct_method_Raw,
         }
     }
 }
@@ -1803,7 +1803,7 @@ impl IFoo for Foo {
 }
 #[allow(non_snake_case)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_IFoo_Automation_query_interface(
+unsafe extern "system" fn __Foo_IFoo_query_interface_Automation(
     self_vtable: intercom::RawComPtr,
     riid: <intercom::REFIID as intercom::type_system::ExternInput<
         intercom::type_system::AutomationTypeSystem,
@@ -1839,7 +1839,7 @@ unsafe extern "system" fn __Foo_IFoo_Automation_query_interface(
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_IFoo_Automation_add_ref(self_vtable:
+unsafe extern "system" fn __Foo_IFoo_add_ref_Automation(self_vtable:
                                                             intercom::RawComPtr)
  ->
      <u32 as
@@ -1869,7 +1869,7 @@ intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_IFoo_Automation_release(self_vtable:
+unsafe extern "system" fn __Foo_IFoo_release_Automation(self_vtable:
                                                             intercom::RawComPtr)
  ->
      <u32 as
@@ -1899,8 +1899,8 @@ intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_IFoo_Automation_trait_method_Automation(self_vtable:
-                                                                            intercom::RawComPtr)
+unsafe extern "system" fn __Foo_IFoo_trait_method_Automation(self_vtable:
+                                                                 intercom::RawComPtr)
  ->
      <() as
 intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
@@ -2002,18 +2002,18 @@ impl intercom::attributes::ComImpl<dyn IFoo, intercom::type_system::AutomationTy
                     intercom::type_system::AutomationTypeSystem,
                 >>::VTable;
                 TVtbl {
-                    query_interface: __Foo_IFoo_Automation_query_interface,
-                    add_ref: __Foo_IFoo_Automation_add_ref,
-                    release: __Foo_IFoo_Automation_release,
+                    query_interface: __Foo_IFoo_query_interface_Automation,
+                    add_ref: __Foo_IFoo_add_ref_Automation,
+                    release: __Foo_IFoo_release_Automation,
                 }
             },
-            trait_method: __Foo_IFoo_Automation_trait_method_Automation,
+            trait_method: __Foo_IFoo_trait_method_Automation,
         }
     }
 }
 #[allow(non_snake_case)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_IFoo_Raw_query_interface(
+unsafe extern "system" fn __Foo_IFoo_query_interface_Raw(
     self_vtable: intercom::RawComPtr,
     riid: <intercom::REFIID as intercom::type_system::ExternInput<
         intercom::type_system::AutomationTypeSystem,
@@ -2050,7 +2050,7 @@ unsafe extern "system" fn __Foo_IFoo_Raw_query_interface(
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_IFoo_Raw_add_ref(self_vtable:
+unsafe extern "system" fn __Foo_IFoo_add_ref_Raw(self_vtable:
                                                      intercom::RawComPtr)
  ->
      <u32 as
@@ -2081,7 +2081,7 @@ intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_IFoo_Raw_release(self_vtable:
+unsafe extern "system" fn __Foo_IFoo_release_Raw(self_vtable:
                                                      intercom::RawComPtr)
  ->
      <u32 as
@@ -2112,8 +2112,8 @@ intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_IFoo_Raw_trait_method_Raw(self_vtable:
-                                                              intercom::RawComPtr)
+unsafe extern "system" fn __Foo_IFoo_trait_method_Raw(self_vtable:
+                                                          intercom::RawComPtr)
  ->
      <() as
 intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
@@ -2216,12 +2216,12 @@ impl intercom::attributes::ComImpl<dyn IFoo, intercom::type_system::RawTypeSyste
                     intercom::type_system::AutomationTypeSystem,
                 >>::VTable;
                 TVtbl {
-                    query_interface: __Foo_IFoo_Raw_query_interface,
-                    add_ref: __Foo_IFoo_Raw_add_ref,
-                    release: __Foo_IFoo_Raw_release,
+                    query_interface: __Foo_IFoo_query_interface_Raw,
+                    add_ref: __Foo_IFoo_add_ref_Raw,
+                    release: __Foo_IFoo_release_Raw,
                 }
             },
-            trait_method: __Foo_IFoo_Raw_trait_method_Raw,
+            trait_method: __Foo_IFoo_trait_method_Raw,
         }
     }
 }

--- a/intercom-attributes/tests/data/run/basic-logging.rs.stdout
+++ b/intercom-attributes/tests/data/run/basic-logging.rs.stdout
@@ -1,8 +1,8 @@
 <TIMESTAMP> INFO  [testcrate] Acquire S as IInterface
-<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] S::query_interface(8846368B-18D7-3322-4DFB-1CE9E67F42A7)
-<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] S::query_interface(8846368B-18D7-3322-4DFB-1CE9E67F42A7) -> IInterface (Automation) [xxxxxxxx]
-<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] S::query_interface(9F4CFB79-0D16-30B4-6BD3-486DC541B7C4)
-<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] S::query_interface(9F4CFB79-0D16-30B4-6BD3-486DC541B7C4) -> IInterface (Raw) [xxxxxxxx]
+<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] S::query_interface(21495B79-90CF-33C7-7032-9BC7C31AD5F9)
+<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] S::query_interface(21495B79-90CF-33C7-7032-9BC7C31AD5F9) -> IInterface (Automation) [xxxxxxxx]
+<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] S::query_interface(C96D83CC-F4BC-3B80-6951-3692BB4FDBC7)
+<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] S::query_interface(C96D83CC-F4BC-3B80-6951-3692BB4FDBC7) -> IInterface (Raw) [xxxxxxxx]
 <TIMESTAMP> INFO  [testcrate] Call IInterface::call
 <TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] Calling IInterface::call
 <TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] Calling IInterface::call, type system: Automation
@@ -13,8 +13,8 @@ Call
 <TIMESTAMP> TRACE [generated::intercom::interfaces] [xxxxxxxx] Calling IUnknown::query_interface
 <TIMESTAMP> TRACE [generated::intercom::interfaces] [xxxxxxxx] Calling IUnknown::query_interface, type system: Automation
 <TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] Serving S::query_interface
-<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] S::query_interface(8CEF9AA1-9CA1-3278-65DE-0DC2088FA5C0)
-<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] S::query_interface(8CEF9AA1-9CA1-3278-65DE-0DC2088FA5C0) -> ISubInterface (Raw) [xxxxxxxx]
+<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] S::query_interface(4CC91049-3D9A-3498-46FF-932AEDA28A33)
+<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] S::query_interface(4CC91049-3D9A-3498-46FF-932AEDA28A33) -> ISubInterface (Raw) [xxxxxxxx]
 <TIMESTAMP> TRACE [generated::intercom::interfaces] [xxxxxxxx] Calling IUnknown::release
 <TIMESTAMP> TRACE [generated::intercom::interfaces] [xxxxxxxx] Calling IUnknown::release, type system: Raw
 <TIMESTAMP> TRACE [generated::testcrate::submodule] [xxxxxxxx] Serving S::release_ptr
@@ -22,13 +22,13 @@ Call
 <TIMESTAMP> TRACE [generated::intercom::interfaces] [xxxxxxxx] Calling IUnknown::query_interface
 <TIMESTAMP> TRACE [generated::intercom::interfaces] [xxxxxxxx] Calling IUnknown::query_interface, type system: Automation
 <TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] Serving S::query_interface
-<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] S::query_interface(3B049C4C-901B-3C27-7CD9-D8D0D5881325)
-<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] S::query_interface(3B049C4C-901B-3C27-7CD9-D8D0D5881325) -> E_NOINTERFACE
+<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] S::query_interface(46B4908C-8685-327F-7766-42C217D7984B)
+<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] S::query_interface(46B4908C-8685-327F-7766-42C217D7984B) -> E_NOINTERFACE
 <TIMESTAMP> TRACE [generated::intercom::interfaces] [xxxxxxxx] Calling IUnknown::query_interface
 <TIMESTAMP> TRACE [generated::intercom::interfaces] [xxxxxxxx] Calling IUnknown::query_interface, type system: Automation
 <TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] Serving S::query_interface
-<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] S::query_interface(A082C6BF-6F0A-3C82-5954-86D506EB8662)
-<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] S::query_interface(A082C6BF-6F0A-3C82-5954-86D506EB8662) -> E_NOINTERFACE
+<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] S::query_interface(25A761EE-99D6-3A40-57CF-7F6A4ACD1615)
+<TIMESTAMP> TRACE [generated::testcrate] [xxxxxxxx] S::query_interface(25A761EE-99D6-3A40-57CF-7F6A4ACD1615) -> E_NOINTERFACE
 <TIMESTAMP> INFO  [testcrate] Cleanup
 <TIMESTAMP> TRACE [generated::intercom::interfaces] [xxxxxxxx] Calling IUnknown::release
 <TIMESTAMP> TRACE [generated::intercom::interfaces] [xxxxxxxx] Calling IUnknown::release, type system: Automation

--- a/intercom-attributes/tests/data/ui/multiple-mods.rs
+++ b/intercom-attributes/tests/data/ui/multiple-mods.rs
@@ -1,0 +1,35 @@
+extern crate intercom;
+
+mod interface {
+
+    #[intercom::com_interface]
+    pub trait MyInterface {
+        fn interface_method(&self) -> u32;
+    }
+}
+
+mod class {
+    #[intercom::com_class(MyStruct, crate::interface::MyInterface)]
+    pub struct MyStruct;
+}
+
+mod interface_impl {
+    #[intercom::com_impl]
+    impl crate::interface::MyInterface for crate::class::MyStruct {
+        fn interface_method(&self) -> u32 { 0 }
+    }
+}
+
+mod class_impl {
+    #[intercom::com_impl]
+    #[intercom::com_interface]
+    impl crate::class::MyStruct {
+        pub fn new() -> Self { Self }
+
+        fn struct_method(&self) -> u32 { 0 }
+    }
+}
+
+intercom::com_library!(
+    class::MyStruct
+);

--- a/intercom-common/src/attributes/com_impl.rs
+++ b/intercom-common/src/attributes/com_impl.rs
@@ -9,6 +9,7 @@ use crate::tyhandlers::Direction;
 
 extern crate proc_macro;
 use self::proc_macro::TokenStream;
+use syn::spanned::Spanned;
 
 /// Expands the `com_impl` attribute.
 ///
@@ -25,20 +26,22 @@ pub fn expand_com_impl(
     // Parse the attribute.
     let mut output = vec![];
     let imp = model::ComImpl::parse(item_tokens.clone().into())?;
-    let struct_ident = imp.struct_name;
-    let itf_ident = imp.interface_name;
+    let struct_path = imp.struct_path;
+    let struct_ident = imp.struct_ident;
+    let itf_path = imp.interface_path;
+    let itf_ident = imp.interface_ident;
     let maybe_dyn = match imp.is_trait_impl {
-        true => quote_spanned!(itf_ident.span() => dyn),
+        true => quote_spanned!(itf_path.span() => dyn),
         false => quote!(),
     };
 
     for (_, impl_variant) in imp.variants {
-        let itf_unique_ident = impl_variant.interface_unique_name;
+        let ts = impl_variant.type_system;
         let ts_tokens = impl_variant
             .type_system
-            .as_typesystem_type(struct_ident.span());
+            .as_typesystem_type(struct_path.span());
         let vtable_offset = quote!(
-            <#struct_ident as intercom::attributes::ComClass<#maybe_dyn #itf_ident, #ts_tokens>>::offset()
+            <#struct_path as intercom::attributes::ComClass<#maybe_dyn #itf_path, #ts_tokens>>::offset()
         );
 
         /////////////////////
@@ -54,9 +57,9 @@ pub fn expand_com_impl(
 
         // QueryInterface
         let query_interface_ident =
-            idents::method_impl(&struct_ident, &itf_unique_ident, "query_interface");
+            idents::method_impl(&struct_ident, &itf_ident, "query_interface", ts);
         let struct_name = struct_ident.to_string();
-        output.push(quote_spanned!(struct_ident.span() =>
+        output.push(quote_spanned!(struct_path.span() =>
             #[allow(non_snake_case)]
             #[doc(hidden)]
             unsafe extern "system" fn #query_interface_ident(
@@ -78,7 +81,7 @@ pub fn expand_com_impl(
                 intercom::logging::trace(|l| l(module_path!(), format_args!(
                     "[{:p}, through {:p}] Serving {}::query_interface",
                     self_ptr, self_vtable, #struct_name)));
-                intercom::ComBoxData::< #struct_ident >::query_interface(
+                intercom::ComBoxData::< #struct_path >::query_interface(
                         &mut *self_ptr,
                         riid,
                         out )
@@ -86,8 +89,8 @@ pub fn expand_com_impl(
         ));
 
         // AddRef
-        let add_ref_ident = idents::method_impl(&struct_ident, &itf_unique_ident, "add_ref");
-        output.push(quote_spanned!(struct_ident.span() =>
+        let add_ref_ident = idents::method_impl(&struct_ident, &itf_ident, "add_ref", ts);
+        output.push(quote_spanned!(struct_path.span() =>
             #[allow(non_snake_case)]
             #[allow(dead_code)]
             #[doc(hidden)]
@@ -101,13 +104,13 @@ pub fn expand_com_impl(
                 intercom::logging::trace(|l| l(module_path!(), format_args!(
                     "[{:p}, through {:p}] Serving {}::add_ref",
                     self_ptr, self_vtable, #struct_name)));
-                intercom::ComBoxData::< #struct_ident >::add_ref_ptr(self_ptr)
+                intercom::ComBoxData::< #struct_path >::add_ref_ptr(self_ptr)
             }
         ));
 
         // Release
-        let release_ident = idents::method_impl(&struct_ident, &itf_unique_ident, "release");
-        output.push(quote_spanned!(struct_ident.span() =>
+        let release_ident = idents::method_impl(&struct_ident, &itf_ident, "release", ts);
+        output.push(quote_spanned!(struct_path.span() =>
             #[allow(non_snake_case)]
             #[allow(dead_code)]
             #[doc(hidden)]
@@ -121,16 +124,16 @@ pub fn expand_com_impl(
                 intercom::logging::trace(|l| l(module_path!(), format_args!(
                     "[{:p}, through {:p}] Serving {}::release_ptr",
                     self_ptr, self_vtable, #struct_name)));
-                intercom::ComBoxData::< #struct_ident >::release_ptr(self_ptr)
+                intercom::ComBoxData::< #struct_path >::release_ptr(self_ptr)
             }
         ));
 
         // Start the definition fo the vtable fields. The base interface is always
         // IUnknown at this point. We might support IDispatch later, but for now
         // we only support IUnknown.
-        let iunk_vtbl_type = quote_spanned!(itf_ident.span() =>
+        let iunk_vtbl_type = quote_spanned!(itf_path.span() =>
             <dyn intercom::IUnknown as intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::VTable);
-        let mut vtable_fields = vec![quote_spanned!(struct_ident.span() =>
+        let mut vtable_fields = vec![quote_spanned!(struct_path.span() =>
             __base : {
                 type TVtbl = #iunk_vtbl_type;
                 TVtbl {
@@ -153,11 +156,8 @@ pub fn expand_com_impl(
         for method_info in impl_variant.methods {
             let method_ident = &method_info.display_name;
             let method_rust_ident = &method_info.display_name;
-            let method_impl_ident = idents::method_impl(
-                &struct_ident,
-                &itf_unique_ident,
-                &method_info.unique_name.to_string(),
-            );
+            let method_impl_ident =
+                idents::method_impl(&struct_ident, &itf_ident, &method_ident, ts);
 
             let in_out_args = method_info.raw_com_args().into_iter().map(|com_arg| {
                 let name = &com_arg.name;
@@ -189,9 +189,9 @@ pub fn expand_com_impl(
             // with the vtable offset.
             let ret_ty = method_info.returnhandler.com_ty();
             let self_struct_stmt = if method_info.is_const {
-                quote!( let self_struct : &#maybe_dyn #itf_ident = &**self_combox )
+                quote!( let self_struct : &#maybe_dyn #itf_path = &**self_combox )
             } else {
-                quote!( let self_struct : &mut #maybe_dyn #itf_ident = &mut **self_combox )
+                quote!( let self_struct : &mut #maybe_dyn #itf_path = &mut **self_combox )
             };
 
             let method_name = method_ident.to_string();
@@ -205,7 +205,7 @@ pub fn expand_com_impl(
                     // Acquire the reference to the ComBoxData. For this we need
                     // to offset the current 'self_vtable' vtable pointer.
                     let self_combox = ( self_vtable as usize - #vtable_offset )
-                            as *mut intercom::ComBoxData< #struct_ident >;
+                            as *mut intercom::ComBoxData< #struct_path >;
 
                     let result : Result< #ret_ty, intercom::ComError > = ( || {
                         intercom::logging::trace(|l| l(module_path!(), format_args!(
@@ -246,13 +246,13 @@ pub fn expand_com_impl(
 
         // Now that we've gathered all the virtual table fields, we can finally
         // emit the virtual table instance.
-        let attrib_data = quote_spanned!(itf_ident.span() =>
-            <#maybe_dyn #itf_ident as intercom::attributes::ComInterface<#ts_tokens>>);
-        output.push(quote_spanned!(itf_ident.span() =>
+        let attrib_data = quote_spanned!(itf_path.span() =>
+            <#maybe_dyn #itf_path as intercom::attributes::ComInterface<#ts_tokens>>);
+        output.push(quote_spanned!(itf_path.span() =>
             #[allow(non_upper_case_globals)]
             impl intercom::attributes::ComImpl<
-                #maybe_dyn #itf_ident, #ts_tokens>
-                for #struct_ident
+                #maybe_dyn #itf_path, #ts_tokens>
+                for #struct_path
             {
                 fn vtable() -> &'static #attrib_data::VTable {
                     type T = #attrib_data::VTable;
@@ -263,7 +263,7 @@ pub fn expand_com_impl(
     }
 
     output.push(quote_spanned!(imp.impl_span =>
-        impl intercom::HasInterface<#maybe_dyn #itf_ident> for #struct_ident {}
+        impl intercom::HasInterface<#maybe_dyn #itf_path> for #struct_path {}
     ));
 
     Ok(tokens_to_tokenstream(item_tokens, output))

--- a/intercom-common/src/attributes/com_impl.rs
+++ b/intercom-common/src/attributes/com_impl.rs
@@ -154,8 +154,8 @@ pub fn expand_com_impl(
         // silently. This is done by breaking out of the 'catch' before adding the
         // method to the vtable fields.
         for method_info in impl_variant.methods {
-            let method_ident = &method_info.display_name;
-            let method_rust_ident = &method_info.display_name;
+            let method_ident = &method_info.name;
+            let method_rust_ident = &method_info.name;
             let method_impl_ident =
                 idents::method_impl(&struct_ident, &itf_ident, &method_ident, ts);
 

--- a/intercom-common/src/attributes/com_interface.rs
+++ b/intercom-common/src/attributes/com_interface.rs
@@ -76,7 +76,7 @@ pub fn expand_com_interface(
     if itf.item_type == utils::InterfaceType::Trait {
         let mut impls = vec![];
         for (_, method) in itf_output.method_impls.iter() {
-            let method_rust_ident = &method.info.display_name;
+            let method_rust_ident = &method.info.name;
             let method_name = method_rust_ident.to_string();
             let mut impl_branches = vec![];
             for (ts, method_ts_impl) in method.impls.iter() {
@@ -286,7 +286,7 @@ fn process_itf_variant(
 
     // Gather all the trait methods for the remaining vtable fields.
     for method_info in &itf_variant.methods {
-        let method_ident = &method_info.display_name;
+        let method_ident = &method_info.name;
         let in_out_args = method_info.raw_com_args().into_iter().map(|com_arg| {
             let name = &com_arg.name;
             let com_ty = &com_arg.handler.com_ty(com_arg.span, com_arg.dir);
@@ -308,7 +308,7 @@ fn process_itf_variant(
         );
         vtbl_fields.push(tt);
 
-        let method_name = method_info.display_name.to_string();
+        let method_name = method_info.name.to_string();
         if !itf_output.method_impls.contains_key(&method_name) {
             itf_output
                 .method_impls
@@ -410,7 +410,7 @@ fn rust_to_com_delegate(
     let return_statement = method_info.returnhandler.com_to_rust_return(&return_ident);
 
     // Resolve some of the fields needed for quote.
-    let method_ident = &method_info.display_name;
+    let method_ident = &method_info.name;
     let return_ty = &method_info.rust_return_ty;
     let iid_tokens = utils::get_guid_tokens(&itf_variant.iid, method_info.signature_span);
     let itf_path = &itf.path;
@@ -493,7 +493,7 @@ fn create_typeinfo_for_variant(
     let ts_type = ts.as_typesystem_type(itf.span);
     let iid_tokens = utils::get_guid_tokens(&itf_variant.iid, itf.span);
     let methods = itf_variant.methods.iter().map( |m| {
-        let method_name = m.display_name.to_string();
+        let method_name = m.name.to_string();
         let return_type = match &m.return_type {
             Some(rt) => quote_spanned!(m.signature_span =>
                 intercom::typelib::Arg {

--- a/intercom-common/src/idents.rs
+++ b/intercom-common/src/idents.rs
@@ -2,6 +2,21 @@ use crate::prelude::*;
 use crate::tyhandlers::ModelTypeSystem;
 use syn::*;
 
+pub trait SomeIdent
+{
+    fn get_some_ident(&self) -> Option<Ident>;
+}
+
+impl SomeIdent for Path
+{
+    fn get_some_ident(&self) -> Option<Ident>
+    {
+        self.get_ident()
+            .cloned()
+            .or_else(|| self.segments.last().map(|l| l.ident.clone()))
+    }
+}
+
 pub fn with_ts(ident: &Ident, ts: ModelTypeSystem) -> Ident
 {
     Ident::new(&format!("{}_{:?}", ident, ts), Span::call_site())
@@ -26,9 +41,17 @@ pub fn iid(itf_name: &Ident, span: Span) -> Ident
     Ident::new(&format!("IID_{}", itf_name), span)
 }
 
-pub fn method_impl(struct_ident: &Ident, itf_ident: &Ident, method_name: &str) -> Ident
+pub fn method_impl<TMethod: std::fmt::Display>(
+    struct_ident: &Ident,
+    itf_ident: &Ident,
+    method_name: TMethod,
+    ts: ModelTypeSystem,
+) -> Ident
 {
-    new_ident(&format!("__{}_{}_{}", struct_ident, itf_ident, method_name))
+    new_ident(&format!(
+        "__{}_{}_{}_{:?}",
+        struct_ident, itf_ident, method_name, ts
+    ))
 }
 
 fn new_ident(s: &str) -> Ident

--- a/intercom-common/src/methodinfo.rs
+++ b/intercom-common/src/methodinfo.rs
@@ -134,10 +134,7 @@ impl ::std::fmt::Debug for ComArg
 pub struct ComMethodInfo
 {
     /// The display name used in public places that do not require an unique name.
-    pub display_name: Ident,
-
-    /// Unique name that differentiates between different type systems.
-    pub unique_name: Ident,
+    pub name: Ident,
 
     /// True if the self parameter is not mutable.
     pub is_const: bool,
@@ -174,8 +171,7 @@ impl PartialEq for ComMethodInfo
 {
     fn eq(&self, other: &ComMethodInfo) -> bool
     {
-        self.display_name == other.display_name
-            && self.unique_name == other.unique_name
+        self.name == other.name
             && self.is_const == other.is_const
             && self.rust_self_arg == other.rust_self_arg
             && self.rust_return_ty == other.rust_return_ty
@@ -242,8 +238,7 @@ impl ComMethodInfo
             get_return_handler(&retval_type, &return_type, retval_span, type_system)
                 .or(Err(ComMethodInfoError::BadReturnType))?;
         Ok(ComMethodInfo {
-            unique_name: Ident::new(&format!("{}_{:?}", n, type_system), n.span()),
-            display_name: n,
+            name: n,
             returnhandler: returnhandler.into(),
             signature_span: decl.span(),
             is_const,
@@ -318,8 +313,7 @@ mod tests
         let info = test_info("fn foo( &self ) {}", Automation);
 
         assert_eq!(info.is_const, true);
-        assert_eq!(info.display_name, "foo");
-        assert_eq!(info.unique_name, "foo_Automation");
+        assert_eq!(info.name, "foo");
         assert_eq!(info.args.len(), 0);
         assert_eq!(info.retval_type.is_none(), true);
         assert_eq!(info.return_type.is_none(), true);
@@ -331,8 +325,7 @@ mod tests
         let info = test_info("fn foo( &self ) -> bool {}", Raw);
 
         assert_eq!(info.is_const, true);
-        assert_eq!(info.display_name, "foo");
-        assert_eq!(info.unique_name, "foo_Raw");
+        assert_eq!(info.name, "foo");
         assert_eq!(info.args.len(), 0);
         assert_eq!(info.retval_type.is_none(), true);
         assert_eq!(info.return_type, Some(parse_quote!(bool)));
@@ -344,8 +337,7 @@ mod tests
         let info = test_info("fn foo( &self ) -> Result<String, f32> {}", Automation);
 
         assert_eq!(info.is_const, true);
-        assert_eq!(info.display_name, "foo");
-        assert_eq!(info.unique_name, "foo_Automation");
+        assert_eq!(info.name, "foo");
         assert_eq!(info.args.len(), 0);
         assert_eq!(info.retval_type, Some(parse_quote!(String)));
         assert_eq!(info.return_type, Some(parse_quote!(f32)));
@@ -357,8 +349,7 @@ mod tests
         let info = test_info("fn foo( &self ) -> ComResult<String> {}", Automation);
 
         assert_eq!(info.is_const, true);
-        assert_eq!(info.display_name, "foo");
-        assert_eq!(info.unique_name, "foo_Automation");
+        assert_eq!(info.name, "foo");
         assert_eq!(info.args.len(), 0);
         assert_eq!(info.retval_type, Some(parse_quote!(String)));
         assert_eq!(info.return_type, Some(parse_quote!(intercom::raw::HRESULT)));
@@ -370,8 +361,7 @@ mod tests
         let info = test_info("fn foo( &self, a : u32, b : f32 ) {}", Raw);
 
         assert_eq!(info.is_const, true);
-        assert_eq!(info.display_name, "foo");
-        assert_eq!(info.unique_name, "foo_Raw");
+        assert_eq!(info.name, "foo");
         assert_eq!(info.retval_type.is_none(), true);
         assert_eq!(info.return_type.is_none(), true);
 

--- a/intercom-common/src/model/comimpl.rs
+++ b/intercom-common/src/model/comimpl.rs
@@ -114,21 +114,11 @@ mod test
         assert_eq!(itf.interface_path, parse_quote!(Foo));
         assert_eq!(itf.is_trait_impl, false);
         assert_eq!(itf.variants[&Automation].methods.len(), 2);
-        assert_eq!(itf.variants[&Automation].methods[0].display_name, "foo");
-        assert_eq!(
-            itf.variants[&Automation].methods[0].unique_name,
-            "foo_Automation"
-        );
-        assert_eq!(itf.variants[&Automation].methods[1].display_name, "bar");
-        assert_eq!(
-            itf.variants[&Automation].methods[1].unique_name,
-            "bar_Automation"
-        );
+        assert_eq!(itf.variants[&Automation].methods[0].name, "foo");
+        assert_eq!(itf.variants[&Automation].methods[1].name, "bar");
         assert_eq!(itf.variants[&Raw].methods.len(), 2);
-        assert_eq!(itf.variants[&Raw].methods[0].display_name, "foo");
-        assert_eq!(itf.variants[&Raw].methods[0].unique_name, "foo_Raw");
-        assert_eq!(itf.variants[&Raw].methods[1].display_name, "bar");
-        assert_eq!(itf.variants[&Raw].methods[1].unique_name, "bar_Raw");
+        assert_eq!(itf.variants[&Raw].methods[0].name, "foo");
+        assert_eq!(itf.variants[&Raw].methods[1].name, "bar");
     }
 
     #[test]
@@ -142,20 +132,10 @@ mod test
         assert_eq!(itf.interface_path, parse_quote!(IFoo));
         assert_eq!(itf.is_trait_impl, true);
         assert_eq!(itf.variants[&Automation].methods.len(), 2);
-        assert_eq!(itf.variants[&Automation].methods[0].display_name, "one");
-        assert_eq!(
-            itf.variants[&Automation].methods[0].unique_name,
-            "one_Automation"
-        );
-        assert_eq!(itf.variants[&Automation].methods[1].display_name, "two");
-        assert_eq!(
-            itf.variants[&Automation].methods[1].unique_name,
-            "two_Automation"
-        );
+        assert_eq!(itf.variants[&Automation].methods[0].name, "one");
+        assert_eq!(itf.variants[&Automation].methods[1].name, "two");
         assert_eq!(itf.variants[&Raw].methods.len(), 2);
-        assert_eq!(itf.variants[&Raw].methods[0].display_name, "one");
-        assert_eq!(itf.variants[&Raw].methods[0].unique_name, "one_Raw");
-        assert_eq!(itf.variants[&Raw].methods[1].display_name, "two");
-        assert_eq!(itf.variants[&Raw].methods[1].unique_name, "two_Raw");
+        assert_eq!(itf.variants[&Raw].methods[0].name, "one");
+        assert_eq!(itf.variants[&Raw].methods[1].name, "two");
     }
 }

--- a/intercom-common/src/model/cominterface.rs
+++ b/intercom-common/src/model/cominterface.rs
@@ -220,8 +220,8 @@ mod test
             GUID::parse("12345678-1234-1234-1234-567890ABCDEF").unwrap()
         );
         assert_eq!(variant.methods.len(), 2);
-        assert_eq!(variant.methods[0].display_name, "foo");
-        assert_eq!(variant.methods[1].display_name, "bar");
+        assert_eq!(variant.methods[0].name, "foo");
+        assert_eq!(variant.methods[1].name, "bar");
 
         let variant = &itf.variants[&Raw];
         assert_eq!(
@@ -229,8 +229,8 @@ mod test
             GUID::parse("12345678-1234-1234-1234-567890FEDCBA").unwrap()
         );
         assert_eq!(variant.methods.len(), 2);
-        assert_eq!(variant.methods[0].display_name, "foo");
-        assert_eq!(variant.methods[1].display_name, "bar");
+        assert_eq!(variant.methods[0].name, "foo");
+        assert_eq!(variant.methods[1].name, "bar");
     }
 
     #[test]
@@ -261,8 +261,8 @@ mod test
             GUID::parse("82B905D9-D292-3531-452F-E04722F567DD").unwrap()
         );
         assert_eq!(variant.methods.len(), 2);
-        assert_eq!(variant.methods[0].display_name, "one");
-        assert_eq!(variant.methods[1].display_name, "two");
+        assert_eq!(variant.methods[0].name, "one");
+        assert_eq!(variant.methods[1].name, "two");
 
         let variant = &itf.variants[&Raw];
         assert_eq!(
@@ -270,8 +270,8 @@ mod test
             GUID::parse("E16EEA74-C0E0-34DE-6F51-1D949883DE06").unwrap()
         );
         assert_eq!(variant.methods.len(), 2);
-        assert_eq!(variant.methods[0].display_name, "one");
-        assert_eq!(variant.methods[1].display_name, "two");
+        assert_eq!(variant.methods[0].name, "one");
+        assert_eq!(variant.methods[1].name, "two");
     }
 
     #[test]
@@ -302,10 +302,8 @@ mod test
             GUID::parse("82B905D9-D292-3531-452F-E04722F567DD").unwrap()
         );
         assert_eq!(variant.methods.len(), 2);
-        assert_eq!(variant.methods[0].display_name, "one");
-        assert_eq!(variant.methods[0].unique_name, "one_Automation");
-        assert_eq!(variant.methods[1].display_name, "two");
-        assert_eq!(variant.methods[1].unique_name, "two_Automation");
+        assert_eq!(variant.methods[0].name, "one");
+        assert_eq!(variant.methods[1].name, "two");
 
         let variant = &itf.variants[&ModelTypeSystem::Raw];
         assert_eq!(
@@ -313,10 +311,8 @@ mod test
             GUID::parse("E16EEA74-C0E0-34DE-6F51-1D949883DE06").unwrap()
         );
         assert_eq!(variant.methods.len(), 2);
-        assert_eq!(variant.methods[0].display_name, "one");
-        assert_eq!(variant.methods[0].unique_name, "one_Raw");
-        assert_eq!(variant.methods[1].display_name, "two");
-        assert_eq!(variant.methods[1].unique_name, "two_Raw");
+        assert_eq!(variant.methods[0].name, "one");
+        assert_eq!(variant.methods[1].name, "two");
     }
 
     #[test]
@@ -347,8 +343,8 @@ mod test
             GUID::parse("82B905D9-D292-3531-452F-E04722F567DD").unwrap()
         );
         assert_eq!(variant.methods.len(), 2);
-        assert_eq!(variant.methods[0].unique_name, "one_Automation");
-        assert_eq!(variant.methods[1].unique_name, "two_Automation");
+        assert_eq!(variant.methods[0].name, "one");
+        assert_eq!(variant.methods[1].name, "two");
 
         let variant = &itf.variants[&Raw];
         assert_eq!(
@@ -356,7 +352,7 @@ mod test
             GUID::parse("E16EEA74-C0E0-34DE-6F51-1D949883DE06").unwrap()
         );
         assert_eq!(variant.methods.len(), 2);
-        assert_eq!(variant.methods[0].unique_name, "one_Raw");
-        assert_eq!(variant.methods[1].unique_name, "two_Raw");
+        assert_eq!(variant.methods[0].name, "one");
+        assert_eq!(variant.methods[1].name, "two");
     }
 }


### PR DESCRIPTION
Putting the work done in #131 into use.

All code gen should now be using paths instead of idents, making it possible to refer to traits/classes/etc. in different modules without having to bother about `use` statements.