### PR TITLE
Implement infallible conversions

### DIFF
--- a/intercom-attributes/tests/data/macro/com_impl.rs.stdout
+++ b/intercom-attributes/tests/data/macro/com_impl.rs.stdout
@@ -852,242 +852,142 @@ unsafe extern "system" fn __Foo_Foo_simple_method_Automation(
             Foo,
             intercom::type_system::AutomationTypeSystem,
         >>::offset()) as *mut intercom::ComBoxData<Foo>;
-    let result: Result<(), intercom::ComError> = (|| {
-        intercom::logging::trace(|l| {
-            l(
-                "testcrate",
-                ::core::fmt::Arguments::new_v1(
-                    &["[", ", through ", "] Serving ", "::"],
-                    &match (&self_combox, &self_vtable, &"Foo", &"simple_method") {
-                        (arg0, arg1, arg2, arg3) => [
-                            ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
-                            ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
-                            ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
-                            ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
-                        ],
-                    },
-                ),
-            )
-        });
-        let self_struct: &Foo = &**self_combox;
-        let __result = self_struct.simple_method();
-        Ok({})
-    })();
-    use intercom::ErrorValue;
-    match result {
-        Ok(v) => {
-            intercom::logging::trace(|l| {
-                l(
-                    "testcrate",
-                    ::core::fmt::Arguments::new_v1(
-                        &["[", ", through ", "] Serving ", "::", ", OK"],
-                        &match (&self_combox, &self_vtable, &"Foo", &"simple_method") {
-                            (arg0, arg1, arg2, arg3) => [
-                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
-                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
-                            ],
-                        },
-                    ),
-                )
-            });
-            v
-        }
-        Err(err) => {
-            intercom::logging::trace(|l| {
-                l(
-                    "testcrate",
-                    ::core::fmt::Arguments::new_v1(
-                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
-                        &match (&self_combox, &self_vtable, &"Foo", &"simple_method") {
-                            (arg0, arg1, arg2, arg3) => [
-                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
-                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
-                            ],
-                        },
-                    ),
-                )
-            });
-            <() as ErrorValue>::from_error(intercom::store_error(err))
-        }
-    }
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::"],
+                &match (&self_combox, &self_vtable, &"Foo", &"simple_method") {
+                    (arg0, arg1, arg2, arg3) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                        ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
+    let self_struct: &Foo = &**self_combox;
+    let __result = self_struct.simple_method();
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::", ", OK"],
+                &match (&self_combox, &self_vtable, &"Foo", &"simple_method") {
+                    (arg0, arg1, arg2, arg3) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                        ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_arg_method_Automation(
     self_vtable: intercom::RawComPtr,
-    a:
-                                                              <u16 as
-                                                              intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
+    a: <u16 as intercom::type_system::InfallibleExternInput<
+        intercom::type_system::AutomationTypeSystem,
+    >>::ForeignType,
 ) -> () {
     let self_combox = (self_vtable as usize
         - <Foo as intercom::attributes::ComClass<
             Foo,
             intercom::type_system::AutomationTypeSystem,
         >>::offset()) as *mut intercom::ComBoxData<Foo>;
-    let result: Result<(), intercom::ComError> = (|| {
-        intercom::logging::trace(|l| {
-            l(
-                "testcrate",
-                ::core::fmt::Arguments::new_v1(
-                    &["[", ", through ", "] Serving ", "::"],
-                    &match (&self_combox, &self_vtable, &"Foo", &"arg_method") {
-                        (arg0, arg1, arg2, arg3) => [
-                            ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
-                            ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
-                            ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
-                            ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
-                        ],
-                    },
-                ),
-            )
-        });
-        let self_struct: &Foo = &**self_combox;
-        let __result = self_struct.arg_method(<u16 as intercom::type_system::ExternInput<
-            intercom::type_system::AutomationTypeSystem,
-        >>::from_foreign_parameter(a)?);
-        Ok({})
-    })();
-    use intercom::ErrorValue;
-    match result {
-        Ok(v) => {
-            intercom::logging::trace(|l| {
-                l(
-                    "testcrate",
-                    ::core::fmt::Arguments::new_v1(
-                        &["[", ", through ", "] Serving ", "::", ", OK"],
-                        &match (&self_combox, &self_vtable, &"Foo", &"arg_method") {
-                            (arg0, arg1, arg2, arg3) => [
-                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
-                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
-                            ],
-                        },
-                    ),
-                )
-            });
-            v
-        }
-        Err(err) => {
-            intercom::logging::trace(|l| {
-                l(
-                    "testcrate",
-                    ::core::fmt::Arguments::new_v1(
-                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
-                        &match (&self_combox, &self_vtable, &"Foo", &"arg_method") {
-                            (arg0, arg1, arg2, arg3) => [
-                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
-                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
-                            ],
-                        },
-                    ),
-                )
-            });
-            <() as ErrorValue>::from_error(intercom::store_error(err))
-        }
-    }
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::"],
+                &match (&self_combox, &self_vtable, &"Foo", &"arg_method") {
+                    (arg0, arg1, arg2, arg3) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                        ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
+    let self_struct: &Foo = &**self_combox;
+    let __result = self_struct.arg_method(<u16 as intercom::type_system::InfallibleExternInput<
+        intercom::type_system::AutomationTypeSystem,
+    >>::from_foreign_parameter(a));
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::", ", OK"],
+                &match (&self_combox, &self_vtable, &"Foo", &"arg_method") {
+                    (arg0, arg1, arg2, arg3) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                        ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_simple_result_method_Automation(self_vtable:
-                                                                        intercom::RawComPtr)
- ->
-     <u16 as
-intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
+unsafe extern "system" fn __Foo_Foo_simple_result_method_Automation(
+    self_vtable: intercom::RawComPtr,
+) -> <u16 as intercom::type_system::InfallibleExternOutput<
+    intercom::type_system::AutomationTypeSystem,
+>>::ForeignType {
     let self_combox = (self_vtable as usize
         - <Foo as intercom::attributes::ComClass<
             Foo,
             intercom::type_system::AutomationTypeSystem,
         >>::offset()) as *mut intercom::ComBoxData<Foo>;
-    let result:
-            Result<<u16 as
-                   intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
-                   intercom::ComError> =
-        (||
-             {
-                 intercom::logging::trace(|l|
-                                              l("testcrate",
-                                                ::core::fmt::Arguments::new_v1(&["[",
-                                                                                 ", through ",
-                                                                                 "] Serving ",
-                                                                                 "::"],
-                                                                               &match (&self_combox,
-                                                                                       &self_vtable,
-                                                                                       &"Foo",
-                                                                                       &"simple_result_method")
-                                                                                    {
-                                                                                    (arg0,
-                                                                                     arg1,
-                                                                                     arg2,
-                                                                                     arg3)
-                                                                                    =>
-                                                                                    [::core::fmt::ArgumentV1::new(arg0,
-                                                                                                                  ::core::fmt::Pointer::fmt),
-                                                                                     ::core::fmt::ArgumentV1::new(arg1,
-                                                                                                                  ::core::fmt::Pointer::fmt),
-                                                                                     ::core::fmt::ArgumentV1::new(arg2,
-                                                                                                                  ::core::fmt::Display::fmt),
-                                                                                     ::core::fmt::ArgumentV1::new(arg3,
-                                                                                                                  ::core::fmt::Display::fmt)],
-                                                                                })));
-                 let self_struct: &Foo = &**self_combox;
-                 let __result = self_struct.simple_result_method();
-                 Ok({
-                        <u16 as
-                            intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::into_foreign_output(__result)?
-                    })
-             })();
-    use intercom::ErrorValue;
-    match result {
-        Ok(v) => {
-            intercom::logging::trace(|l| {
-                l(
-                    "testcrate",
-                    ::core::fmt::Arguments::new_v1(
-                        &["[", ", through ", "] Serving ", "::", ", OK"],
-                        &match (&self_combox, &self_vtable, &"Foo", &"simple_result_method") {
-                            (arg0, arg1, arg2, arg3) => [
-                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
-                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
-                            ],
-                        },
-                    ),
-                )
-            });
-            v
-        }
-        Err(err) => {
-            intercom::logging::trace(|l| {
-                l(
-                    "testcrate",
-                    ::core::fmt::Arguments::new_v1(
-                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
-                        &match (&self_combox, &self_vtable, &"Foo", &"simple_result_method") {
-                            (arg0, arg1, arg2, arg3) => [
-                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
-                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
-                            ],
-                        },
-                    ),
-                )
-            });
-            <<u16 as intercom::type_system::ExternOutput<
-                intercom::type_system::AutomationTypeSystem,
-            >>::ForeignType as ErrorValue>::from_error(intercom::store_error(err))
-        }
-    }
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::"],
+                &match (&self_combox, &self_vtable, &"Foo", &"simple_result_method") {
+                    (arg0, arg1, arg2, arg3) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                        ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
+    let self_struct: &Foo = &**self_combox;
+    let __result = self_struct.simple_result_method();
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::", ", OK"],
+                &match (&self_combox, &self_vtable, &"Foo", &"simple_result_method") {
+                    (arg0, arg1, arg2, arg3) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                        ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
+    <u16 as intercom::type_system::InfallibleExternOutput<
+        intercom::type_system::AutomationTypeSystem,
+    >>::into_foreign_output(__result)
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]
@@ -1403,94 +1303,59 @@ unsafe extern "system" fn __Foo_Foo_tuple_result_method_Automation(
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_string_method_Automation(self_vtable:
-                                                                 intercom::RawComPtr,
-                                                             input:
-                                                                 <String as
-                                                                 intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
- ->
-     <String as
-intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
+unsafe extern "system" fn __Foo_Foo_string_method_Automation(
+    self_vtable: intercom::RawComPtr,
+    input: <String as intercom::type_system::InfallibleExternInput<
+        intercom::type_system::AutomationTypeSystem,
+    >>::ForeignType,
+) -> <String as intercom::type_system::InfallibleExternOutput<
+    intercom::type_system::AutomationTypeSystem,
+>>::ForeignType {
     let self_combox = (self_vtable as usize
         - <Foo as intercom::attributes::ComClass<
             Foo,
             intercom::type_system::AutomationTypeSystem,
         >>::offset()) as *mut intercom::ComBoxData<Foo>;
-    let result: Result<
-        <String as intercom::type_system::ExternOutput<
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::"],
+                &match (&self_combox, &self_vtable, &"Foo", &"string_method") {
+                    (arg0, arg1, arg2, arg3) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                        ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
+    let self_struct: &Foo = &**self_combox;
+    let __result =
+        self_struct.string_method(<String as intercom::type_system::InfallibleExternInput<
             intercom::type_system::AutomationTypeSystem,
-        >>::ForeignType,
-        intercom::ComError,
-    > = (|| {
-        intercom::logging::trace(|l| {
-            l(
-                "testcrate",
-                ::core::fmt::Arguments::new_v1(
-                    &["[", ", through ", "] Serving ", "::"],
-                    &match (&self_combox, &self_vtable, &"Foo", &"string_method") {
-                        (arg0, arg1, arg2, arg3) => [
-                            ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
-                            ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
-                            ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
-                            ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
-                        ],
-                    },
-                ),
-            )
-        });
-        let self_struct: &Foo = &**self_combox;
-        let __result = self_struct.string_method(<String as intercom::type_system::ExternInput<
-            intercom::type_system::AutomationTypeSystem,
-        >>::from_foreign_parameter(input)?);
-        Ok({
-            <String as intercom::type_system::ExternOutput<
-                intercom::type_system::AutomationTypeSystem,
-            >>::into_foreign_output(__result)?
-        })
-    })();
-    use intercom::ErrorValue;
-    match result {
-        Ok(v) => {
-            intercom::logging::trace(|l| {
-                l(
-                    "testcrate",
-                    ::core::fmt::Arguments::new_v1(
-                        &["[", ", through ", "] Serving ", "::", ", OK"],
-                        &match (&self_combox, &self_vtable, &"Foo", &"string_method") {
-                            (arg0, arg1, arg2, arg3) => [
-                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
-                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
-                            ],
-                        },
-                    ),
-                )
-            });
-            v
-        }
-        Err(err) => {
-            intercom::logging::trace(|l| {
-                l(
-                    "testcrate",
-                    ::core::fmt::Arguments::new_v1(
-                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
-                        &match (&self_combox, &self_vtable, &"Foo", &"string_method") {
-                            (arg0, arg1, arg2, arg3) => [
-                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
-                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
-                            ],
-                        },
-                    ),
-                )
-            });
-            <<String as intercom::type_system::ExternOutput<
-                intercom::type_system::AutomationTypeSystem,
-            >>::ForeignType as ErrorValue>::from_error(intercom::store_error(err))
-        }
-    }
+        >>::from_foreign_parameter(input));
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::", ", OK"],
+                &match (&self_combox, &self_vtable, &"Foo", &"string_method") {
+                    (arg0, arg1, arg2, arg3) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                        ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
+    <String as intercom::type_system::InfallibleExternOutput<
+        intercom::type_system::AutomationTypeSystem,
+    >>::into_foreign_output(__result)
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]
@@ -2059,77 +1924,49 @@ unsafe extern "system" fn __Foo_Foo_simple_method_Raw(self_vtable: intercom::Raw
                  intercom::attributes::ComClass<Foo,
                                                 intercom::type_system::RawTypeSystem>>::offset())
             as *mut intercom::ComBoxData<Foo>;
-    let result: Result<(), intercom::ComError> = (|| {
-        intercom::logging::trace(|l| {
-            l(
-                "testcrate",
-                ::core::fmt::Arguments::new_v1(
-                    &["[", ", through ", "] Serving ", "::"],
-                    &match (&self_combox, &self_vtable, &"Foo", &"simple_method") {
-                        (arg0, arg1, arg2, arg3) => [
-                            ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
-                            ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
-                            ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
-                            ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
-                        ],
-                    },
-                ),
-            )
-        });
-        let self_struct: &Foo = &**self_combox;
-        let __result = self_struct.simple_method();
-        Ok({})
-    })();
-    use intercom::ErrorValue;
-    match result {
-        Ok(v) => {
-            intercom::logging::trace(|l| {
-                l(
-                    "testcrate",
-                    ::core::fmt::Arguments::new_v1(
-                        &["[", ", through ", "] Serving ", "::", ", OK"],
-                        &match (&self_combox, &self_vtable, &"Foo", &"simple_method") {
-                            (arg0, arg1, arg2, arg3) => [
-                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
-                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
-                            ],
-                        },
-                    ),
-                )
-            });
-            v
-        }
-        Err(err) => {
-            intercom::logging::trace(|l| {
-                l(
-                    "testcrate",
-                    ::core::fmt::Arguments::new_v1(
-                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
-                        &match (&self_combox, &self_vtable, &"Foo", &"simple_method") {
-                            (arg0, arg1, arg2, arg3) => [
-                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
-                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
-                            ],
-                        },
-                    ),
-                )
-            });
-            <() as ErrorValue>::from_error(intercom::store_error(err))
-        }
-    }
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::"],
+                &match (&self_combox, &self_vtable, &"Foo", &"simple_method") {
+                    (arg0, arg1, arg2, arg3) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                        ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
+    let self_struct: &Foo = &**self_combox;
+    let __result = self_struct.simple_method();
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::", ", OK"],
+                &match (&self_combox, &self_vtable, &"Foo", &"simple_method") {
+                    (arg0, arg1, arg2, arg3) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                        ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_arg_method_Raw(
     self_vtable: intercom::RawComPtr,
-    a:
-                                                       <u16 as
-                                                       intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
+    a: <u16 as intercom::type_system::InfallibleExternInput<
+        intercom::type_system::RawTypeSystem,
+    >>::ForeignType,
 ) -> () {
     let self_combox =
         (self_vtable as usize -
@@ -2137,165 +1974,93 @@ unsafe extern "system" fn __Foo_Foo_arg_method_Raw(
                  intercom::attributes::ComClass<Foo,
                                                 intercom::type_system::RawTypeSystem>>::offset())
             as *mut intercom::ComBoxData<Foo>;
-    let result: Result<(), intercom::ComError> = (|| {
-        intercom::logging::trace(|l| {
-            l(
-                "testcrate",
-                ::core::fmt::Arguments::new_v1(
-                    &["[", ", through ", "] Serving ", "::"],
-                    &match (&self_combox, &self_vtable, &"Foo", &"arg_method") {
-                        (arg0, arg1, arg2, arg3) => [
-                            ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
-                            ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
-                            ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
-                            ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
-                        ],
-                    },
-                ),
-            )
-        });
-        let self_struct: &Foo = &**self_combox;
-        let __result = self_struct.arg_method(<u16 as intercom::type_system::ExternInput<
-            intercom::type_system::RawTypeSystem,
-        >>::from_foreign_parameter(a)?);
-        Ok({})
-    })();
-    use intercom::ErrorValue;
-    match result {
-        Ok(v) => {
-            intercom::logging::trace(|l| {
-                l(
-                    "testcrate",
-                    ::core::fmt::Arguments::new_v1(
-                        &["[", ", through ", "] Serving ", "::", ", OK"],
-                        &match (&self_combox, &self_vtable, &"Foo", &"arg_method") {
-                            (arg0, arg1, arg2, arg3) => [
-                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
-                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
-                            ],
-                        },
-                    ),
-                )
-            });
-            v
-        }
-        Err(err) => {
-            intercom::logging::trace(|l| {
-                l(
-                    "testcrate",
-                    ::core::fmt::Arguments::new_v1(
-                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
-                        &match (&self_combox, &self_vtable, &"Foo", &"arg_method") {
-                            (arg0, arg1, arg2, arg3) => [
-                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
-                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
-                            ],
-                        },
-                    ),
-                )
-            });
-            <() as ErrorValue>::from_error(intercom::store_error(err))
-        }
-    }
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::"],
+                &match (&self_combox, &self_vtable, &"Foo", &"arg_method") {
+                    (arg0, arg1, arg2, arg3) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                        ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
+    let self_struct: &Foo = &**self_combox;
+    let __result = self_struct.arg_method(<u16 as intercom::type_system::InfallibleExternInput<
+        intercom::type_system::RawTypeSystem,
+    >>::from_foreign_parameter(a));
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::", ", OK"],
+                &match (&self_combox, &self_vtable, &"Foo", &"arg_method") {
+                    (arg0, arg1, arg2, arg3) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                        ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_simple_result_method_Raw(
-    self_vtable: intercom::RawComPtr,
-) -> <u16 as intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
-{
+unsafe extern "system" fn __Foo_Foo_simple_result_method_Raw(self_vtable:
+                                                                 intercom::RawComPtr)
+ ->
+     <u16 as
+intercom::type_system::InfallibleExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType{
     let self_combox =
         (self_vtable as usize -
              <Foo as
                  intercom::attributes::ComClass<Foo,
                                                 intercom::type_system::RawTypeSystem>>::offset())
             as *mut intercom::ComBoxData<Foo>;
-    let result:
-            Result<<u16 as
-                   intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType,
-                   intercom::ComError> =
-        (||
-             {
-                 intercom::logging::trace(|l|
-                                              l("testcrate",
-                                                ::core::fmt::Arguments::new_v1(&["[",
-                                                                                 ", through ",
-                                                                                 "] Serving ",
-                                                                                 "::"],
-                                                                               &match (&self_combox,
-                                                                                       &self_vtable,
-                                                                                       &"Foo",
-                                                                                       &"simple_result_method")
-                                                                                    {
-                                                                                    (arg0,
-                                                                                     arg1,
-                                                                                     arg2,
-                                                                                     arg3)
-                                                                                    =>
-                                                                                    [::core::fmt::ArgumentV1::new(arg0,
-                                                                                                                  ::core::fmt::Pointer::fmt),
-                                                                                     ::core::fmt::ArgumentV1::new(arg1,
-                                                                                                                  ::core::fmt::Pointer::fmt),
-                                                                                     ::core::fmt::ArgumentV1::new(arg2,
-                                                                                                                  ::core::fmt::Display::fmt),
-                                                                                     ::core::fmt::ArgumentV1::new(arg3,
-                                                                                                                  ::core::fmt::Display::fmt)],
-                                                                                })));
-                 let self_struct: &Foo = &**self_combox;
-                 let __result = self_struct.simple_result_method();
-                 Ok({
-                        <u16 as
-                            intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::into_foreign_output(__result)?
-                    })
-             })();
-    use intercom::ErrorValue;
-    match result {
-        Ok(v) => {
-            intercom::logging::trace(|l| {
-                l(
-                    "testcrate",
-                    ::core::fmt::Arguments::new_v1(
-                        &["[", ", through ", "] Serving ", "::", ", OK"],
-                        &match (&self_combox, &self_vtable, &"Foo", &"simple_result_method") {
-                            (arg0, arg1, arg2, arg3) => [
-                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
-                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
-                            ],
-                        },
-                    ),
-                )
-            });
-            v
-        }
-        Err(err) => {
-            intercom::logging::trace(|l| {
-                l(
-                    "testcrate",
-                    ::core::fmt::Arguments::new_v1(
-                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
-                        &match (&self_combox, &self_vtable, &"Foo", &"simple_result_method") {
-                            (arg0, arg1, arg2, arg3) => [
-                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
-                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
-                            ],
-                        },
-                    ),
-                )
-            });
-            <<u16 as
-             intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
-                as ErrorValue>::from_error(intercom::store_error(err))
-        }
-    }
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::"],
+                &match (&self_combox, &self_vtable, &"Foo", &"simple_result_method") {
+                    (arg0, arg1, arg2, arg3) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                        ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
+    let self_struct: &Foo = &**self_combox;
+    let __result = self_struct.simple_result_method();
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::", ", OK"],
+                &match (&self_combox, &self_vtable, &"Foo", &"simple_result_method") {
+                    (arg0, arg1, arg2, arg3) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                        ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
+    <u16 as
+        intercom::type_system::InfallibleExternOutput<intercom::type_system::RawTypeSystem>>::into_foreign_output(__result)
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]
@@ -2618,99 +2383,56 @@ unsafe extern "system" fn __Foo_Foo_string_method_Raw(self_vtable:
                                                           intercom::RawComPtr,
                                                       input:
                                                           <String as
-                                                          intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType)
+                                                          intercom::type_system::InfallibleExternInput<intercom::type_system::RawTypeSystem>>::ForeignType)
  ->
      <String as
-intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType{
+intercom::type_system::InfallibleExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType{
     let self_combox =
         (self_vtable as usize -
              <Foo as
                  intercom::attributes::ComClass<Foo,
                                                 intercom::type_system::RawTypeSystem>>::offset())
             as *mut intercom::ComBoxData<Foo>;
-    let result:
-            Result<<String as
-                   intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType,
-                   intercom::ComError> =
-        (||
-             {
-                 intercom::logging::trace(|l|
-                                              l("testcrate",
-                                                ::core::fmt::Arguments::new_v1(&["[",
-                                                                                 ", through ",
-                                                                                 "] Serving ",
-                                                                                 "::"],
-                                                                               &match (&self_combox,
-                                                                                       &self_vtable,
-                                                                                       &"Foo",
-                                                                                       &"string_method")
-                                                                                    {
-                                                                                    (arg0,
-                                                                                     arg1,
-                                                                                     arg2,
-                                                                                     arg3)
-                                                                                    =>
-                                                                                    [::core::fmt::ArgumentV1::new(arg0,
-                                                                                                                  ::core::fmt::Pointer::fmt),
-                                                                                     ::core::fmt::ArgumentV1::new(arg1,
-                                                                                                                  ::core::fmt::Pointer::fmt),
-                                                                                     ::core::fmt::ArgumentV1::new(arg2,
-                                                                                                                  ::core::fmt::Display::fmt),
-                                                                                     ::core::fmt::ArgumentV1::new(arg3,
-                                                                                                                  ::core::fmt::Display::fmt)],
-                                                                                })));
-                 let self_struct: &Foo = &**self_combox;
-                 let __result =
-                     self_struct.string_method(<String as
-                                                   intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::from_foreign_parameter(input)?);
-                 Ok({
-                        <String as
-                            intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::into_foreign_output(__result)?
-                    })
-             })();
-    use intercom::ErrorValue;
-    match result {
-        Ok(v) => {
-            intercom::logging::trace(|l| {
-                l(
-                    "testcrate",
-                    ::core::fmt::Arguments::new_v1(
-                        &["[", ", through ", "] Serving ", "::", ", OK"],
-                        &match (&self_combox, &self_vtable, &"Foo", &"string_method") {
-                            (arg0, arg1, arg2, arg3) => [
-                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
-                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
-                            ],
-                        },
-                    ),
-                )
-            });
-            v
-        }
-        Err(err) => {
-            intercom::logging::trace(|l| {
-                l(
-                    "testcrate",
-                    ::core::fmt::Arguments::new_v1(
-                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
-                        &match (&self_combox, &self_vtable, &"Foo", &"string_method") {
-                            (arg0, arg1, arg2, arg3) => [
-                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
-                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
-                            ],
-                        },
-                    ),
-                )
-            });
-            <<String as
-             intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
-                as ErrorValue>::from_error(intercom::store_error(err))
-        }
-    }
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::"],
+                &match (&self_combox, &self_vtable, &"Foo", &"string_method") {
+                    (arg0, arg1, arg2, arg3) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                        ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
+    let self_struct: &Foo = &**self_combox;
+    let __result =
+        self_struct.string_method(<String as intercom::type_system::InfallibleExternInput<
+            intercom::type_system::RawTypeSystem,
+        >>::from_foreign_parameter(input));
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::", ", OK"],
+                &match (&self_combox, &self_vtable, &"Foo", &"string_method") {
+                    (arg0, arg1, arg2, arg3) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                        ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
+    <String as intercom::type_system::InfallibleExternOutput<
+        intercom::type_system::RawTypeSystem,
+    >>::into_foreign_output(__result)
 }
 #[allow(non_snake_case)]
 #[allow(dead_code)]

--- a/intercom-attributes/tests/data/macro/com_interface.rs.stdout
+++ b/intercom-attributes/tests/data/macro/com_interface.rs.stdout
@@ -43,13 +43,13 @@ pub struct __IntercomVtableForFoo_Automation {
                                                   intercom::RawComPtr,
                                               a:
                                                   <u16 as
-                                                  intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
+                                                  intercom::type_system::InfallibleExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
                         -> (),
     pub simple_result_method: unsafe extern "system" fn(self_vtable:
                                                             intercom::RawComPtr)
                                   ->
                                       <u16 as
-                                      intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
+                                      intercom::type_system::InfallibleExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
     pub com_result_method: unsafe extern "system" fn(self_vtable:
                                                          intercom::RawComPtr,
                                                      __out:
@@ -84,10 +84,10 @@ pub struct __IntercomVtableForFoo_Automation {
                                                      intercom::RawComPtr,
                                                  msg:
                                                      <String as
-                                                     intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
+                                                     intercom::type_system::InfallibleExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
                            ->
                                <String as
-                               intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
+                               intercom::type_system::InfallibleExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
     pub comitf_method: unsafe extern "system" fn(self_vtable:
                                                      intercom::RawComPtr,
                                                  itf:
@@ -153,13 +153,13 @@ pub struct __IntercomVtableForFoo_Raw {
                                                   intercom::RawComPtr,
                                               a:
                                                   <u16 as
-                                                  intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType)
+                                                  intercom::type_system::InfallibleExternInput<intercom::type_system::RawTypeSystem>>::ForeignType)
                         -> (),
     pub simple_result_method: unsafe extern "system" fn(self_vtable:
                                                             intercom::RawComPtr)
                                   ->
                                       <u16 as
-                                      intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType,
+                                      intercom::type_system::InfallibleExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType,
     pub com_result_method: unsafe extern "system" fn(self_vtable:
                                                          intercom::RawComPtr,
                                                      __out:
@@ -194,10 +194,10 @@ pub struct __IntercomVtableForFoo_Raw {
                                                      intercom::RawComPtr,
                                                  msg:
                                                      <String as
-                                                     intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType)
+                                                     intercom::type_system::InfallibleExternInput<intercom::type_system::RawTypeSystem>>::ForeignType)
                            ->
                                <String as
-                               intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType,
+                               intercom::type_system::InfallibleExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType,
     pub comitf_method: unsafe extern "system" fn(self_vtable:
                                                      intercom::RawComPtr,
                                                  itf:
@@ -293,13 +293,14 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::AutomationTypeSystem,
                 >>::VTable;
+
             #[allow(unused_unsafe)]
-            let __intercom_result: Result<(), intercom::ComError> = (|| unsafe {
+            unsafe {
                 let __result = ((**vtbl).arg_method)(
                     comptr.ptr,
-                    <u16 as intercom::type_system::ExternInput<
+                    <u16 as intercom::type_system::InfallibleExternInput<
                         intercom::type_system::AutomationTypeSystem,
-                    >>::into_foreign_parameter(a)?
+                    >>::into_foreign_parameter(a)
                     .0,
                 );
                 let __intercom_iid = intercom::GUID {
@@ -308,12 +309,8 @@ impl Foo for intercom::ComItf<dyn Foo> {
                     data3: 0u16,
                     data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8],
                 };
-                Ok({})
-            })();
-            return match __intercom_result {
-                Ok(v) => v,
-                Err(err) => <() as intercom::ErrorValue>::from_com_error(err),
-            };
+                return {};
+            }
         }
         if let Some(comptr) =
             intercom::ComItf::maybe_ptr::<intercom::type_system::RawTypeSystem>(self)
@@ -340,13 +337,14 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::RawTypeSystem,
                 >>::VTable;
+
             #[allow(unused_unsafe)]
-            let __intercom_result: Result<(), intercom::ComError> = (|| unsafe {
+            unsafe {
                 let __result = ((**vtbl).arg_method)(
                     comptr.ptr,
-                    <u16 as intercom::type_system::ExternInput<
+                    <u16 as intercom::type_system::InfallibleExternInput<
                         intercom::type_system::RawTypeSystem,
-                    >>::into_foreign_parameter(a)?
+                    >>::into_foreign_parameter(a)
                     .0,
                 );
                 let __intercom_iid = intercom::GUID {
@@ -355,14 +353,16 @@ impl Foo for intercom::ComItf<dyn Foo> {
                     data3: 0u16,
                     data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8],
                 };
-                Ok({})
-            })();
-            return match __intercom_result {
-                Ok(v) => v,
-                Err(err) => <() as intercom::ErrorValue>::from_com_error(err),
-            };
+                return {};
+            }
         }
-        <() as intercom::ErrorValue>::from_com_error(intercom::ComError::E_POINTER.into())
+        {
+            {
+                ::std::rt::begin_panic("internal error: entered unreachable code",
+                                       &("C:/Dev/Projects/rust-com/intercom-attributes/tests/data/macro/com_interface.rs",
+                                         12u32, 5u32))
+            }
+        };
     }
     fn bool_method(&self, input: bool) -> ComResult<bool> {
         intercom::logging::trace(|l| {
@@ -508,9 +508,13 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 Err(err) => <ComResult<bool> as intercom::ErrorValue>::from_com_error(err),
             };
         }
-        <ComResult<bool> as intercom::ErrorValue>::from_com_error(
-            intercom::ComError::E_POINTER.into(),
-        )
+        {
+            {
+                ::std::rt::begin_panic("internal error: entered unreachable code",
+                                       &("C:/Dev/Projects/rust-com/intercom-attributes/tests/data/macro/com_interface.rs",
+                                         24u32, 5u32))
+            }
+        };
     }
     fn com_result_method(&self) -> ComResult<u16> {
         intercom::logging::trace(|l| {
@@ -648,9 +652,13 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 Err(err) => <ComResult<u16> as intercom::ErrorValue>::from_com_error(err),
             };
         }
-        <ComResult<u16> as intercom::ErrorValue>::from_com_error(
-            intercom::ComError::E_POINTER.into(),
-        )
+        {
+            {
+                ::std::rt::begin_panic("internal error: entered unreachable code",
+                                       &("C:/Dev/Projects/rust-com/intercom-attributes/tests/data/macro/com_interface.rs",
+                                         15u32, 5u32))
+            }
+        };
     }
     fn comitf_method(&self, itf: ComItf<dyn Foo>) -> ComResult<ComItf<dyn IUnknown>> {
         intercom::logging::trace(|l| {
@@ -810,9 +818,13 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 }
             };
         }
-        <ComResult<ComItf<dyn IUnknown>> as intercom::ErrorValue>::from_com_error(
-            intercom::ComError::E_POINTER.into(),
-        )
+        {
+            {
+                ::std::rt::begin_panic("internal error: entered unreachable code",
+                                       &("C:/Dev/Projects/rust-com/intercom-attributes/tests/data/macro/com_interface.rs",
+                                         21u32, 5u32))
+            }
+        };
     }
     fn complete_method(&mut self, a: u16, b: i16) -> ComResult<bool> {
         intercom::logging::trace(|l| {
@@ -972,9 +984,13 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 Err(err) => <ComResult<bool> as intercom::ErrorValue>::from_com_error(err),
             };
         }
-        <ComResult<bool> as intercom::ErrorValue>::from_com_error(
-            intercom::ComError::E_POINTER.into(),
-        )
+        {
+            {
+                ::std::rt::begin_panic("internal error: entered unreachable code",
+                                       &("C:/Dev/Projects/rust-com/intercom-attributes/tests/data/macro/com_interface.rs",
+                                         18u32, 5u32))
+            }
+        };
     }
     fn rust_result_method(&self) -> Result<u16, i32> {
         intercom::logging::trace(|l| {
@@ -1112,9 +1128,13 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 Err(err) => <Result<u16, i32> as intercom::ErrorValue>::from_com_error(err),
             };
         }
-        <Result<u16, i32> as intercom::ErrorValue>::from_com_error(
-            intercom::ComError::E_POINTER.into(),
-        )
+        {
+            {
+                ::std::rt::begin_panic("internal error: entered unreachable code",
+                                       &("C:/Dev/Projects/rust-com/intercom-attributes/tests/data/macro/com_interface.rs",
+                                         16u32, 5u32))
+            }
+        };
     }
     fn simple_method(&self) -> () {
         intercom::logging::trace(|l| {
@@ -1159,8 +1179,9 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::AutomationTypeSystem,
                 >>::VTable;
+
             #[allow(unused_unsafe)]
-            let __intercom_result: Result<(), intercom::ComError> = (|| unsafe {
+            unsafe {
                 let __result = ((**vtbl).simple_method)(comptr.ptr);
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
@@ -1168,12 +1189,8 @@ impl Foo for intercom::ComItf<dyn Foo> {
                     data3: 0u16,
                     data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8],
                 };
-                Ok({})
-            })();
-            return match __intercom_result {
-                Ok(v) => v,
-                Err(err) => <() as intercom::ErrorValue>::from_com_error(err),
-            };
+                return {};
+            }
         }
         if let Some(comptr) =
             intercom::ComItf::maybe_ptr::<intercom::type_system::RawTypeSystem>(self)
@@ -1200,8 +1217,9 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::RawTypeSystem,
                 >>::VTable;
+
             #[allow(unused_unsafe)]
-            let __intercom_result: Result<(), intercom::ComError> = (|| unsafe {
+            unsafe {
                 let __result = ((**vtbl).simple_method)(comptr.ptr);
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
@@ -1209,14 +1227,16 @@ impl Foo for intercom::ComItf<dyn Foo> {
                     data3: 0u16,
                     data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8],
                 };
-                Ok({})
-            })();
-            return match __intercom_result {
-                Ok(v) => v,
-                Err(err) => <() as intercom::ErrorValue>::from_com_error(err),
-            };
+                return {};
+            }
         }
-        <() as intercom::ErrorValue>::from_com_error(intercom::ComError::E_POINTER.into())
+        {
+            {
+                ::std::rt::begin_panic("internal error: entered unreachable code",
+                                       &("C:/Dev/Projects/rust-com/intercom-attributes/tests/data/macro/com_interface.rs",
+                                         10u32, 5u32))
+            }
+        };
     }
     fn simple_result_method(&self) -> u16 {
         intercom::logging::trace(|l| {
@@ -1267,8 +1287,9 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::AutomationTypeSystem,
                 >>::VTable;
+
             #[allow(unused_unsafe)]
-            let __intercom_result: Result<u16, intercom::ComError> = (|| unsafe {
+            unsafe {
                 let __result = ((**vtbl).simple_result_method)(comptr.ptr);
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
@@ -1276,16 +1297,12 @@ impl Foo for intercom::ComItf<dyn Foo> {
                     data3: 0u16,
                     data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8],
                 };
-                Ok({
-                    <u16 as intercom::type_system::ExternOutput<
+                return {
+                    <u16 as intercom::type_system::InfallibleExternOutput<
                         intercom::type_system::AutomationTypeSystem,
-                    >>::from_foreign_output(__result)?
-                })
-            })();
-            return match __intercom_result {
-                Ok(v) => v,
-                Err(err) => <u16 as intercom::ErrorValue>::from_com_error(err),
-            };
+                    >>::from_foreign_output(__result)
+                };
+            }
         }
         if let Some(comptr) =
             intercom::ComItf::maybe_ptr::<intercom::type_system::RawTypeSystem>(self)
@@ -1312,8 +1329,9 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::RawTypeSystem,
                 >>::VTable;
+
             #[allow(unused_unsafe)]
-            let __intercom_result: Result<u16, intercom::ComError> = (|| unsafe {
+            unsafe {
                 let __result = ((**vtbl).simple_result_method)(comptr.ptr);
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
@@ -1321,18 +1339,20 @@ impl Foo for intercom::ComItf<dyn Foo> {
                     data3: 0u16,
                     data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8],
                 };
-                Ok({
-                    <u16 as intercom::type_system::ExternOutput<
+                return {
+                    <u16 as intercom::type_system::InfallibleExternOutput<
                         intercom::type_system::RawTypeSystem,
-                    >>::from_foreign_output(__result)?
-                })
-            })();
-            return match __intercom_result {
-                Ok(v) => v,
-                Err(err) => <u16 as intercom::ErrorValue>::from_com_error(err),
-            };
+                    >>::from_foreign_output(__result)
+                };
+            }
         }
-        <u16 as intercom::ErrorValue>::from_com_error(intercom::ComError::E_POINTER.into())
+        {
+            {
+                ::std::rt::begin_panic("internal error: entered unreachable code",
+                                       &("C:/Dev/Projects/rust-com/intercom-attributes/tests/data/macro/com_interface.rs",
+                                         14u32, 5u32))
+            }
+        };
     }
     fn string_method(&self, msg: String) -> String {
         intercom::logging::trace(|l| {
@@ -1377,13 +1397,14 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::AutomationTypeSystem,
                 >>::VTable;
+
             #[allow(unused_unsafe)]
-            let __intercom_result: Result<String, intercom::ComError> = (|| unsafe {
+            unsafe {
                 let __result = ((**vtbl).string_method)(
                     comptr.ptr,
-                    <String as intercom::type_system::ExternInput<
+                    <String as intercom::type_system::InfallibleExternInput<
                         intercom::type_system::AutomationTypeSystem,
-                    >>::into_foreign_parameter(msg)?
+                    >>::into_foreign_parameter(msg)
                     .0,
                 );
                 let __intercom_iid = intercom::GUID {
@@ -1392,16 +1413,12 @@ impl Foo for intercom::ComItf<dyn Foo> {
                     data3: 0u16,
                     data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8],
                 };
-                Ok({
-                    <String as intercom::type_system::ExternOutput<
+                return {
+                    <String as intercom::type_system::InfallibleExternOutput<
                         intercom::type_system::AutomationTypeSystem,
-                    >>::from_foreign_output(__result)?
-                })
-            })();
-            return match __intercom_result {
-                Ok(v) => v,
-                Err(err) => <String as intercom::ErrorValue>::from_com_error(err),
-            };
+                    >>::from_foreign_output(__result)
+                };
+            }
         }
         if let Some(comptr) =
             intercom::ComItf::maybe_ptr::<intercom::type_system::RawTypeSystem>(self)
@@ -1428,13 +1445,14 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::RawTypeSystem,
                 >>::VTable;
+
             #[allow(unused_unsafe)]
-            let __intercom_result: Result<String, intercom::ComError> = (|| unsafe {
+            unsafe {
                 let __result = ((**vtbl).string_method)(
                     comptr.ptr,
-                    <String as intercom::type_system::ExternInput<
+                    <String as intercom::type_system::InfallibleExternInput<
                         intercom::type_system::RawTypeSystem,
-                    >>::into_foreign_parameter(msg)?
+                    >>::into_foreign_parameter(msg)
                     .0,
                 );
                 let __intercom_iid = intercom::GUID {
@@ -1443,18 +1461,20 @@ impl Foo for intercom::ComItf<dyn Foo> {
                     data3: 0u16,
                     data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8],
                 };
-                Ok({
-                    <String as intercom::type_system::ExternOutput<
+                return {
+                    <String as intercom::type_system::InfallibleExternOutput<
                         intercom::type_system::RawTypeSystem,
-                    >>::from_foreign_output(__result)?
-                })
-            })();
-            return match __intercom_result {
-                Ok(v) => v,
-                Err(err) => <String as intercom::ErrorValue>::from_com_error(err),
-            };
+                    >>::from_foreign_output(__result)
+                };
+            }
         }
-        <String as intercom::ErrorValue>::from_com_error(intercom::ComError::E_POINTER.into())
+        {
+            {
+                ::std::rt::begin_panic("internal error: entered unreachable code",
+                                       &("C:/Dev/Projects/rust-com/intercom-attributes/tests/data/macro/com_interface.rs",
+                                         20u32, 5u32))
+            }
+        };
     }
     fn variant_method(&self, input: Variant) -> ComResult<Variant> {
         intercom::logging::trace(|l| {
@@ -1602,9 +1622,13 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 Err(err) => <ComResult<Variant> as intercom::ErrorValue>::from_com_error(err),
             };
         }
-        <ComResult<Variant> as intercom::ErrorValue>::from_com_error(
-            intercom::ComError::E_POINTER.into(),
-        )
+        {
+            {
+                ::std::rt::begin_panic("internal error: entered unreachable code",
+                                       &("C:/Dev/Projects/rust-com/intercom-attributes/tests/data/macro/com_interface.rs",
+                                         26u32, 5u32))
+            }
+        };
     }
 }
 impl intercom::ComInterface for dyn Foo {
@@ -1697,13 +1721,13 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::InfallibleExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::InfallibleExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
@@ -1899,13 +1923,13 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<String
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::InfallibleExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<String
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::InfallibleExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
@@ -2121,13 +2145,13 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::InfallibleExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::InfallibleExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
@@ -2323,13 +2347,13 @@ impl intercom::attributes::InterfaceHasTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<String
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::InfallibleExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<String
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::InfallibleExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:

--- a/intercom-attributes/tests/data/macro/com_interface.rs.stdout
+++ b/intercom-attributes/tests/data/macro/com_interface.rs.stdout
@@ -358,9 +358,10 @@ impl Foo for intercom::ComItf<dyn Foo> {
         }
         {
             {
-                ::std::rt::begin_panic("internal error: entered unreachable code",
-                                       &("com_interface.rs",
-                                         12u32, 5u32))
+                ::std::rt::begin_panic(
+                    "internal error: entered unreachable code",
+                    &("com_interface.rs", 12u32, 5u32),
+                )
             }
         };
     }
@@ -510,9 +511,10 @@ impl Foo for intercom::ComItf<dyn Foo> {
         }
         {
             {
-                ::std::rt::begin_panic("internal error: entered unreachable code",
-                                       &("com_interface.rs",
-                                         24u32, 5u32))
+                ::std::rt::begin_panic(
+                    "internal error: entered unreachable code",
+                    &("com_interface.rs", 24u32, 5u32),
+                )
             }
         };
     }
@@ -654,9 +656,10 @@ impl Foo for intercom::ComItf<dyn Foo> {
         }
         {
             {
-                ::std::rt::begin_panic("internal error: entered unreachable code",
-                                       &("com_interface.rs",
-                                         15u32, 5u32))
+                ::std::rt::begin_panic(
+                    "internal error: entered unreachable code",
+                    &("com_interface.rs", 15u32, 5u32),
+                )
             }
         };
     }
@@ -820,9 +823,10 @@ impl Foo for intercom::ComItf<dyn Foo> {
         }
         {
             {
-                ::std::rt::begin_panic("internal error: entered unreachable code",
-                                       &("com_interface.rs",
-                                         21u32, 5u32))
+                ::std::rt::begin_panic(
+                    "internal error: entered unreachable code",
+                    &("com_interface.rs", 21u32, 5u32),
+                )
             }
         };
     }
@@ -986,9 +990,10 @@ impl Foo for intercom::ComItf<dyn Foo> {
         }
         {
             {
-                ::std::rt::begin_panic("internal error: entered unreachable code",
-                                       &("com_interface.rs",
-                                         18u32, 5u32))
+                ::std::rt::begin_panic(
+                    "internal error: entered unreachable code",
+                    &("com_interface.rs", 18u32, 5u32),
+                )
             }
         };
     }
@@ -1130,9 +1135,10 @@ impl Foo for intercom::ComItf<dyn Foo> {
         }
         {
             {
-                ::std::rt::begin_panic("internal error: entered unreachable code",
-                                       &("com_interface.rs",
-                                         16u32, 5u32))
+                ::std::rt::begin_panic(
+                    "internal error: entered unreachable code",
+                    &("com_interface.rs", 16u32, 5u32),
+                )
             }
         };
     }
@@ -1232,9 +1238,10 @@ impl Foo for intercom::ComItf<dyn Foo> {
         }
         {
             {
-                ::std::rt::begin_panic("internal error: entered unreachable code",
-                                       &("com_interface.rs",
-                                         10u32, 5u32))
+                ::std::rt::begin_panic(
+                    "internal error: entered unreachable code",
+                    &("com_interface.rs", 10u32, 5u32),
+                )
             }
         };
     }
@@ -1348,9 +1355,10 @@ impl Foo for intercom::ComItf<dyn Foo> {
         }
         {
             {
-                ::std::rt::begin_panic("internal error: entered unreachable code",
-                                       &("com_interface.rs",
-                                         14u32, 5u32))
+                ::std::rt::begin_panic(
+                    "internal error: entered unreachable code",
+                    &("com_interface.rs", 14u32, 5u32),
+                )
             }
         };
     }
@@ -1470,9 +1478,10 @@ impl Foo for intercom::ComItf<dyn Foo> {
         }
         {
             {
-                ::std::rt::begin_panic("internal error: entered unreachable code",
-                                       &("com_interface.rs",
-                                         20u32, 5u32))
+                ::std::rt::begin_panic(
+                    "internal error: entered unreachable code",
+                    &("com_interface.rs", 20u32, 5u32),
+                )
             }
         };
     }
@@ -1624,9 +1633,10 @@ impl Foo for intercom::ComItf<dyn Foo> {
         }
         {
             {
-                ::std::rt::begin_panic("internal error: entered unreachable code",
-                                       &("com_interface.rs",
-                                         26u32, 5u32))
+                ::std::rt::begin_panic(
+                    "internal error: entered unreachable code",
+                    &("com_interface.rs", 26u32, 5u32),
+                )
             }
         };
     }

--- a/intercom-attributes/tests/data/macro/com_interface.rs.stdout
+++ b/intercom-attributes/tests/data/macro/com_interface.rs.stdout
@@ -359,7 +359,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
         {
             {
                 ::std::rt::begin_panic("internal error: entered unreachable code",
-                                       &("C:/Dev/Projects/rust-com/intercom-attributes/tests/data/macro/com_interface.rs",
+                                       &("com_interface.rs",
                                          12u32, 5u32))
             }
         };
@@ -511,7 +511,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
         {
             {
                 ::std::rt::begin_panic("internal error: entered unreachable code",
-                                       &("C:/Dev/Projects/rust-com/intercom-attributes/tests/data/macro/com_interface.rs",
+                                       &("com_interface.rs",
                                          24u32, 5u32))
             }
         };
@@ -655,7 +655,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
         {
             {
                 ::std::rt::begin_panic("internal error: entered unreachable code",
-                                       &("C:/Dev/Projects/rust-com/intercom-attributes/tests/data/macro/com_interface.rs",
+                                       &("com_interface.rs",
                                          15u32, 5u32))
             }
         };
@@ -821,7 +821,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
         {
             {
                 ::std::rt::begin_panic("internal error: entered unreachable code",
-                                       &("C:/Dev/Projects/rust-com/intercom-attributes/tests/data/macro/com_interface.rs",
+                                       &("com_interface.rs",
                                          21u32, 5u32))
             }
         };
@@ -987,7 +987,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
         {
             {
                 ::std::rt::begin_panic("internal error: entered unreachable code",
-                                       &("C:/Dev/Projects/rust-com/intercom-attributes/tests/data/macro/com_interface.rs",
+                                       &("com_interface.rs",
                                          18u32, 5u32))
             }
         };
@@ -1131,7 +1131,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
         {
             {
                 ::std::rt::begin_panic("internal error: entered unreachable code",
-                                       &("C:/Dev/Projects/rust-com/intercom-attributes/tests/data/macro/com_interface.rs",
+                                       &("com_interface.rs",
                                          16u32, 5u32))
             }
         };
@@ -1233,7 +1233,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
         {
             {
                 ::std::rt::begin_panic("internal error: entered unreachable code",
-                                       &("C:/Dev/Projects/rust-com/intercom-attributes/tests/data/macro/com_interface.rs",
+                                       &("com_interface.rs",
                                          10u32, 5u32))
             }
         };
@@ -1349,7 +1349,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
         {
             {
                 ::std::rt::begin_panic("internal error: entered unreachable code",
-                                       &("C:/Dev/Projects/rust-com/intercom-attributes/tests/data/macro/com_interface.rs",
+                                       &("com_interface.rs",
                                          14u32, 5u32))
             }
         };
@@ -1471,7 +1471,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
         {
             {
                 ::std::rt::begin_panic("internal error: entered unreachable code",
-                                       &("C:/Dev/Projects/rust-com/intercom-attributes/tests/data/macro/com_interface.rs",
+                                       &("com_interface.rs",
                                          20u32, 5u32))
             }
         };
@@ -1625,7 +1625,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
         {
             {
                 ::std::rt::begin_panic("internal error: entered unreachable code",
-                                       &("C:/Dev/Projects/rust-com/intercom-attributes/tests/data/macro/com_interface.rs",
+                                       &("com_interface.rs",
                                          26u32, 5u32))
             }
         };

--- a/intercom-attributes/tests/data/macro/private_item.rs.stdout
+++ b/intercom-attributes/tests/data/macro/private_item.rs.stdout
@@ -107,8 +107,9 @@ impl IFoo for intercom::ComItf<dyn IFoo> {
                 as *const *const <dyn IFoo as intercom::attributes::ComInterface<
                     intercom::type_system::AutomationTypeSystem,
                 >>::VTable;
+
             #[allow(unused_unsafe)]
-            let __intercom_result: Result<(), intercom::ComError> = (|| unsafe {
+            unsafe {
                 let __result = ((**vtbl).trait_method)(comptr.ptr);
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
@@ -116,12 +117,8 @@ impl IFoo for intercom::ComItf<dyn IFoo> {
                     data3: 0u16,
                     data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8],
                 };
-                Ok({})
-            })();
-            return match __intercom_result {
-                Ok(v) => v,
-                Err(err) => <() as intercom::ErrorValue>::from_com_error(err),
-            };
+                return {};
+            }
         }
         if let Some(comptr) =
             intercom::ComItf::maybe_ptr::<intercom::type_system::RawTypeSystem>(self)
@@ -148,8 +145,9 @@ impl IFoo for intercom::ComItf<dyn IFoo> {
                 as *const *const <dyn IFoo as intercom::attributes::ComInterface<
                     intercom::type_system::RawTypeSystem,
                 >>::VTable;
+
             #[allow(unused_unsafe)]
-            let __intercom_result: Result<(), intercom::ComError> = (|| unsafe {
+            unsafe {
                 let __result = ((**vtbl).trait_method)(comptr.ptr);
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
@@ -157,14 +155,17 @@ impl IFoo for intercom::ComItf<dyn IFoo> {
                     data3: 0u16,
                     data4: [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8],
                 };
-                Ok({})
-            })();
-            return match __intercom_result {
-                Ok(v) => v,
-                Err(err) => <() as intercom::ErrorValue>::from_com_error(err),
-            };
+                return {};
+            }
         }
-        <() as intercom::ErrorValue>::from_com_error(intercom::ComError::E_POINTER.into())
+
+        {
+            {
+                ::std::rt::begin_panic("internal error: entered unreachable code",
+                                       &("C:/Dev/Projects/rust-com/intercom-attributes/tests/data/macro/private_item.rs",
+                                         8u32, 5u32))
+            }
+        };
     }
 }
 impl intercom::ComInterface for dyn IFoo {
@@ -1308,68 +1309,40 @@ unsafe extern "system" fn __Foo_Foo_struct_method_Automation(
             Foo,
             intercom::type_system::AutomationTypeSystem,
         >>::offset()) as *mut intercom::ComBoxData<Foo>;
-    let result: Result<(), intercom::ComError> = (|| {
-        intercom::logging::trace(|l| {
-            l(
-                "testcrate",
-                ::core::fmt::Arguments::new_v1(
-                    &["[", ", through ", "] Serving ", "::"],
-                    &match (&self_combox, &self_vtable, &"Foo", &"struct_method") {
-                        (arg0, arg1, arg2, arg3) => [
-                            ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
-                            ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
-                            ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
-                            ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
-                        ],
-                    },
-                ),
-            )
-        });
-        let self_struct: &Foo = &**self_combox;
-        let __result = self_struct.struct_method();
-        Ok({})
-    })();
-    use intercom::ErrorValue;
-    match result {
-        Ok(v) => {
-            intercom::logging::trace(|l| {
-                l(
-                    "testcrate",
-                    ::core::fmt::Arguments::new_v1(
-                        &["[", ", through ", "] Serving ", "::", ", OK"],
-                        &match (&self_combox, &self_vtable, &"Foo", &"struct_method") {
-                            (arg0, arg1, arg2, arg3) => [
-                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
-                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
-                            ],
-                        },
-                    ),
-                )
-            });
-            v
-        }
-        Err(err) => {
-            intercom::logging::trace(|l| {
-                l(
-                    "testcrate",
-                    ::core::fmt::Arguments::new_v1(
-                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
-                        &match (&self_combox, &self_vtable, &"Foo", &"struct_method") {
-                            (arg0, arg1, arg2, arg3) => [
-                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
-                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
-                            ],
-                        },
-                    ),
-                )
-            });
-            <() as ErrorValue>::from_error(intercom::store_error(err))
-        }
-    }
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::"],
+                &match (&self_combox, &self_vtable, &"Foo", &"struct_method") {
+                    (arg0, arg1, arg2, arg3) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                        ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
+    let self_struct: &Foo = &**self_combox;
+    let __result = self_struct.struct_method();
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::", ", OK"],
+                &match (&self_combox, &self_vtable, &"Foo", &"struct_method") {
+                    (arg0, arg1, arg2, arg3) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                        ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
 }
 #[allow(non_upper_case_globals)]
 impl intercom::attributes::ComImpl<Foo, intercom::type_system::AutomationTypeSystem> for Foo {
@@ -1502,68 +1475,40 @@ unsafe extern "system" fn __Foo_Foo_struct_method_Raw(self_vtable: intercom::Raw
                  intercom::attributes::ComClass<Foo,
                                                 intercom::type_system::RawTypeSystem>>::offset())
             as *mut intercom::ComBoxData<Foo>;
-    let result: Result<(), intercom::ComError> = (|| {
-        intercom::logging::trace(|l| {
-            l(
-                "testcrate",
-                ::core::fmt::Arguments::new_v1(
-                    &["[", ", through ", "] Serving ", "::"],
-                    &match (&self_combox, &self_vtable, &"Foo", &"struct_method") {
-                        (arg0, arg1, arg2, arg3) => [
-                            ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
-                            ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
-                            ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
-                            ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
-                        ],
-                    },
-                ),
-            )
-        });
-        let self_struct: &Foo = &**self_combox;
-        let __result = self_struct.struct_method();
-        Ok({})
-    })();
-    use intercom::ErrorValue;
-    match result {
-        Ok(v) => {
-            intercom::logging::trace(|l| {
-                l(
-                    "testcrate",
-                    ::core::fmt::Arguments::new_v1(
-                        &["[", ", through ", "] Serving ", "::", ", OK"],
-                        &match (&self_combox, &self_vtable, &"Foo", &"struct_method") {
-                            (arg0, arg1, arg2, arg3) => [
-                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
-                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
-                            ],
-                        },
-                    ),
-                )
-            });
-            v
-        }
-        Err(err) => {
-            intercom::logging::trace(|l| {
-                l(
-                    "testcrate",
-                    ::core::fmt::Arguments::new_v1(
-                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
-                        &match (&self_combox, &self_vtable, &"Foo", &"struct_method") {
-                            (arg0, arg1, arg2, arg3) => [
-                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
-                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
-                            ],
-                        },
-                    ),
-                )
-            });
-            <() as ErrorValue>::from_error(intercom::store_error(err))
-        }
-    }
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::"],
+                &match (&self_combox, &self_vtable, &"Foo", &"struct_method") {
+                    (arg0, arg1, arg2, arg3) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                        ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
+    let self_struct: &Foo = &**self_combox;
+    let __result = self_struct.struct_method();
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::", ", OK"],
+                &match (&self_combox, &self_vtable, &"Foo", &"struct_method") {
+                    (arg0, arg1, arg2, arg3) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                        ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
 }
 #[allow(non_upper_case_globals)]
 impl intercom::attributes::ComImpl<Foo, intercom::type_system::RawTypeSystem> for Foo {
@@ -1851,68 +1796,40 @@ unsafe extern "system" fn __Foo_IFoo_trait_method_Automation(
             dyn IFoo,
             intercom::type_system::AutomationTypeSystem,
         >>::offset()) as *mut intercom::ComBoxData<Foo>;
-    let result: Result<(), intercom::ComError> = (|| {
-        intercom::logging::trace(|l| {
-            l(
-                "testcrate",
-                ::core::fmt::Arguments::new_v1(
-                    &["[", ", through ", "] Serving ", "::"],
-                    &match (&self_combox, &self_vtable, &"Foo", &"trait_method") {
-                        (arg0, arg1, arg2, arg3) => [
-                            ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
-                            ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
-                            ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
-                            ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
-                        ],
-                    },
-                ),
-            )
-        });
-        let self_struct: &dyn IFoo = &**self_combox;
-        let __result = self_struct.trait_method();
-        Ok({})
-    })();
-    use intercom::ErrorValue;
-    match result {
-        Ok(v) => {
-            intercom::logging::trace(|l| {
-                l(
-                    "testcrate",
-                    ::core::fmt::Arguments::new_v1(
-                        &["[", ", through ", "] Serving ", "::", ", OK"],
-                        &match (&self_combox, &self_vtable, &"Foo", &"trait_method") {
-                            (arg0, arg1, arg2, arg3) => [
-                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
-                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
-                            ],
-                        },
-                    ),
-                )
-            });
-            v
-        }
-        Err(err) => {
-            intercom::logging::trace(|l| {
-                l(
-                    "testcrate",
-                    ::core::fmt::Arguments::new_v1(
-                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
-                        &match (&self_combox, &self_vtable, &"Foo", &"trait_method") {
-                            (arg0, arg1, arg2, arg3) => [
-                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
-                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
-                            ],
-                        },
-                    ),
-                )
-            });
-            <() as ErrorValue>::from_error(intercom::store_error(err))
-        }
-    }
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::"],
+                &match (&self_combox, &self_vtable, &"Foo", &"trait_method") {
+                    (arg0, arg1, arg2, arg3) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                        ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
+    let self_struct: &dyn IFoo = &**self_combox;
+    let __result = self_struct.trait_method();
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::", ", OK"],
+                &match (&self_combox, &self_vtable, &"Foo", &"trait_method") {
+                    (arg0, arg1, arg2, arg3) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                        ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
 }
 #[allow(non_upper_case_globals)]
 impl intercom::attributes::ComImpl<dyn IFoo, intercom::type_system::AutomationTypeSystem> for Foo {
@@ -2045,68 +1962,40 @@ unsafe extern "system" fn __Foo_IFoo_trait_method_Raw(self_vtable: intercom::Raw
                 dyn IFoo,
                 intercom::type_system::RawTypeSystem,
             >>::offset()) as *mut intercom::ComBoxData<Foo>;
-    let result: Result<(), intercom::ComError> = (|| {
-        intercom::logging::trace(|l| {
-            l(
-                "testcrate",
-                ::core::fmt::Arguments::new_v1(
-                    &["[", ", through ", "] Serving ", "::"],
-                    &match (&self_combox, &self_vtable, &"Foo", &"trait_method") {
-                        (arg0, arg1, arg2, arg3) => [
-                            ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
-                            ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
-                            ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
-                            ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
-                        ],
-                    },
-                ),
-            )
-        });
-        let self_struct: &dyn IFoo = &**self_combox;
-        let __result = self_struct.trait_method();
-        Ok({})
-    })();
-    use intercom::ErrorValue;
-    match result {
-        Ok(v) => {
-            intercom::logging::trace(|l| {
-                l(
-                    "testcrate",
-                    ::core::fmt::Arguments::new_v1(
-                        &["[", ", through ", "] Serving ", "::", ", OK"],
-                        &match (&self_combox, &self_vtable, &"Foo", &"trait_method") {
-                            (arg0, arg1, arg2, arg3) => [
-                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
-                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
-                            ],
-                        },
-                    ),
-                )
-            });
-            v
-        }
-        Err(err) => {
-            intercom::logging::trace(|l| {
-                l(
-                    "testcrate",
-                    ::core::fmt::Arguments::new_v1(
-                        &["[", ", through ", "] Serving ", "::", ", ERROR"],
-                        &match (&self_combox, &self_vtable, &"Foo", &"trait_method") {
-                            (arg0, arg1, arg2, arg3) => [
-                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
-                                ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
-                                ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
-                            ],
-                        },
-                    ),
-                )
-            });
-            <() as ErrorValue>::from_error(intercom::store_error(err))
-        }
-    }
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::"],
+                &match (&self_combox, &self_vtable, &"Foo", &"trait_method") {
+                    (arg0, arg1, arg2, arg3) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                        ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
+    let self_struct: &dyn IFoo = &**self_combox;
+    let __result = self_struct.trait_method();
+    intercom::logging::trace(|l| {
+        l(
+            "testcrate",
+            ::core::fmt::Arguments::new_v1(
+                &["[", ", through ", "] Serving ", "::", ", OK"],
+                &match (&self_combox, &self_vtable, &"Foo", &"trait_method") {
+                    (arg0, arg1, arg2, arg3) => [
+                        ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Pointer::fmt),
+                        ::core::fmt::ArgumentV1::new(arg2, ::core::fmt::Display::fmt),
+                        ::core::fmt::ArgumentV1::new(arg3, ::core::fmt::Display::fmt),
+                    ],
+                },
+            ),
+        )
+    });
 }
 #[allow(non_upper_case_globals)]
 impl intercom::attributes::ComImpl<dyn IFoo, intercom::type_system::RawTypeSystem> for Foo {

--- a/intercom-attributes/tests/data/macro/private_item.rs.stdout
+++ b/intercom-attributes/tests/data/macro/private_item.rs.stdout
@@ -162,7 +162,7 @@ impl IFoo for intercom::ComItf<dyn IFoo> {
         {
             {
                 ::std::rt::begin_panic("internal error: entered unreachable code",
-                                       &("C:/Dev/Projects/rust-com/intercom-attributes/tests/data/macro/private_item.rs",
+                                       &("private_item.rs",
                                          8u32, 5u32))
             }
         };

--- a/intercom-attributes/tests/data/macro/private_item.rs.stdout
+++ b/intercom-attributes/tests/data/macro/private_item.rs.stdout
@@ -161,9 +161,10 @@ impl IFoo for intercom::ComItf<dyn IFoo> {
 
         {
             {
-                ::std::rt::begin_panic("internal error: entered unreachable code",
-                                       &("private_item.rs",
-                                         8u32, 5u32))
+                ::std::rt::begin_panic(
+                    "internal error: entered unreachable code",
+                    &("private_item.rs", 8u32, 5u32),
+                )
             }
         };
     }

--- a/intercom-attributes/tests/data/ui/span-externtype-error.rs.stderr
+++ b/intercom-attributes/tests/data/ui/span-externtype-error.rs.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `NotExternType: intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>` is not satisfied
+error[E0277]: the trait bound `NotExternType: intercom::type_system::InfallibleExternInput<intercom::type_system::AutomationTypeSystem>` is not satisfied
   --> span-externtype-error.rs:12:5
    |
 12 |     fn arg_type(&self, bad_type: NotExternType);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>` is not implemented for `NotExternType`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `intercom::type_system::InfallibleExternInput<intercom::type_system::AutomationTypeSystem>` is not implemented for `NotExternType`
 
 error[E0277]: the trait bound `NotExternType: intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>` is not satisfied
   --> span-externtype-error.rs:14:5
@@ -10,11 +10,17 @@ error[E0277]: the trait bound `NotExternType: intercom::type_system::ExternOutpu
 14 |     fn ret_type(&self) -> ComResult<NotExternType>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>` is not implemented for `NotExternType`
 
-error[E0277]: the trait bound `NotExternType: intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>` is not satisfied
+error[E0277]: the trait bound `NotExternType: intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>` is not satisfied
+  --> span-externtype-error.rs:16:5
+   |
+16 |     fn all_type(&self, bad_type: NotExternType) -> ComResult<NotExternType>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>` is not implemented for `NotExternType`
+
+error[E0277]: the trait bound `NotExternType: intercom::type_system::InfallibleExternInput<intercom::type_system::RawTypeSystem>` is not satisfied
   --> span-externtype-error.rs:12:5
    |
 12 |     fn arg_type(&self, bad_type: NotExternType);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>` is not implemented for `NotExternType`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `intercom::type_system::InfallibleExternInput<intercom::type_system::RawTypeSystem>` is not implemented for `NotExternType`
 
 error[E0277]: the trait bound `NotExternType: intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>` is not satisfied
   --> span-externtype-error.rs:14:5
@@ -22,6 +28,12 @@ error[E0277]: the trait bound `NotExternType: intercom::type_system::ExternOutpu
 14 |     fn ret_type(&self) -> ComResult<NotExternType>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>` is not implemented for `NotExternType`
 
-error: aborting due to 4 previous errors
+error[E0277]: the trait bound `NotExternType: intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>` is not satisfied
+  --> span-externtype-error.rs:16:5
+   |
+16 |     fn all_type(&self, bad_type: NotExternType) -> ComResult<NotExternType>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>` is not implemented for `NotExternType`
+
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/intercom-attributes/tests/lib.rs
+++ b/intercom-attributes/tests/lib.rs
@@ -444,7 +444,7 @@ fn assert_test_output(
     // decide on their naming as we write them.
     vec![
         assert_output_with(result_stdout, source_path, "stdout", |s| {
-            strip_path(source_path, sanitize(s))
+            sanitize(strip_path(source_path, s))
         }),
         assert_output_with(result_stderr, source_path, "stderr", |s| {
             strip_path(source_path, s)

--- a/intercom-attributes/tests/lib.rs
+++ b/intercom-attributes/tests/lib.rs
@@ -443,7 +443,9 @@ fn assert_test_output(
     // This shouldn't matter in practice as these are test files and we can
     // decide on their naming as we write them.
     vec![
-        assert_output_with(result_stdout, source_path, "stdout", sanitize),
+        assert_output_with(result_stdout, source_path, "stdout", |s| {
+            strip_path(source_path, sanitize(s))
+        }),
         assert_output_with(result_stderr, source_path, "stderr", |s| {
             strip_path(source_path, s)
         }),

--- a/intercom-common/src/methodinfo.rs
+++ b/intercom-common/src/methodinfo.rs
@@ -165,6 +165,9 @@ pub struct ComMethodInfo
 
     /// Type system.
     pub type_system: ModelTypeSystem,
+
+    /// Is the method infallible.
+    pub infallible: bool,
 }
 
 impl PartialEq for ComMethodInfo
@@ -239,6 +242,7 @@ impl ComMethodInfo
                 .or(Err(ComMethodInfoError::BadReturnType))?;
         Ok(ComMethodInfo {
             name: n,
+            infallible: returnhandler.is_infallible(),
             returnhandler: returnhandler.into(),
             signature_span: decl.span(),
             is_const,

--- a/test/multilib/src/lib.rs
+++ b/test/multilib/src/lib.rs
@@ -11,7 +11,7 @@ com_library!(class HelloWorld);
 #[com_interface]
 trait IHelloWorld
 {
-    fn get_hello(&self) -> String;
+    fn get_hello(&self) -> ComResult<String>;
 }
 
 #[com_class(clsid = "{25ccb3f6-b782-4b2d-933e-54ab447da0aa}", IHelloWorld)]
@@ -29,9 +29,9 @@ impl HelloWorld
 #[com_impl]
 impl IHelloWorld for HelloWorld
 {
-    fn get_hello(&self) -> String
+    fn get_hello(&self) -> ComResult<String>
     {
-        "Hello World!".to_string()
+        Ok("Hello World!".to_string())
     }
 }
 
@@ -39,5 +39,5 @@ impl IHelloWorld for HelloWorld
 fn hello_world_returns_hello_world()
 {
     let hello = HelloWorld::new();
-    assert_eq!(hello.get_hello(), "Hello World!");
+    assert_eq!(hello.get_hello().unwrap(), "Hello World!");
 }

--- a/test/testlib/src/alloc.rs
+++ b/test/testlib/src/alloc.rs
@@ -8,16 +8,6 @@ pub struct AllocTests;
 #[com_impl]
 impl AllocTests
 {
-    pub fn new() -> AllocTests
-    {
-        AllocTests
-    }
-
-    pub fn get_bstr(&self, value: u32) -> String
-    {
-        format!("{}", value)
-    }
-
     pub fn get_bstr_result(&self, value: u32) -> ComResult<String>
     {
         Ok(format!("{}", value))


### PR DESCRIPTION
Implemented `InfallibleExternInput`/`InfallibleExternOutput` traits. These traits are similar to the original `ExternInput`/`ExternOutput` traits save for not returning a `ComResult`. These traits are used in COM methods that do not return a `ComResult` (or other type that ends up using our `ErrorResultHandler` return handler).

The end goal with this is to avoid need to support "error results for arbitrary types". If the user wants the convenience of Intercom type system, they need to implement methods that can return proper errors. If the user requires special return values, they need to handle all type conversions that might fail on their own.

Closes #146 