### PR TITLE
Work around the need for specialization to support Stable Rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,28 +89,6 @@ and deallocated using [`IIntercomAllocator`]
 
 [`IIntercomAllocator`]: https://github.com/Rantanen/intercom/issues/27
 
-## Nightly requirement
-
-Intercom requires nightly Rust version for few unstable features. By far the
-most important of these is the procedural macro attributes. Unfortunately these
-are not properly feature gated.
-
-The features with feature gates and tracking issues that Intercom depends on are
-listed below:
-
-- `specialization` - needed for handling `ComItf`, which may refer to an
-  interface that might or might not be a concrete struct interface.
-  Tracking issue: [#31844](https://github.com/rust-lang/rust/issues/31844)
-- `non_exhaustive` - There are some types that we may want to add items to.
-  Tracking issue: [#44109](https://github.com/rust-lang/rust/issues/44109)
-
-The following features are currently in use, but more for 'nice to have'
-reasons and could be worked around if we needed to get to stable quickly:
-
-- `try_from`, tracking issue: [#33417](https://github.com/rust-lang/rust/issues/33417)
-- `try_trait`, tracking issue: [#42327](https://github.com/rust-lang/rust/issues/42327)
-- `integer_atomics`, tracking issue: [#32976](https://github.com/rust-lang/rust/issues/32976)
-
 ## Technical details
 
 ### Background
@@ -135,7 +113,7 @@ and `"stdcall"` in Rust).
 The Intercom libraries are built over Rust [proc macro attributes]. Currently
 there are four attributes available:
 
-- `[com_library(LIBID, Classes...)]` - A required attribute that implements the
+- `com_library!(LIBID, Classes...)` - A required attribute that implements the
   exported `DllGetClassObject` entry point as well as the `CoClass` for the
   `ClassFactory`.
 - `[com_interface(IID)]` - An attribute that specifies a `trait` or an `impl`

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,12 +3,24 @@ trigger:
 
 strategy:
     matrix:
-        Linux:
+        Linux_nightly:
             imageName: "ubuntu-16.04"
+            rustVersion: nightly
             cmake_generator_opts:
             memcheck: valgrind --error-exitcode=1 --leak-check=full
-        Windows:
+        Windows_nightly:
             imageName: "vs2017-win2016"
+            rustVersion: nightly
+            cmake_generator_opts: -DCMAKE_GENERATOR_PLATFORM=x64
+            memcheck:
+        Linux_stable:
+            imageName: "ubuntu-16.04"
+            rustVersion: stable
+            cmake_generator_opts:
+            memcheck: valgrind --error-exitcode=1 --leak-check=full
+        Windows_stable:
+            imageName: "vs2017-win2016"
+            rustVersion: stable
             cmake_generator_opts: -DCMAKE_GENERATOR_PLATFORM=x64
             memcheck:
 
@@ -18,7 +30,7 @@ pool:
 steps:
 - script: |
     curl -sSf -o rustup-init.exe https://win.rustup.rs
-    rustup-init.exe --default-toolchain nightly -y
+    rustup-init.exe --default-toolchain $(rustVersion) -y
   displayName: 'Update environment (Windows)'
   condition: and(succeeded(), eq( variables['Agent.OS'], 'Windows_NT' ))
 
@@ -31,8 +43,8 @@ steps:
     rustup -V
     rustup self update
     rustup set profile minimal
-    rustup toolchain install nightly -c rustfmt -c clippy
-    rustup default nightly
+    rustup toolchain install $(rustVersion) -c rustfmt -c clippy
+    rustup default $(rustVersion)
     cargo -V
     rustc -V
     cargo clippy -V

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,9 +57,11 @@ steps:
 
 - script: cargo clippy
   displayName: 'Run build'
+  condition: and(succeeded(), eq( variables['rustVersion'], 'nightly' ))
 
 - script: cargo test
   displayName: 'Run unit tests'
+  condition: and(succeeded(), eq( variables['rustVersion'], 'nightly' ))
 
 - script: |
     mkdir build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,6 +53,7 @@ steps:
 
 - script: cargo fmt -- --check
   displayName: 'Check style'
+  condition: and(succeeded(), eq( variables['rustVersion'], 'nightly' ))
 
 - script: cargo clippy
   displayName: 'Run build'

--- a/intercom-attributes/tests/data/macro/com_interface.rs.stdout
+++ b/intercom-attributes/tests/data/macro/com_interface.rs.stdout
@@ -443,7 +443,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
             })();
             return match __intercom_result {
                 Ok(v) => v,
-                Err(err) => <ComResult<bool> as intercom::ErrorValue>::from_com_error(err),
+                Err(err) => <ComResult<bool> as intercom::ErrorValue>::from_error(err),
             };
         }
         if let Some(comptr) =
@@ -506,7 +506,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
             })();
             return match __intercom_result {
                 Ok(v) => v,
-                Err(err) => <ComResult<bool> as intercom::ErrorValue>::from_com_error(err),
+                Err(err) => <ComResult<bool> as intercom::ErrorValue>::from_error(err),
             };
         }
         {
@@ -595,7 +595,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
             })();
             return match __intercom_result {
                 Ok(v) => v,
-                Err(err) => <ComResult<u16> as intercom::ErrorValue>::from_com_error(err),
+                Err(err) => <ComResult<u16> as intercom::ErrorValue>::from_error(err),
             };
         }
         if let Some(comptr) =
@@ -651,7 +651,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
             })();
             return match __intercom_result {
                 Ok(v) => v,
-                Err(err) => <ComResult<u16> as intercom::ErrorValue>::from_com_error(err),
+                Err(err) => <ComResult<u16> as intercom::ErrorValue>::from_error(err),
             };
         }
         {
@@ -747,7 +747,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
             return match __intercom_result {
                 Ok(v) => v,
                 Err(err) => {
-                    <ComResult<ComItf<dyn IUnknown>> as intercom::ErrorValue>::from_com_error(err)
+                    <ComResult<ComItf<dyn IUnknown>> as intercom::ErrorValue>::from_error(err)
                 }
             };
         }
@@ -817,7 +817,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
             return match __intercom_result {
                 Ok(v) => v,
                 Err(err) => {
-                    <ComResult<ComItf<dyn IUnknown>> as intercom::ErrorValue>::from_com_error(err)
+                    <ComResult<ComItf<dyn IUnknown>> as intercom::ErrorValue>::from_error(err)
                 }
             };
         }
@@ -918,7 +918,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
             })();
             return match __intercom_result {
                 Ok(v) => v,
-                Err(err) => <ComResult<bool> as intercom::ErrorValue>::from_com_error(err),
+                Err(err) => <ComResult<bool> as intercom::ErrorValue>::from_error(err),
             };
         }
         if let Some(comptr) =
@@ -985,7 +985,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
             })();
             return match __intercom_result {
                 Ok(v) => v,
-                Err(err) => <ComResult<bool> as intercom::ErrorValue>::from_com_error(err),
+                Err(err) => <ComResult<bool> as intercom::ErrorValue>::from_error(err),
             };
         }
         {
@@ -1074,7 +1074,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
             })();
             return match __intercom_result {
                 Ok(v) => v,
-                Err(err) => <Result<u16, i32> as intercom::ErrorValue>::from_com_error(err),
+                Err(err) => <Result<u16, i32> as intercom::ErrorValue>::from_error(err),
             };
         }
         if let Some(comptr) =
@@ -1130,7 +1130,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
             })();
             return match __intercom_result {
                 Ok(v) => v,
-                Err(err) => <Result<u16, i32> as intercom::ErrorValue>::from_com_error(err),
+                Err(err) => <Result<u16, i32> as intercom::ErrorValue>::from_error(err),
             };
         }
         {
@@ -1564,7 +1564,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
             );
             return match __intercom_result {
                 Ok(v) => v,
-                Err(err) => <ComResult<Variant> as intercom::ErrorValue>::from_com_error(err),
+                Err(err) => <ComResult<Variant> as intercom::ErrorValue>::from_error(err),
             };
         }
         if let Some(comptr) =
@@ -1628,7 +1628,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
             );
             return match __intercom_result {
                 Ok(v) => v,
-                Err(err) => <ComResult<Variant> as intercom::ErrorValue>::from_com_error(err),
+                Err(err) => <ComResult<Variant> as intercom::ErrorValue>::from_error(err),
             };
         }
         {

--- a/intercom-cli/src/main.rs
+++ b/intercom-cli/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(inner_deref)]
 #![allow(clippy::match_bool)]
 
 use std::fs::File;

--- a/intercom-common/src/attributes/com_interface.rs
+++ b/intercom-common/src/attributes/com_interface.rs
@@ -464,7 +464,7 @@ fn rust_to_com_delegate(
 
             return match __intercom_result {
                 Ok( v ) => v,
-                Err( err ) => < #return_ty as intercom::ErrorValue >::from_com_error( err ),
+                Err( err ) => < #return_ty as intercom::ErrorValue >::from_error( err ),
             };
         )
     }

--- a/intercom-common/src/model/mod.rs
+++ b/intercom-common/src/model/mod.rs
@@ -8,7 +8,6 @@
 //!
 
 #[derive(Fail, Debug)]
-#[non_exhaustive]
 pub enum ParseError
 {
     #[fail(display = "Parsing [com_library] failed: {}", _0)]
@@ -28,6 +27,10 @@ pub enum ParseError
 
     #[fail(display = "Reading TOML failed: {}", _0)]
     CargoToml(String),
+
+    #[doc(hidden)]
+    #[fail(display = "<Internal>")]
+    __NonExhaustive,
 }
 
 pub type ParseResult<T> = Result<T, ParseError>;

--- a/intercom/src/error.rs
+++ b/intercom/src/error.rs
@@ -519,22 +519,6 @@ pub trait ErrorValue
 {
     /// Attempts to convert a COM error into a custom status code. Must not panic.
     fn from_error(_: ComError) -> Self;
-
-    /// Attempts to convert a COM error into a custom status code. May panic.
-    fn from_com_error(_: ComError) -> Self;
-}
-
-impl<T> ErrorValue for T
-{
-    default fn from_error(_: ComError) -> Self
-    {
-        panic!("Function does not support error values")
-    }
-
-    default fn from_com_error(_: ComError) -> Self
-    {
-        panic!("Function does not support error values")
-    }
 }
 
 impl<S, E: ErrorValue> ErrorValue for Result<S, E>
@@ -543,46 +527,13 @@ impl<S, E: ErrorValue> ErrorValue for Result<S, E>
     {
         Err(E::from_error(e))
     }
-
-    fn from_com_error(e: ComError) -> Self
-    {
-        Err(E::from_error(e))
-    }
-}
-
-impl ErrorValue for ComError
-{
-    fn from_error(err: ComError) -> Self
-    {
-        err
-    }
-    fn from_com_error(err: ComError) -> Self
-    {
-        err
-    }
 }
 
 impl<T: From<ComError>> ErrorValue for T
 {
-    default fn from_error(err: ComError) -> Self
-    {
-        err.into()
-    }
-    default fn from_com_error(err: ComError) -> Self
-    {
-        err.into()
-    }
-}
-
-impl ErrorValue for raw::HRESULT
-{
     fn from_error(err: ComError) -> Self
     {
-        err.hresult
-    }
-    fn from_com_error(err: ComError) -> Self
-    {
-        err.hresult
+        err.into()
     }
 }
 

--- a/intercom/src/lib.rs
+++ b/intercom/src/lib.rs
@@ -54,7 +54,6 @@
 //! ```
 
 #![crate_type = "dylib"]
-#![feature(specialization, integer_atomics, associated_type_defaults)]
 #![allow(clippy::match_bool)]
 
 extern crate self as intercom;

--- a/test/multilib/src/lib.rs
+++ b/test/multilib/src/lib.rs
@@ -1,5 +1,4 @@
 #![crate_type = "dylib"]
-#![feature(type_ascription)]
 
 extern crate intercom;
 use intercom::*;

--- a/test/testlib/src/lib.rs
+++ b/test/testlib/src/lib.rs
@@ -1,5 +1,4 @@
 #![crate_type = "dylib"]
-#![feature(type_ascription, specialization)]
 
 extern crate intercom;
 use intercom::*;


### PR DESCRIPTION
`specialization` was used in:
- `IntercomFrom`/`IntercomInto`, which was removed in #141.
- `ErrorValue`, which was made obsolete with #149.
- Few minor places, which were taken care of in this PR.

This was more or less the only unstable feature that we were depending on. The ergonomic losses are not that big and ability to support stable Rust outweighs them.