### PR TITLE
Ensure mising rls/clippy won't fail Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
     - CC=gcc-5 CXX=g++-5 RUSTFLAGS='-C link-dead-code'
 
 script:
-    - rustup component add clippy rustfmt
+    - rustup component add clippy rustfmt || true
     - if( ! cargo clippy -V || ! cargo fmt --version ); then rustup uninstall nightly && rustup toolchain install nightly -c clippy -c rustfmt; fi
     - cargo clippy --all -- -D warnings
     - cargo test


### PR DESCRIPTION
The build completes currently but the initial rustup component install failure causes the build to fail even if we recover from it.