### PR TITLE
Make InterfacePtr NonNull

### DIFF
--- a/intercom-attributes/tests/data/macro/com_impl.rs.stdout
+++ b/intercom-attributes/tests/data/macro/com_impl.rs.stdout
@@ -115,7 +115,7 @@ impl intercom::CoClass for Foo {
     fn query_interface(
         vtables: &Self::VTableList,
         riid: intercom::REFIID,
-    ) -> intercom::RawComResult<intercom::RawComPtr> {
+    ) -> intercom::RawComResult<intercom::raw::RawComPtr> {
         if riid.is_null() {
             intercom::logging::error(|l| {
                 l(
@@ -195,7 +195,7 @@ impl intercom::CoClass for Foo {
                            as
                            *mut &<dyn intercom::ISupportErrorInfo as
                                  intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::VTable
-                           as intercom::RawComPtr;
+                           as intercom::raw::RawComPtr;
                     intercom::logging::trace(|l| {
                         l(
                             "testcrate",
@@ -279,7 +279,7 @@ impl intercom::CoClass for Foo {
                            as
                            *mut &<dyn intercom::ISupportErrorInfo as
                                  intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::VTable
-                           as intercom::RawComPtr;
+                           as intercom::raw::RawComPtr;
                     intercom::logging::trace(|l| {
                         l(
                             "testcrate",
@@ -368,7 +368,7 @@ impl intercom::CoClass for Foo {
                         >>::VTable
                         as *mut &<Foo as intercom::attributes::ComInterface<
                             intercom::type_system::AutomationTypeSystem,
-                        >>::VTable as intercom::RawComPtr;
+                        >>::VTable as intercom::raw::RawComPtr;
                     intercom::logging::trace(|l| {
                         l(
                             "testcrate",
@@ -479,7 +479,7 @@ impl intercom::CoClass for Foo {
                         >>::VTable
                         as *mut &<Foo as intercom::attributes::ComInterface<
                             intercom::type_system::RawTypeSystem,
-                        >>::VTable as intercom::RawComPtr;
+                        >>::VTable as intercom::raw::RawComPtr;
                     intercom::logging::trace(|l| {
                         l(
                             "testcrate",
@@ -749,11 +749,11 @@ impl Foo {
 #[allow(non_snake_case)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_query_interface_Automation(
-    self_vtable: intercom::RawComPtr,
+    self_vtable: intercom::raw::RawComPtr,
     riid: <intercom::REFIID as intercom::type_system::ExternInput<
         intercom::type_system::AutomationTypeSystem,
     >>::ForeignType,
-    out: *mut <intercom::RawComPtr as intercom::type_system::ExternOutput<
+    out: *mut <intercom::raw::RawComPtr as intercom::type_system::ExternOutput<
         intercom::type_system::AutomationTypeSystem,
     >>::ForeignType,
 ) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
@@ -785,7 +785,7 @@ unsafe extern "system" fn __Foo_Foo_query_interface_Automation(
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_add_ref_Automation(self_vtable:
-                                                           intercom::RawComPtr)
+                                                           intercom::raw::RawComPtr)
  ->
      <u32 as
 intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
@@ -815,7 +815,7 @@ intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_release_Automation(self_vtable:
-                                                           intercom::RawComPtr)
+                                                           intercom::raw::RawComPtr)
  ->
      <u32 as
 intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
@@ -845,7 +845,7 @@ intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_simple_method_Automation(
-    self_vtable: intercom::RawComPtr,
+    self_vtable: intercom::raw::RawComPtr,
 ) -> () {
     let self_combox = (self_vtable as usize
         - <Foo as intercom::attributes::ComClass<
@@ -891,7 +891,7 @@ unsafe extern "system" fn __Foo_Foo_simple_method_Automation(
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_arg_method_Automation(
-    self_vtable: intercom::RawComPtr,
+    self_vtable: intercom::raw::RawComPtr,
     a: <u16 as intercom::type_system::InfallibleExternInput<
         intercom::type_system::AutomationTypeSystem,
     >>::ForeignType,
@@ -942,7 +942,7 @@ unsafe extern "system" fn __Foo_Foo_arg_method_Automation(
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_simple_result_method_Automation(
-    self_vtable: intercom::RawComPtr,
+    self_vtable: intercom::raw::RawComPtr,
 ) -> <u16 as intercom::type_system::InfallibleExternOutput<
     intercom::type_system::AutomationTypeSystem,
 >>::ForeignType {
@@ -993,7 +993,7 @@ unsafe extern "system" fn __Foo_Foo_simple_result_method_Automation(
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_com_result_method_Automation(
-    self_vtable: intercom::RawComPtr,
+    self_vtable: intercom::raw::RawComPtr,
     __out: *mut <u16 as intercom::type_system::ExternOutput<
         intercom::type_system::AutomationTypeSystem,
     >>::ForeignType,
@@ -1092,7 +1092,7 @@ unsafe extern "system" fn __Foo_Foo_com_result_method_Automation(
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_rust_result_method_Automation(
-    self_vtable: intercom::RawComPtr,
+    self_vtable: intercom::raw::RawComPtr,
     __out: *mut <u16 as intercom::type_system::ExternOutput<
         intercom::type_system::AutomationTypeSystem,
     >>::ForeignType,
@@ -1191,7 +1191,7 @@ unsafe extern "system" fn __Foo_Foo_rust_result_method_Automation(
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_tuple_result_method_Automation(
-    self_vtable: intercom::RawComPtr,
+    self_vtable: intercom::raw::RawComPtr,
     __out1: *mut <u8 as intercom::type_system::ExternOutput<
         intercom::type_system::AutomationTypeSystem,
     >>::ForeignType,
@@ -1304,7 +1304,7 @@ unsafe extern "system" fn __Foo_Foo_tuple_result_method_Automation(
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_string_method_Automation(
-    self_vtable: intercom::RawComPtr,
+    self_vtable: intercom::raw::RawComPtr,
     input: <String as intercom::type_system::InfallibleExternInput<
         intercom::type_system::AutomationTypeSystem,
     >>::ForeignType,
@@ -1361,7 +1361,7 @@ unsafe extern "system" fn __Foo_Foo_string_method_Automation(
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_string_result_method_Automation(
-    self_vtable: intercom::RawComPtr,
+    self_vtable: intercom::raw::RawComPtr,
     input: <String as intercom::type_system::ExternInput<
         intercom::type_system::AutomationTypeSystem,
     >>::ForeignType,
@@ -1466,7 +1466,7 @@ unsafe extern "system" fn __Foo_Foo_string_result_method_Automation(
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_complete_method_Automation(
-    self_vtable: intercom::RawComPtr,
+    self_vtable: intercom::raw::RawComPtr,
     a:
                                                                    <u16 as
                                                                    intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
@@ -1578,7 +1578,7 @@ unsafe extern "system" fn __Foo_Foo_complete_method_Automation(
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_bool_method_Automation(
-    self_vtable: intercom::RawComPtr,
+    self_vtable: intercom::raw::RawComPtr,
     input: <bool as intercom::type_system::ExternInput<
         intercom::type_system::AutomationTypeSystem,
     >>::ForeignType,
@@ -1682,7 +1682,7 @@ unsafe extern "system" fn __Foo_Foo_bool_method_Automation(
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_variant_method_Automation(
-    self_vtable: intercom::RawComPtr,
+    self_vtable: intercom::raw::RawComPtr,
     input: <Variant as intercom::type_system::ExternInput<
         intercom::type_system::AutomationTypeSystem,
     >>::ForeignType,
@@ -1819,11 +1819,11 @@ impl intercom::attributes::ComImpl<Foo, intercom::type_system::AutomationTypeSys
 #[allow(non_snake_case)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_query_interface_Raw(
-    self_vtable: intercom::RawComPtr,
+    self_vtable: intercom::raw::RawComPtr,
     riid: <intercom::REFIID as intercom::type_system::ExternInput<
         intercom::type_system::AutomationTypeSystem,
     >>::ForeignType,
-    out: *mut <intercom::RawComPtr as intercom::type_system::ExternOutput<
+    out: *mut <intercom::raw::RawComPtr as intercom::type_system::ExternOutput<
         intercom::type_system::AutomationTypeSystem,
     >>::ForeignType,
 ) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
@@ -1856,7 +1856,7 @@ unsafe extern "system" fn __Foo_Foo_query_interface_Raw(
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_add_ref_Raw(self_vtable:
-                                                    intercom::RawComPtr)
+                                                    intercom::raw::RawComPtr)
  ->
      <u32 as
 intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
@@ -1887,7 +1887,7 @@ intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_release_Raw(self_vtable:
-                                                    intercom::RawComPtr)
+                                                    intercom::raw::RawComPtr)
  ->
      <u32 as
 intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
@@ -1917,7 +1917,7 @@ intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_simple_method_Raw(self_vtable: intercom::RawComPtr) -> () {
+unsafe extern "system" fn __Foo_Foo_simple_method_Raw(self_vtable: intercom::raw::RawComPtr) -> () {
     let self_combox =
         (self_vtable as usize -
              <Foo as
@@ -1963,7 +1963,7 @@ unsafe extern "system" fn __Foo_Foo_simple_method_Raw(self_vtable: intercom::Raw
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_arg_method_Raw(
-    self_vtable: intercom::RawComPtr,
+    self_vtable: intercom::raw::RawComPtr,
     a: <u16 as intercom::type_system::InfallibleExternInput<
         intercom::type_system::RawTypeSystem,
     >>::ForeignType,
@@ -2015,7 +2015,7 @@ unsafe extern "system" fn __Foo_Foo_arg_method_Raw(
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_simple_result_method_Raw(self_vtable:
-                                                                 intercom::RawComPtr)
+                                                                 intercom::raw::RawComPtr)
  ->
      <u16 as
 intercom::type_system::InfallibleExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType{
@@ -2066,7 +2066,7 @@ intercom::type_system::InfallibleExternOutput<intercom::type_system::RawTypeSyst
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_com_result_method_Raw(
-    self_vtable: intercom::RawComPtr,
+    self_vtable: intercom::raw::RawComPtr,
     __out: *mut <u16 as intercom::type_system::ExternOutput<
         intercom::type_system::RawTypeSystem,
     >>::ForeignType,
@@ -2166,7 +2166,7 @@ unsafe extern "system" fn __Foo_Foo_com_result_method_Raw(
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_rust_result_method_Raw(
-    self_vtable: intercom::RawComPtr,
+    self_vtable: intercom::raw::RawComPtr,
     __out: *mut <u16 as intercom::type_system::ExternOutput<
         intercom::type_system::RawTypeSystem,
     >>::ForeignType,
@@ -2266,7 +2266,7 @@ unsafe extern "system" fn __Foo_Foo_rust_result_method_Raw(
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_tuple_result_method_Raw(
-    self_vtable: intercom::RawComPtr,
+    self_vtable: intercom::raw::RawComPtr,
     __out1: *mut <u8 as intercom::type_system::ExternOutput<
         intercom::type_system::RawTypeSystem,
     >>::ForeignType,
@@ -2380,7 +2380,7 @@ unsafe extern "system" fn __Foo_Foo_tuple_result_method_Raw(
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_string_method_Raw(self_vtable:
-                                                          intercom::RawComPtr,
+                                                          intercom::raw::RawComPtr,
                                                       input:
                                                           <String as
                                                           intercom::type_system::InfallibleExternInput<intercom::type_system::RawTypeSystem>>::ForeignType)
@@ -2438,7 +2438,7 @@ intercom::type_system::InfallibleExternOutput<intercom::type_system::RawTypeSyst
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_string_result_method_Raw(
-    self_vtable: intercom::RawComPtr,
+    self_vtable: intercom::raw::RawComPtr,
     input:
                                                                  <String as
                                                                  intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
@@ -2544,7 +2544,7 @@ unsafe extern "system" fn __Foo_Foo_string_result_method_Raw(
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_complete_method_Raw(
-    self_vtable: intercom::RawComPtr,
+    self_vtable: intercom::raw::RawComPtr,
     a:
                                                             <u16 as
                                                             intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
@@ -2658,7 +2658,7 @@ unsafe extern "system" fn __Foo_Foo_complete_method_Raw(
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_bool_method_Raw(
-    self_vtable: intercom::RawComPtr,
+    self_vtable: intercom::raw::RawComPtr,
     input:
                                                         <bool as
                                                         intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
@@ -2763,7 +2763,7 @@ unsafe extern "system" fn __Foo_Foo_bool_method_Raw(
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_variant_method_Raw(
-    self_vtable: intercom::RawComPtr,
+    self_vtable: intercom::raw::RawComPtr,
     input:
                                                            <Variant as
                                                            intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,

--- a/intercom-attributes/tests/data/macro/com_interface.rs.stdout
+++ b/intercom-attributes/tests/data/macro/com_interface.rs.stdout
@@ -37,21 +37,21 @@ pub struct __IntercomVtableForFoo_Automation {
     pub __base: <dyn intercom::IUnknown as
                 intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::VTable,
     pub simple_method: unsafe extern "system" fn(self_vtable:
-                                                     intercom::RawComPtr)
+                                                     intercom::raw::RawComPtr)
                            -> (),
     pub arg_method: unsafe extern "system" fn(self_vtable:
-                                                  intercom::RawComPtr,
+                                                  intercom::raw::RawComPtr,
                                               a:
                                                   <u16 as
                                                   intercom::type_system::InfallibleExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
                         -> (),
     pub simple_result_method: unsafe extern "system" fn(self_vtable:
-                                                            intercom::RawComPtr)
+                                                            intercom::raw::RawComPtr)
                                   ->
                                       <u16 as
                                       intercom::type_system::InfallibleExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
     pub com_result_method: unsafe extern "system" fn(self_vtable:
-                                                         intercom::RawComPtr,
+                                                         intercom::raw::RawComPtr,
                                                      __out:
                                                          *mut <u16 as
                                                               intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
@@ -59,7 +59,7 @@ pub struct __IntercomVtableForFoo_Automation {
                                    <intercom::raw::HRESULT as
                                    intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
     pub rust_result_method: unsafe extern "system" fn(self_vtable:
-                                                          intercom::RawComPtr,
+                                                          intercom::raw::RawComPtr,
                                                       __out:
                                                           *mut <u16 as
                                                                intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
@@ -67,7 +67,7 @@ pub struct __IntercomVtableForFoo_Automation {
                                     <intercom::raw::HRESULT as
                                     intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
     pub complete_method: unsafe extern "system" fn(self_vtable:
-                                                       intercom::RawComPtr,
+                                                       intercom::raw::RawComPtr,
                                                    a:
                                                        <u16 as
                                                        intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
@@ -81,7 +81,7 @@ pub struct __IntercomVtableForFoo_Automation {
                                  <intercom::raw::HRESULT as
                                  intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
     pub string_method: unsafe extern "system" fn(self_vtable:
-                                                     intercom::RawComPtr,
+                                                     intercom::raw::RawComPtr,
                                                  msg:
                                                      <String as
                                                      intercom::type_system::InfallibleExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
@@ -89,7 +89,7 @@ pub struct __IntercomVtableForFoo_Automation {
                                <String as
                                intercom::type_system::InfallibleExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
     pub comitf_method: unsafe extern "system" fn(self_vtable:
-                                                     intercom::RawComPtr,
+                                                     intercom::raw::RawComPtr,
                                                  itf:
                                                      <ComItf<dyn Foo> as
                                                      intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
@@ -101,7 +101,7 @@ pub struct __IntercomVtableForFoo_Automation {
                                <intercom::raw::HRESULT as
                                intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
     pub bool_method: unsafe extern "system" fn(self_vtable:
-                                                   intercom::RawComPtr,
+                                                   intercom::raw::RawComPtr,
                                                input:
                                                    <bool as
                                                    intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
@@ -112,7 +112,7 @@ pub struct __IntercomVtableForFoo_Automation {
                              <intercom::raw::HRESULT as
                              intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
     pub variant_method: unsafe extern "system" fn(self_vtable:
-                                                      intercom::RawComPtr,
+                                                      intercom::raw::RawComPtr,
                                                   input:
                                                       <Variant as
                                                       intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
@@ -147,21 +147,21 @@ pub struct __IntercomVtableForFoo_Raw {
     pub __base: <dyn intercom::IUnknown as
                 intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::VTable,
     pub simple_method: unsafe extern "system" fn(self_vtable:
-                                                     intercom::RawComPtr)
+                                                     intercom::raw::RawComPtr)
                            -> (),
     pub arg_method: unsafe extern "system" fn(self_vtable:
-                                                  intercom::RawComPtr,
+                                                  intercom::raw::RawComPtr,
                                               a:
                                                   <u16 as
                                                   intercom::type_system::InfallibleExternInput<intercom::type_system::RawTypeSystem>>::ForeignType)
                         -> (),
     pub simple_result_method: unsafe extern "system" fn(self_vtable:
-                                                            intercom::RawComPtr)
+                                                            intercom::raw::RawComPtr)
                                   ->
                                       <u16 as
                                       intercom::type_system::InfallibleExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType,
     pub com_result_method: unsafe extern "system" fn(self_vtable:
-                                                         intercom::RawComPtr,
+                                                         intercom::raw::RawComPtr,
                                                      __out:
                                                          *mut <u16 as
                                                               intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType)
@@ -169,7 +169,7 @@ pub struct __IntercomVtableForFoo_Raw {
                                    <intercom::raw::HRESULT as
                                    intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType,
     pub rust_result_method: unsafe extern "system" fn(self_vtable:
-                                                          intercom::RawComPtr,
+                                                          intercom::raw::RawComPtr,
                                                       __out:
                                                           *mut <u16 as
                                                                intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType)
@@ -177,7 +177,7 @@ pub struct __IntercomVtableForFoo_Raw {
                                     <intercom::raw::HRESULT as
                                     intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType,
     pub complete_method: unsafe extern "system" fn(self_vtable:
-                                                       intercom::RawComPtr,
+                                                       intercom::raw::RawComPtr,
                                                    a:
                                                        <u16 as
                                                        intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
@@ -191,7 +191,7 @@ pub struct __IntercomVtableForFoo_Raw {
                                  <intercom::raw::HRESULT as
                                  intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType,
     pub string_method: unsafe extern "system" fn(self_vtable:
-                                                     intercom::RawComPtr,
+                                                     intercom::raw::RawComPtr,
                                                  msg:
                                                      <String as
                                                      intercom::type_system::InfallibleExternInput<intercom::type_system::RawTypeSystem>>::ForeignType)
@@ -199,7 +199,7 @@ pub struct __IntercomVtableForFoo_Raw {
                                <String as
                                intercom::type_system::InfallibleExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType,
     pub comitf_method: unsafe extern "system" fn(self_vtable:
-                                                     intercom::RawComPtr,
+                                                     intercom::raw::RawComPtr,
                                                  itf:
                                                      <ComItf<dyn Foo> as
                                                      intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
@@ -211,7 +211,7 @@ pub struct __IntercomVtableForFoo_Raw {
                                <intercom::raw::HRESULT as
                                intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType,
     pub bool_method: unsafe extern "system" fn(self_vtable:
-                                                   intercom::RawComPtr,
+                                                   intercom::raw::RawComPtr,
                                                input:
                                                    <bool as
                                                    intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
@@ -222,7 +222,7 @@ pub struct __IntercomVtableForFoo_Raw {
                              <intercom::raw::HRESULT as
                              intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType,
     pub variant_method: unsafe extern "system" fn(self_vtable:
-                                                      intercom::RawComPtr,
+                                                      intercom::raw::RawComPtr,
                                                   input:
                                                       <Variant as
                                                       intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
@@ -269,7 +269,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
         #[allow(unused_imports)]
         use intercom::ErrorValue;
         if let Some(comptr) =
-            intercom::ComItf::maybe_ptr::<intercom::type_system::AutomationTypeSystem>(self)
+            intercom::ComItf::ptr::<intercom::type_system::AutomationTypeSystem>(self)
         {
             intercom::logging::trace(|l| {
                 l(
@@ -289,7 +289,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            let vtbl = comptr.ptr
+            let vtbl = comptr.ptr.as_ptr()
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::AutomationTypeSystem,
                 >>::VTable;
@@ -297,7 +297,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
             #[allow(unused_unsafe)]
             unsafe {
                 let __result = ((**vtbl).arg_method)(
-                    comptr.ptr,
+                    comptr.ptr.as_ptr(),
                     <u16 as intercom::type_system::InfallibleExternInput<
                         intercom::type_system::AutomationTypeSystem,
                     >>::into_foreign_parameter(a)
@@ -312,9 +312,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 return {};
             }
         }
-        if let Some(comptr) =
-            intercom::ComItf::maybe_ptr::<intercom::type_system::RawTypeSystem>(self)
-        {
+        if let Some(comptr) = intercom::ComItf::ptr::<intercom::type_system::RawTypeSystem>(self) {
             intercom::logging::trace(|l| {
                 l(
                     "testcrate",
@@ -333,7 +331,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            let vtbl = comptr.ptr
+            let vtbl = comptr.ptr.as_ptr()
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::RawTypeSystem,
                 >>::VTable;
@@ -341,7 +339,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
             #[allow(unused_unsafe)]
             unsafe {
                 let __result = ((**vtbl).arg_method)(
-                    comptr.ptr,
+                    comptr.ptr.as_ptr(),
                     <u16 as intercom::type_system::InfallibleExternInput<
                         intercom::type_system::RawTypeSystem,
                     >>::into_foreign_parameter(a)
@@ -384,7 +382,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
         #[allow(unused_imports)]
         use intercom::ErrorValue;
         if let Some(comptr) =
-            intercom::ComItf::maybe_ptr::<intercom::type_system::AutomationTypeSystem>(self)
+            intercom::ComItf::ptr::<intercom::type_system::AutomationTypeSystem>(self)
         {
             intercom::logging::trace(|l| {
                 l(
@@ -404,7 +402,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            let vtbl = comptr.ptr
+            let vtbl = comptr.ptr.as_ptr()
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::AutomationTypeSystem,
                 >>::VTable;
@@ -414,7 +412,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                     intercom::type_system::AutomationTypeSystem,
                 >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).bool_method)(
-                    comptr.ptr,
+                    comptr.ptr.as_ptr(),
                     <bool as intercom::type_system::ExternInput<
                         intercom::type_system::AutomationTypeSystem,
                     >>::into_foreign_parameter(input)?
@@ -446,9 +444,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 Err(err) => <ComResult<bool> as intercom::ErrorValue>::from_error(err),
             };
         }
-        if let Some(comptr) =
-            intercom::ComItf::maybe_ptr::<intercom::type_system::RawTypeSystem>(self)
-        {
+        if let Some(comptr) = intercom::ComItf::ptr::<intercom::type_system::RawTypeSystem>(self) {
             intercom::logging::trace(|l| {
                 l(
                     "testcrate",
@@ -467,7 +463,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            let vtbl = comptr.ptr
+            let vtbl = comptr.ptr.as_ptr()
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::RawTypeSystem,
                 >>::VTable;
@@ -477,7 +473,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                     intercom::type_system::RawTypeSystem,
                 >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).bool_method)(
-                    comptr.ptr,
+                    comptr.ptr.as_ptr(),
                     <bool as intercom::type_system::ExternInput<
                         intercom::type_system::RawTypeSystem,
                     >>::into_foreign_parameter(input)?
@@ -537,7 +533,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
         #[allow(unused_imports)]
         use intercom::ErrorValue;
         if let Some(comptr) =
-            intercom::ComItf::maybe_ptr::<intercom::type_system::AutomationTypeSystem>(self)
+            intercom::ComItf::ptr::<intercom::type_system::AutomationTypeSystem>(self)
         {
             intercom::logging::trace(|l| {
                 l(
@@ -563,7 +559,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            let vtbl = comptr.ptr
+            let vtbl = comptr.ptr.as_ptr()
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::AutomationTypeSystem,
                 >>::VTable;
@@ -572,7 +568,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 let mut __out: <u16 as intercom::type_system::ExternOutput<
                     intercom::type_system::AutomationTypeSystem,
                 >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
-                let __result = ((**vtbl).com_result_method)(comptr.ptr, &mut __out);
+                let __result = ((**vtbl).com_result_method)(comptr.ptr.as_ptr(), &mut __out);
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
                     data2: 0u16,
@@ -598,9 +594,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 Err(err) => <ComResult<u16> as intercom::ErrorValue>::from_error(err),
             };
         }
-        if let Some(comptr) =
-            intercom::ComItf::maybe_ptr::<intercom::type_system::RawTypeSystem>(self)
-        {
+        if let Some(comptr) = intercom::ComItf::ptr::<intercom::type_system::RawTypeSystem>(self) {
             intercom::logging::trace(|l| {
                 l(
                     "testcrate",
@@ -619,7 +613,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            let vtbl = comptr.ptr
+            let vtbl = comptr.ptr.as_ptr()
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::RawTypeSystem,
                 >>::VTable;
@@ -628,7 +622,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 let mut __out: <u16 as intercom::type_system::ExternOutput<
                     intercom::type_system::RawTypeSystem,
                 >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
-                let __result = ((**vtbl).com_result_method)(comptr.ptr, &mut __out);
+                let __result = ((**vtbl).com_result_method)(comptr.ptr.as_ptr(), &mut __out);
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
                     data2: 0u16,
@@ -682,7 +676,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
         #[allow(unused_imports)]
         use intercom::ErrorValue;
         if let Some(comptr) =
-            intercom::ComItf::maybe_ptr::<intercom::type_system::AutomationTypeSystem>(self)
+            intercom::ComItf::ptr::<intercom::type_system::AutomationTypeSystem>(self)
         {
             intercom::logging::trace(|l| {
                 l(
@@ -702,7 +696,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            let vtbl = comptr.ptr
+            let vtbl = comptr.ptr.as_ptr()
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::AutomationTypeSystem,
                 >>::VTable;
@@ -715,7 +709,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                     intercom::type_system::AutomationTypeSystem,
                 >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).comitf_method)(
-                    comptr.ptr,
+                    comptr.ptr.as_ptr(),
                     <ComItf<dyn Foo> as intercom::type_system::ExternInput<
                         intercom::type_system::AutomationTypeSystem,
                     >>::into_foreign_parameter(itf)?
@@ -751,9 +745,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 }
             };
         }
-        if let Some(comptr) =
-            intercom::ComItf::maybe_ptr::<intercom::type_system::RawTypeSystem>(self)
-        {
+        if let Some(comptr) = intercom::ComItf::ptr::<intercom::type_system::RawTypeSystem>(self) {
             intercom::logging::trace(|l| {
                 l(
                     "testcrate",
@@ -772,7 +764,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            let vtbl = comptr.ptr
+            let vtbl = comptr.ptr.as_ptr()
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::RawTypeSystem,
                 >>::VTable;
@@ -785,7 +777,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                     intercom::type_system::RawTypeSystem,
                 >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).comitf_method)(
-                    comptr.ptr,
+                    comptr.ptr.as_ptr(),
                     <ComItf<dyn Foo> as intercom::type_system::ExternInput<
                         intercom::type_system::RawTypeSystem,
                     >>::into_foreign_parameter(itf)?
@@ -849,7 +841,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
         #[allow(unused_imports)]
         use intercom::ErrorValue;
         if let Some(comptr) =
-            intercom::ComItf::maybe_ptr::<intercom::type_system::AutomationTypeSystem>(self)
+            intercom::ComItf::ptr::<intercom::type_system::AutomationTypeSystem>(self)
         {
             intercom::logging::trace(|l| {
                 l(
@@ -875,7 +867,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            let vtbl = comptr.ptr
+            let vtbl = comptr.ptr.as_ptr()
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::AutomationTypeSystem,
                 >>::VTable;
@@ -885,7 +877,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                     intercom::type_system::AutomationTypeSystem,
                 >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).complete_method)(
-                    comptr.ptr,
+                    comptr.ptr.as_ptr(),
                     <u16 as intercom::type_system::ExternInput<
                         intercom::type_system::AutomationTypeSystem,
                     >>::into_foreign_parameter(a)?
@@ -921,9 +913,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 Err(err) => <ComResult<bool> as intercom::ErrorValue>::from_error(err),
             };
         }
-        if let Some(comptr) =
-            intercom::ComItf::maybe_ptr::<intercom::type_system::RawTypeSystem>(self)
-        {
+        if let Some(comptr) = intercom::ComItf::ptr::<intercom::type_system::RawTypeSystem>(self) {
             intercom::logging::trace(|l| {
                 l(
                     "testcrate",
@@ -942,7 +932,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            let vtbl = comptr.ptr
+            let vtbl = comptr.ptr.as_ptr()
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::RawTypeSystem,
                 >>::VTable;
@@ -952,7 +942,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                     intercom::type_system::RawTypeSystem,
                 >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).complete_method)(
-                    comptr.ptr,
+                    comptr.ptr.as_ptr(),
                     <u16 as intercom::type_system::ExternInput<
                         intercom::type_system::RawTypeSystem,
                     >>::into_foreign_parameter(a)?
@@ -1016,7 +1006,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
         #[allow(unused_imports)]
         use intercom::ErrorValue;
         if let Some(comptr) =
-            intercom::ComItf::maybe_ptr::<intercom::type_system::AutomationTypeSystem>(self)
+            intercom::ComItf::ptr::<intercom::type_system::AutomationTypeSystem>(self)
         {
             intercom::logging::trace(|l| {
                 l(
@@ -1042,7 +1032,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            let vtbl = comptr.ptr
+            let vtbl = comptr.ptr.as_ptr()
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::AutomationTypeSystem,
                 >>::VTable;
@@ -1051,7 +1041,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 let mut __out: <u16 as intercom::type_system::ExternOutput<
                     intercom::type_system::AutomationTypeSystem,
                 >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
-                let __result = ((**vtbl).rust_result_method)(comptr.ptr, &mut __out);
+                let __result = ((**vtbl).rust_result_method)(comptr.ptr.as_ptr(), &mut __out);
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
                     data2: 0u16,
@@ -1077,9 +1067,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 Err(err) => <Result<u16, i32> as intercom::ErrorValue>::from_error(err),
             };
         }
-        if let Some(comptr) =
-            intercom::ComItf::maybe_ptr::<intercom::type_system::RawTypeSystem>(self)
-        {
+        if let Some(comptr) = intercom::ComItf::ptr::<intercom::type_system::RawTypeSystem>(self) {
             intercom::logging::trace(|l| {
                 l(
                     "testcrate",
@@ -1098,7 +1086,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            let vtbl = comptr.ptr
+            let vtbl = comptr.ptr.as_ptr()
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::RawTypeSystem,
                 >>::VTable;
@@ -1107,7 +1095,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 let mut __out: <u16 as intercom::type_system::ExternOutput<
                     intercom::type_system::RawTypeSystem,
                 >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
-                let __result = ((**vtbl).rust_result_method)(comptr.ptr, &mut __out);
+                let __result = ((**vtbl).rust_result_method)(comptr.ptr.as_ptr(), &mut __out);
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
                     data2: 0u16,
@@ -1161,7 +1149,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
         #[allow(unused_imports)]
         use intercom::ErrorValue;
         if let Some(comptr) =
-            intercom::ComItf::maybe_ptr::<intercom::type_system::AutomationTypeSystem>(self)
+            intercom::ComItf::ptr::<intercom::type_system::AutomationTypeSystem>(self)
         {
             intercom::logging::trace(|l| {
                 l(
@@ -1181,14 +1169,14 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            let vtbl = comptr.ptr
+            let vtbl = comptr.ptr.as_ptr()
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::AutomationTypeSystem,
                 >>::VTable;
 
             #[allow(unused_unsafe)]
             unsafe {
-                let __result = ((**vtbl).simple_method)(comptr.ptr);
+                let __result = ((**vtbl).simple_method)(comptr.ptr.as_ptr());
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
                     data2: 0u16,
@@ -1198,9 +1186,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 return {};
             }
         }
-        if let Some(comptr) =
-            intercom::ComItf::maybe_ptr::<intercom::type_system::RawTypeSystem>(self)
-        {
+        if let Some(comptr) = intercom::ComItf::ptr::<intercom::type_system::RawTypeSystem>(self) {
             intercom::logging::trace(|l| {
                 l(
                     "testcrate",
@@ -1219,14 +1205,14 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            let vtbl = comptr.ptr
+            let vtbl = comptr.ptr.as_ptr()
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::RawTypeSystem,
                 >>::VTable;
 
             #[allow(unused_unsafe)]
             unsafe {
-                let __result = ((**vtbl).simple_method)(comptr.ptr);
+                let __result = ((**vtbl).simple_method)(comptr.ptr.as_ptr());
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
                     data2: 0u16,
@@ -1264,7 +1250,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
         #[allow(unused_imports)]
         use intercom::ErrorValue;
         if let Some(comptr) =
-            intercom::ComItf::maybe_ptr::<intercom::type_system::AutomationTypeSystem>(self)
+            intercom::ComItf::ptr::<intercom::type_system::AutomationTypeSystem>(self)
         {
             intercom::logging::trace(|l| {
                 l(
@@ -1290,14 +1276,14 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            let vtbl = comptr.ptr
+            let vtbl = comptr.ptr.as_ptr()
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::AutomationTypeSystem,
                 >>::VTable;
 
             #[allow(unused_unsafe)]
             unsafe {
-                let __result = ((**vtbl).simple_result_method)(comptr.ptr);
+                let __result = ((**vtbl).simple_result_method)(comptr.ptr.as_ptr());
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
                     data2: 0u16,
@@ -1311,9 +1297,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 };
             }
         }
-        if let Some(comptr) =
-            intercom::ComItf::maybe_ptr::<intercom::type_system::RawTypeSystem>(self)
-        {
+        if let Some(comptr) = intercom::ComItf::ptr::<intercom::type_system::RawTypeSystem>(self) {
             intercom::logging::trace(|l| {
                 l(
                     "testcrate",
@@ -1332,14 +1316,14 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            let vtbl = comptr.ptr
+            let vtbl = comptr.ptr.as_ptr()
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::RawTypeSystem,
                 >>::VTable;
 
             #[allow(unused_unsafe)]
             unsafe {
-                let __result = ((**vtbl).simple_result_method)(comptr.ptr);
+                let __result = ((**vtbl).simple_result_method)(comptr.ptr.as_ptr());
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
                     data2: 0u16,
@@ -1381,7 +1365,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
         #[allow(unused_imports)]
         use intercom::ErrorValue;
         if let Some(comptr) =
-            intercom::ComItf::maybe_ptr::<intercom::type_system::AutomationTypeSystem>(self)
+            intercom::ComItf::ptr::<intercom::type_system::AutomationTypeSystem>(self)
         {
             intercom::logging::trace(|l| {
                 l(
@@ -1401,7 +1385,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            let vtbl = comptr.ptr
+            let vtbl = comptr.ptr.as_ptr()
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::AutomationTypeSystem,
                 >>::VTable;
@@ -1409,7 +1393,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
             #[allow(unused_unsafe)]
             unsafe {
                 let __result = ((**vtbl).string_method)(
-                    comptr.ptr,
+                    comptr.ptr.as_ptr(),
                     <String as intercom::type_system::InfallibleExternInput<
                         intercom::type_system::AutomationTypeSystem,
                     >>::into_foreign_parameter(msg)
@@ -1428,9 +1412,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 };
             }
         }
-        if let Some(comptr) =
-            intercom::ComItf::maybe_ptr::<intercom::type_system::RawTypeSystem>(self)
-        {
+        if let Some(comptr) = intercom::ComItf::ptr::<intercom::type_system::RawTypeSystem>(self) {
             intercom::logging::trace(|l| {
                 l(
                     "testcrate",
@@ -1449,7 +1431,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            let vtbl = comptr.ptr
+            let vtbl = comptr.ptr.as_ptr()
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::RawTypeSystem,
                 >>::VTable;
@@ -1457,7 +1439,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
             #[allow(unused_unsafe)]
             unsafe {
                 let __result = ((**vtbl).string_method)(
-                    comptr.ptr,
+                    comptr.ptr.as_ptr(),
                     <String as intercom::type_system::InfallibleExternInput<
                         intercom::type_system::RawTypeSystem,
                     >>::into_foreign_parameter(msg)
@@ -1504,7 +1486,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
         #[allow(unused_imports)]
         use intercom::ErrorValue;
         if let Some(comptr) =
-            intercom::ComItf::maybe_ptr::<intercom::type_system::AutomationTypeSystem>(self)
+            intercom::ComItf::ptr::<intercom::type_system::AutomationTypeSystem>(self)
         {
             intercom::logging::trace(|l| {
                 l(
@@ -1524,7 +1506,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            let vtbl = comptr.ptr
+            let vtbl = comptr.ptr.as_ptr()
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::AutomationTypeSystem,
                 >>::VTable;
@@ -1534,7 +1516,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                     intercom::type_system::AutomationTypeSystem,
                 >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).variant_method)(
-                    comptr.ptr,
+                    comptr.ptr.as_ptr(),
                     <Variant as intercom::type_system::ExternInput<
                         intercom::type_system::AutomationTypeSystem,
                     >>::into_foreign_parameter(input)?
@@ -1567,9 +1549,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 Err(err) => <ComResult<Variant> as intercom::ErrorValue>::from_error(err),
             };
         }
-        if let Some(comptr) =
-            intercom::ComItf::maybe_ptr::<intercom::type_system::RawTypeSystem>(self)
-        {
+        if let Some(comptr) = intercom::ComItf::ptr::<intercom::type_system::RawTypeSystem>(self) {
             intercom::logging::trace(|l| {
                 l(
                     "testcrate",
@@ -1588,7 +1568,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                 )
             });
             #[allow(unused_imports)]
-            let vtbl = comptr.ptr
+            let vtbl = comptr.ptr.as_ptr()
                 as *const *const <dyn Foo as intercom::attributes::ComInterface<
                     intercom::type_system::RawTypeSystem,
                 >>::VTable;
@@ -1598,7 +1578,7 @@ impl Foo for intercom::ComItf<dyn Foo> {
                     intercom::type_system::RawTypeSystem,
                 >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).variant_method)(
-                    comptr.ptr,
+                    comptr.ptr.as_ptr(),
                     <Variant as intercom::type_system::ExternInput<
                         intercom::type_system::RawTypeSystem,
                     >>::into_foreign_parameter(input)?

--- a/intercom-attributes/tests/data/macro/com_library.rs.stdout
+++ b/intercom-attributes/tests/data/macro/com_library.rs.stdout
@@ -30,7 +30,7 @@ pub(crate) fn get_intercom_coclass_info_for_SimpleType() -> intercom::typelib::T
 pub unsafe fn __get_module_class_factory(
     rclsid: intercom::REFCLSID,
     riid: intercom::REFIID,
-    pout: *mut intercom::RawComPtr,
+    pout: *mut intercom::raw::RawComPtr,
 ) -> Option<intercom::raw::HRESULT> {
     match *rclsid {
         some::path::CLSID_Type => {
@@ -50,7 +50,7 @@ pub unsafe fn __get_module_class_factory(
 pub unsafe extern "system" fn DllGetClassObject(
     rclsid: intercom::REFCLSID,
     riid: intercom::REFIID,
-    pout: *mut intercom::RawComPtr,
+    pout: *mut intercom::raw::RawComPtr,
 ) -> intercom::raw::HRESULT {
     if let Some(hr) = __get_module_class_factory(rclsid, riid, pout) {
         return hr;
@@ -72,7 +72,7 @@ pub fn __gather_module_types() -> Vec<intercom::typelib::TypeInfo> {
 #[no_mangle]
 pub unsafe extern "system" fn IntercomTypeLib(
     type_system: intercom::type_system::TypeSystemName,
-    out: *mut intercom::RawComPtr,
+    out: *mut intercom::raw::RawComPtr,
 ) -> intercom::raw::HRESULT {
     let mut tlib = intercom::ComBox::new(intercom::typelib::TypeLib::__new(
         "TestLib".into(),
@@ -90,14 +90,7 @@ pub unsafe extern "system" fn IntercomTypeLib(
     ));
     let rc = intercom::ComRc::<intercom::typelib::IIntercomTypeLib>::from(&tlib);
     let itf = intercom::ComRc::detach(rc);
-    *out = match type_system {
-        intercom::type_system::TypeSystemName::Automation => {
-            intercom::ComItf::ptr::<intercom::type_system::AutomationTypeSystem>(&itf).ptr
-        }
-        intercom::type_system::TypeSystemName::Raw => {
-            intercom::ComItf::ptr::<intercom::type_system::RawTypeSystem>(&itf).ptr
-        }
-    };
+    *out = type_system.get_ptr(&itf);
     intercom::raw::S_OK
 }
 #[no_mangle]

--- a/intercom-attributes/tests/data/macro/private_item.rs.stdout
+++ b/intercom-attributes/tests/data/macro/private_item.rs.stdout
@@ -19,7 +19,7 @@ struct __IntercomVtableForIFoo_Automation {
     pub __base: <dyn intercom::IUnknown as intercom::attributes::ComInterface<
         intercom::type_system::AutomationTypeSystem,
     >>::VTable,
-    pub trait_method: unsafe extern "system" fn(self_vtable: intercom::RawComPtr) -> (),
+    pub trait_method: unsafe extern "system" fn(self_vtable: intercom::raw::RawComPtr) -> (),
 }
 #[allow(non_camel_case_types)]
 #[allow(non_snake_case)]
@@ -45,7 +45,7 @@ struct __IntercomVtableForIFoo_Raw {
     pub __base: <dyn intercom::IUnknown as intercom::attributes::ComInterface<
         intercom::type_system::AutomationTypeSystem,
     >>::VTable,
-    pub trait_method: unsafe extern "system" fn(self_vtable: intercom::RawComPtr) -> (),
+    pub trait_method: unsafe extern "system" fn(self_vtable: intercom::raw::RawComPtr) -> (),
 }
 #[allow(non_camel_case_types)]
 #[allow(non_snake_case)]
@@ -83,7 +83,7 @@ impl IFoo for intercom::ComItf<dyn IFoo> {
         #[allow(unused_imports)]
         use intercom::ErrorValue;
         if let Some(comptr) =
-            intercom::ComItf::maybe_ptr::<intercom::type_system::AutomationTypeSystem>(self)
+            intercom::ComItf::ptr::<intercom::type_system::AutomationTypeSystem>(self)
         {
             intercom::logging::trace(|l| {
                 l(
@@ -103,14 +103,14 @@ impl IFoo for intercom::ComItf<dyn IFoo> {
                 )
             });
             #[allow(unused_imports)]
-            let vtbl = comptr.ptr
+            let vtbl = comptr.ptr.as_ptr()
                 as *const *const <dyn IFoo as intercom::attributes::ComInterface<
                     intercom::type_system::AutomationTypeSystem,
                 >>::VTable;
 
             #[allow(unused_unsafe)]
             unsafe {
-                let __result = ((**vtbl).trait_method)(comptr.ptr);
+                let __result = ((**vtbl).trait_method)(comptr.ptr.as_ptr());
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
                     data2: 0u16,
@@ -120,9 +120,7 @@ impl IFoo for intercom::ComItf<dyn IFoo> {
                 return {};
             }
         }
-        if let Some(comptr) =
-            intercom::ComItf::maybe_ptr::<intercom::type_system::RawTypeSystem>(self)
-        {
+        if let Some(comptr) = intercom::ComItf::ptr::<intercom::type_system::RawTypeSystem>(self) {
             intercom::logging::trace(|l| {
                 l(
                     "testcrate",
@@ -141,14 +139,14 @@ impl IFoo for intercom::ComItf<dyn IFoo> {
                 )
             });
             #[allow(unused_imports)]
-            let vtbl = comptr.ptr
+            let vtbl = comptr.ptr.as_ptr()
                 as *const *const <dyn IFoo as intercom::attributes::ComInterface<
                     intercom::type_system::RawTypeSystem,
                 >>::VTable;
 
             #[allow(unused_unsafe)]
             unsafe {
-                let __result = ((**vtbl).trait_method)(comptr.ptr);
+                let __result = ((**vtbl).trait_method)(comptr.ptr.as_ptr());
                 let __intercom_iid = intercom::GUID {
                     data1: 0u32,
                     data2: 0u16,
@@ -367,7 +365,7 @@ impl intercom::CoClass for Foo {
     fn query_interface(
         vtables: &Self::VTableList,
         riid: intercom::REFIID,
-    ) -> intercom::RawComResult<intercom::RawComPtr> {
+    ) -> intercom::RawComResult<intercom::raw::RawComPtr> {
         if riid.is_null() {
             intercom::logging::error(|l| {
                 l(
@@ -447,7 +445,7 @@ impl intercom::CoClass for Foo {
                            as
                            *mut &<dyn intercom::ISupportErrorInfo as
                                  intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::VTable
-                           as intercom::RawComPtr;
+                           as intercom::raw::RawComPtr;
                     intercom::logging::trace(|l| {
                         l(
                             "testcrate",
@@ -531,7 +529,7 @@ impl intercom::CoClass for Foo {
                            as
                            *mut &<dyn intercom::ISupportErrorInfo as
                                  intercom::attributes::ComInterface<intercom::type_system::AutomationTypeSystem>>::VTable
-                           as intercom::RawComPtr;
+                           as intercom::raw::RawComPtr;
                     intercom::logging::trace(|l| {
                         l(
                             "testcrate",
@@ -620,7 +618,7 @@ impl intercom::CoClass for Foo {
                         >>::VTable
                         as *mut &<Foo as intercom::attributes::ComInterface<
                             intercom::type_system::AutomationTypeSystem,
-                        >>::VTable as intercom::RawComPtr;
+                        >>::VTable as intercom::raw::RawComPtr;
                     intercom::logging::trace(|l| {
                         l(
                             "testcrate",
@@ -731,7 +729,7 @@ impl intercom::CoClass for Foo {
                         >>::VTable
                         as *mut &<Foo as intercom::attributes::ComInterface<
                             intercom::type_system::RawTypeSystem,
-                        >>::VTable as intercom::RawComPtr;
+                        >>::VTable as intercom::raw::RawComPtr;
                     intercom::logging::trace(|l| {
                         l(
                             "testcrate",
@@ -842,7 +840,7 @@ impl intercom::CoClass for Foo {
                         >>::VTable
                         as *mut &<dyn IFoo as intercom::attributes::ComInterface<
                             intercom::type_system::AutomationTypeSystem,
-                        >>::VTable as intercom::RawComPtr;
+                        >>::VTable as intercom::raw::RawComPtr;
                     intercom::logging::trace(|l| {
                         l(
                             "testcrate",
@@ -953,7 +951,7 @@ impl intercom::CoClass for Foo {
                         >>::VTable
                         as *mut &<dyn IFoo as intercom::attributes::ComInterface<
                             intercom::type_system::RawTypeSystem,
-                        >>::VTable as intercom::RawComPtr;
+                        >>::VTable as intercom::raw::RawComPtr;
                     intercom::logging::trace(|l| {
                         l(
                             "testcrate",
@@ -1207,11 +1205,11 @@ impl Foo {
 #[allow(non_snake_case)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_query_interface_Automation(
-    self_vtable: intercom::RawComPtr,
+    self_vtable: intercom::raw::RawComPtr,
     riid: <intercom::REFIID as intercom::type_system::ExternInput<
         intercom::type_system::AutomationTypeSystem,
     >>::ForeignType,
-    out: *mut <intercom::RawComPtr as intercom::type_system::ExternOutput<
+    out: *mut <intercom::raw::RawComPtr as intercom::type_system::ExternOutput<
         intercom::type_system::AutomationTypeSystem,
     >>::ForeignType,
 ) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
@@ -1243,7 +1241,7 @@ unsafe extern "system" fn __Foo_Foo_query_interface_Automation(
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_add_ref_Automation(self_vtable:
-                                                           intercom::RawComPtr)
+                                                           intercom::raw::RawComPtr)
  ->
      <u32 as
 intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
@@ -1273,7 +1271,7 @@ intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_release_Automation(self_vtable:
-                                                           intercom::RawComPtr)
+                                                           intercom::raw::RawComPtr)
  ->
      <u32 as
 intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
@@ -1303,7 +1301,7 @@ intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_struct_method_Automation(
-    self_vtable: intercom::RawComPtr,
+    self_vtable: intercom::raw::RawComPtr,
 ) -> () {
     let self_combox = (self_vtable as usize
         - <Foo as intercom::attributes::ComClass<
@@ -1371,11 +1369,11 @@ impl intercom::attributes::ComImpl<Foo, intercom::type_system::AutomationTypeSys
 #[allow(non_snake_case)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_query_interface_Raw(
-    self_vtable: intercom::RawComPtr,
+    self_vtable: intercom::raw::RawComPtr,
     riid: <intercom::REFIID as intercom::type_system::ExternInput<
         intercom::type_system::AutomationTypeSystem,
     >>::ForeignType,
-    out: *mut <intercom::RawComPtr as intercom::type_system::ExternOutput<
+    out: *mut <intercom::raw::RawComPtr as intercom::type_system::ExternOutput<
         intercom::type_system::AutomationTypeSystem,
     >>::ForeignType,
 ) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
@@ -1408,7 +1406,7 @@ unsafe extern "system" fn __Foo_Foo_query_interface_Raw(
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_add_ref_Raw(self_vtable:
-                                                    intercom::RawComPtr)
+                                                    intercom::raw::RawComPtr)
  ->
      <u32 as
 intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
@@ -1439,7 +1437,7 @@ intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_Foo_release_Raw(self_vtable:
-                                                    intercom::RawComPtr)
+                                                    intercom::raw::RawComPtr)
  ->
      <u32 as
 intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
@@ -1469,7 +1467,7 @@ intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_Foo_struct_method_Raw(self_vtable: intercom::RawComPtr) -> () {
+unsafe extern "system" fn __Foo_Foo_struct_method_Raw(self_vtable: intercom::raw::RawComPtr) -> () {
     let self_combox =
         (self_vtable as usize -
              <Foo as
@@ -1545,7 +1543,7 @@ pub struct __IntercomVtableForFoo_Automation {
     pub __base: <dyn intercom::IUnknown as intercom::attributes::ComInterface<
         intercom::type_system::AutomationTypeSystem,
     >>::VTable,
-    pub struct_method: unsafe extern "system" fn(self_vtable: intercom::RawComPtr) -> (),
+    pub struct_method: unsafe extern "system" fn(self_vtable: intercom::raw::RawComPtr) -> (),
 }
 #[allow(non_camel_case_types)]
 #[allow(non_snake_case)]
@@ -1571,7 +1569,7 @@ pub struct __IntercomVtableForFoo_Raw {
     pub __base: <dyn intercom::IUnknown as intercom::attributes::ComInterface<
         intercom::type_system::AutomationTypeSystem,
     >>::VTable,
-    pub struct_method: unsafe extern "system" fn(self_vtable: intercom::RawComPtr) -> (),
+    pub struct_method: unsafe extern "system" fn(self_vtable: intercom::raw::RawComPtr) -> (),
 }
 #[allow(non_camel_case_types)]
 #[allow(non_snake_case)]
@@ -1694,11 +1692,11 @@ impl IFoo for Foo {
 #[allow(non_snake_case)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_IFoo_query_interface_Automation(
-    self_vtable: intercom::RawComPtr,
+    self_vtable: intercom::raw::RawComPtr,
     riid: <intercom::REFIID as intercom::type_system::ExternInput<
         intercom::type_system::AutomationTypeSystem,
     >>::ForeignType,
-    out: *mut <intercom::RawComPtr as intercom::type_system::ExternOutput<
+    out: *mut <intercom::raw::RawComPtr as intercom::type_system::ExternOutput<
         intercom::type_system::AutomationTypeSystem,
     >>::ForeignType,
 ) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
@@ -1730,7 +1728,7 @@ unsafe extern "system" fn __Foo_IFoo_query_interface_Automation(
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_IFoo_add_ref_Automation(self_vtable:
-                                                            intercom::RawComPtr)
+                                                            intercom::raw::RawComPtr)
  ->
      <u32 as
 intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
@@ -1760,7 +1758,7 @@ intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_IFoo_release_Automation(self_vtable:
-                                                            intercom::RawComPtr)
+                                                            intercom::raw::RawComPtr)
  ->
      <u32 as
 intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
@@ -1790,7 +1788,7 @@ intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_IFoo_trait_method_Automation(
-    self_vtable: intercom::RawComPtr,
+    self_vtable: intercom::raw::RawComPtr,
 ) -> () {
     let self_combox = (self_vtable as usize
         - <Foo as intercom::attributes::ComClass<
@@ -1858,11 +1856,11 @@ impl intercom::attributes::ComImpl<dyn IFoo, intercom::type_system::AutomationTy
 #[allow(non_snake_case)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_IFoo_query_interface_Raw(
-    self_vtable: intercom::RawComPtr,
+    self_vtable: intercom::raw::RawComPtr,
     riid: <intercom::REFIID as intercom::type_system::ExternInput<
         intercom::type_system::AutomationTypeSystem,
     >>::ForeignType,
-    out: *mut <intercom::RawComPtr as intercom::type_system::ExternOutput<
+    out: *mut <intercom::raw::RawComPtr as intercom::type_system::ExternOutput<
         intercom::type_system::AutomationTypeSystem,
     >>::ForeignType,
 ) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
@@ -1895,7 +1893,7 @@ unsafe extern "system" fn __Foo_IFoo_query_interface_Raw(
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_IFoo_add_ref_Raw(self_vtable:
-                                                     intercom::RawComPtr)
+                                                     intercom::raw::RawComPtr)
  ->
      <u32 as
 intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
@@ -1926,7 +1924,7 @@ intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>
 #[allow(dead_code)]
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_IFoo_release_Raw(self_vtable:
-                                                     intercom::RawComPtr)
+                                                     intercom::raw::RawComPtr)
  ->
      <u32 as
 intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType{
@@ -1956,7 +1954,7 @@ intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_IFoo_trait_method_Raw(self_vtable: intercom::RawComPtr) -> () {
+unsafe extern "system" fn __Foo_IFoo_trait_method_Raw(self_vtable: intercom::raw::RawComPtr) -> () {
     let self_combox =
         (self_vtable as usize
             - <Foo as intercom::attributes::ComClass<

--- a/intercom-cli/src/typelib.rs
+++ b/intercom-cli/src/typelib.rs
@@ -18,19 +18,17 @@ pub fn read_typelib(path: &Path) -> Result<intercom::typelib::TypeLib, failure::
         let fn_get_type_lib: libloading::Symbol<
             unsafe extern "C" fn(
                 TypeSystemName,
-                *mut intercom::RawComPtr,
+                *mut intercom::raw::RawComPtr,
             ) -> intercom::raw::HRESULT,
         > = lib.get(b"IntercomTypeLib")?;
 
-        let mut ptr: intercom::RawComPtr = std::ptr::null_mut();
+        let mut ptr: intercom::raw::RawComPtr = std::ptr::null_mut();
         fn_get_type_lib(TypeSystemName::Automation, &mut ptr as *mut _);
 
         let comptr =
-            intercom::raw::InterfacePtr::<AutomationTypeSystem, dyn IIntercomTypeLib>::new(ptr);
-        let comitf = intercom::ComItf::maybe_wrap(comptr)
-            .ok_or_else(|| TypeLibError::AcquiringTypeLib("Null ptr".to_owned()))?;
-
-        intercom::ComRc::attach(comitf)
+            intercom::raw::InterfacePtr::<AutomationTypeSystem, dyn IIntercomTypeLib>::new(ptr)
+                .ok_or_else(|| TypeLibError::AcquiringTypeLib("Null ptr".to_owned()))?;
+        intercom::ComRc::wrap(comptr)
     };
 
     Ok(intercom::typelib::TypeLib::from_comrc(&typelib)?)

--- a/intercom-common/src/attributes/com_class.rs
+++ b/intercom-common/src/attributes/com_class.rs
@@ -42,7 +42,7 @@ pub fn expand_com_class(
                 let ptr = ( &vtables._ISupportErrorInfo )
                     as *const &#support_error_info_vtbl
                     as *mut &#support_error_info_vtbl
-                    as intercom::RawComPtr;
+                    as intercom::raw::RawComPtr;
                 intercom::logging::trace(|l| l(module_path!(), format_args!(
                     "[{:p}] {}::query_interface({:-X}) -> IUnknown [{:p}]",
                     vtables, #struct_name, riid, ptr)));
@@ -54,7 +54,7 @@ pub fn expand_com_class(
                 let ptr = ( &vtables._ISupportErrorInfo )
                     as *const &#support_error_info_vtbl
                     as *mut &#support_error_info_vtbl
-                    as intercom::RawComPtr;
+                    as intercom::raw::RawComPtr;
                 intercom::logging::trace(|l| l(module_path!(), format_args!(
                     "[{:p}] {}::query_interface({:-X}) -> ISupportErrorInfo [{:p}]",
                     vtables, #struct_name, riid, ptr)));
@@ -139,7 +139,7 @@ pub fn expand_com_class(
                     let ptr = &vtables.#itf_variant
                         as *const &#itf_attrib_data::VTable
                         as *mut &#itf_attrib_data::VTable
-                        as intercom::RawComPtr;
+                        as intercom::raw::RawComPtr;
                     intercom::logging::trace(|l| l(module_path!(), format_args!(
                         "[{:p}] {}::query_interface({:-X}) -> {} ({}) [{:p}]",
                         vtables, #struct_name, riid, #itf_name, #ts_name, ptr)));
@@ -234,7 +234,7 @@ pub fn expand_com_class(
             fn query_interface(
                 vtables : &Self::VTableList,
                 riid : intercom::REFIID,
-            ) -> intercom::RawComResult< intercom::RawComPtr > {
+            ) -> intercom::RawComResult< intercom::raw::RawComPtr > {
                 if riid.is_null() {
                     intercom::logging::error(|l| l(module_path!(), format_args!(
                         "[{:p}] {}::query_interface(NULL)", vtables, #struct_name)));

--- a/intercom-common/src/attributes/com_impl.rs
+++ b/intercom-common/src/attributes/com_impl.rs
@@ -63,11 +63,11 @@ pub fn expand_com_impl(
             #[allow(non_snake_case)]
             #[doc(hidden)]
             unsafe extern "system" fn #query_interface_ident(
-                self_vtable : intercom::RawComPtr,
+                self_vtable : intercom::raw::RawComPtr,
                 riid : <intercom::REFIID as intercom::type_system::ExternInput<
                         intercom::type_system::AutomationTypeSystem>>
                             ::ForeignType,
-                out : *mut <intercom::RawComPtr as intercom::type_system::ExternOutput<
+                out : *mut <intercom::raw::RawComPtr as intercom::type_system::ExternOutput<
                         intercom::type_system::AutomationTypeSystem>>
                             ::ForeignType,
             ) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
@@ -95,7 +95,7 @@ pub fn expand_com_impl(
             #[allow(dead_code)]
             #[doc(hidden)]
             unsafe extern "system" fn #add_ref_ident(
-                self_vtable : intercom::RawComPtr
+                self_vtable : intercom::raw::RawComPtr
             ) -> <u32 as intercom::type_system::ExternOutput<
                     intercom::type_system::AutomationTypeSystem>>
                         ::ForeignType
@@ -115,7 +115,7 @@ pub fn expand_com_impl(
             #[allow(dead_code)]
             #[doc(hidden)]
             unsafe extern "system" fn #release_ident(
-                self_vtable : intercom::RawComPtr
+                self_vtable : intercom::raw::RawComPtr
             ) -> <u32 as intercom::type_system::ExternOutput<
                     intercom::type_system::AutomationTypeSystem>>
                         ::ForeignType
@@ -171,7 +171,7 @@ pub fn expand_com_impl(
                 };
                 quote!( #name : #dir #com_ty )
             });
-            let self_arg = quote!(self_vtable: intercom::RawComPtr);
+            let self_arg = quote!(self_vtable: intercom::raw::RawComPtr);
             let args = iter::once(self_arg).chain(in_out_args);
 
             // Format the in and out parameters for the Rust call.

--- a/intercom-common/src/attributes/com_library.rs
+++ b/intercom-common/src/attributes/com_library.rs
@@ -48,7 +48,7 @@ pub fn expand_com_module(
         pub unsafe fn __get_module_class_factory(
             rclsid : intercom::REFCLSID,
             riid : intercom::REFIID,
-            pout : *mut intercom::RawComPtr
+            pout : *mut intercom::raw::RawComPtr
         ) -> Option<intercom::raw::HRESULT>
         {
             // Create new class factory.
@@ -103,7 +103,7 @@ fn get_dll_get_class_object_function() -> TokenStream
         pub unsafe extern "system" fn DllGetClassObject(
             rclsid: intercom::REFCLSID,
             riid: intercom::REFIID,
-            pout: *mut intercom::RawComPtr,
+            pout: *mut intercom::raw::RawComPtr,
         ) -> intercom::raw::HRESULT
         {
             // Delegate to the module implementation.
@@ -154,7 +154,7 @@ fn create_get_typelib_function(lib: &model::ComLibrary) -> Result<TokenStream, S
         #[no_mangle]
         pub unsafe extern "system" fn IntercomTypeLib(
             type_system: intercom::type_system::TypeSystemName,
-            out: *mut intercom::RawComPtr,
+            out: *mut intercom::raw::RawComPtr,
         ) -> intercom::raw::HRESULT
         {
             let mut tlib = intercom::ComBox::new(intercom::typelib::TypeLib::__new(
@@ -167,12 +167,7 @@ fn create_get_typelib_function(lib: &model::ComLibrary) -> Result<TokenStream, S
             ));
             let rc = intercom::ComRc::<intercom::typelib::IIntercomTypeLib>::from( &tlib );
             let itf = intercom::ComRc::detach(rc);
-            *out = match type_system {
-                intercom::type_system::TypeSystemName::Automation =>
-                    intercom::ComItf::ptr::<intercom::type_system::AutomationTypeSystem>(&itf).ptr,
-                intercom::type_system::TypeSystemName::Raw =>
-                    intercom::ComItf::ptr::<intercom::type_system::RawTypeSystem>(&itf).ptr,
-            };
+            *out = type_system.get_ptr(&itf);
 
             intercom::raw::S_OK
         }

--- a/intercom/src/classfactory.rs
+++ b/intercom/src/classfactory.rs
@@ -7,6 +7,7 @@
 
 use super::*;
 use crate::attributes;
+use crate::raw::RawComPtr;
 use crate::type_system::AutomationTypeSystem;
 
 type IUnknownVtbl = <dyn crate::IUnknown as attributes::ComInterface<
@@ -71,10 +72,8 @@ impl<T: Default + CoClass> ClassFactory<T>
     /// # Safety
     ///
     /// The `out` pointer must be valid for receiving the requested interface.
-    pub unsafe fn create(
-        riid: intercom::REFIID,
-        out: *mut intercom::RawComPtr,
-    ) -> crate::error::raw::HRESULT
+    pub unsafe fn create(riid: intercom::REFIID, out: *mut RawComPtr)
+        -> crate::error::raw::HRESULT
     {
         let factory = Self {
             phantom: std::marker::PhantomData,

--- a/intercom/src/combox.rs
+++ b/intercom/src/combox.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::raw::RawComPtr;
 use crate::type_system::TypeSystemName;
 use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -82,10 +83,11 @@ impl<T: CoClass> ComBox<T>
             (automation_ptr, raw_ptr)
         };
 
-        ComItf::new(
+        ComItf::maybe_new(
             raw::InterfacePtr::new(automation_ptr),
             raw::InterfacePtr::new(raw_ptr),
         )
+        .expect("Intercom failed to create interface pointers")
     }
 }
 

--- a/intercom/src/comitf.rs
+++ b/intercom/src/comitf.rs
@@ -49,7 +49,7 @@ impl<T: ?Sized> ComItf<T>
     }
 
     /// Creates a `ComItf<T>` from a raw type system COM interface pointer..
-    pub unsafe fn maybe_new(
+    pub fn maybe_new(
         automation: Option<raw::InterfacePtr<AutomationTypeSystem, T>>,
         raw: Option<raw::InterfacePtr<RawTypeSystem, T>>,
     ) -> Option<ComItf<T>>

--- a/intercom/src/comrc.rs
+++ b/intercom/src/comrc.rs
@@ -38,9 +38,7 @@ impl<TS: TypeSystem, T: ComInterface + ?Sized> From<crate::raw::InterfacePtr<TS,
     fn from(source: crate::raw::InterfacePtr<TS, T>) -> Self
     {
         // Lone ComItf doesn't outlast the pointer.
-        unsafe {
-            ComItf::as_rc(&ComItf::wrap(source))
-        }
+        unsafe { ComItf::as_rc(&ComItf::wrap(source)) }
     }
 }
 
@@ -182,7 +180,7 @@ where
     unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self>
     {
         match source {
-            Some(ptr) => Ok(ComItf::as_rc(&ComItf::wrap(ptr))),
+            Some(ptr) => Ok(ComRc::from(ptr)),
             None => Err(ComError::E_POINTER),
         }
     }
@@ -231,7 +229,7 @@ where
     unsafe fn from_foreign_parameter(source: Self::ForeignType) -> ComResult<Self>
     {
         Ok(match source {
-            Some(ptr) => Some(ComItf::as_rc(&ComItf::wrap(ptr))),
+            Some(ptr) => Some(ComRc::from(ptr)),
             None => None,
         })
     }

--- a/intercom/src/comrc.rs
+++ b/intercom/src/comrc.rs
@@ -33,6 +33,17 @@ impl<T: ComInterface + ?Sized> From<&ComItf<T>> for ComRc<T>
     }
 }
 
+impl<TS: TypeSystem, T: ComInterface + ?Sized> From<crate::raw::InterfacePtr<TS, T>> for ComRc<T>
+{
+    fn from(source: crate::raw::InterfacePtr<TS, T>) -> Self
+    {
+        // Lone ComItf doesn't outlast the pointer.
+        unsafe {
+            ComItf::as_rc(&ComItf::wrap(source))
+        }
+    }
+}
+
 impl<T: ComInterface + ?Sized> ComRc<T>
 {
     /// Attaches a floating ComItf reference and brings it under managed

--- a/intercom/src/error.rs
+++ b/intercom/src/error.rs
@@ -292,7 +292,7 @@ mod error_store
         errorinfo: Option<crate::raw::InterfacePtr<AutomationTypeSystem, dyn IErrorInfo>>,
     ) -> raw::HRESULT
     {
-        reset_error_store(errorinfo.map(|ptr| ComRc::wrap(ptr)));
+        reset_error_store(errorinfo.map(|ptr| ComRc::from(ptr)));
         raw::S_OK
     }
 

--- a/intercom/src/error.rs
+++ b/intercom/src/error.rs
@@ -292,7 +292,7 @@ mod error_store
         errorinfo: Option<crate::raw::InterfacePtr<AutomationTypeSystem, dyn IErrorInfo>>,
     ) -> raw::HRESULT
     {
-        reset_error_store(errorinfo.map(|ptr| ComRc::from(ptr)));
+        reset_error_store(errorinfo.map(ComRc::from));
         raw::S_OK
     }
 

--- a/intercom/src/error.rs
+++ b/intercom/src/error.rs
@@ -292,7 +292,7 @@ mod error_store
         errorinfo: Option<crate::raw::InterfacePtr<AutomationTypeSystem, dyn IErrorInfo>>,
     ) -> raw::HRESULT
     {
-        reset_error_store(ComItf::maybe_wrap(errorinfo).map(|i| ComRc::from(&i)));
+        reset_error_store(errorinfo.map(|ptr| ComRc::wrap(ptr)));
         raw::S_OK
     }
 
@@ -307,7 +307,7 @@ mod error_store
                 raw::S_OK
             }
             None => {
-                *errorinfo = crate::raw::InterfacePtr::null();
+                *errorinfo = None;
                 raw::S_FALSE
             }
         }

--- a/intercom/src/interfaces.rs
+++ b/intercom/src/interfaces.rs
@@ -20,7 +20,7 @@ pub trait IUnknown
     ///
     /// Returns `Ok( interface_ptr )` if the object supports the specified
     /// interface or `Err( E_NOINTERFACE )` if it doesn't.
-    fn query_interface(&self, riid: crate::REFIID) -> crate::RawComResult<crate::RawComPtr>;
+    fn query_interface(&self, riid: crate::REFIID) -> crate::RawComResult<crate::raw::RawComPtr>;
 
     /// Increments the reference count of the object.
     ///

--- a/intercom/src/prelude.rs
+++ b/intercom/src/prelude.rs
@@ -1,1 +1,4 @@
-pub use crate::ComResult;
+pub use crate::{
+    com_class, com_impl, com_interface, com_library, com_module, ComBox, ComError, ComItf, ComRc,
+    ComResult,
+};

--- a/intercom/src/type_system.rs
+++ b/intercom/src/type_system.rs
@@ -9,6 +9,22 @@ pub enum TypeSystemName
     Raw = 1,
 }
 
+impl TypeSystemName
+{
+    pub fn get_ptr<I: ?Sized>(&self, itf: &ComItf<I>) -> crate::raw::RawComPtr
+    {
+        let opt = match self {
+            TypeSystemName::Automation => AutomationTypeSystem::get_ptr(itf).map(|p| p.ptr),
+            TypeSystemName::Raw => RawTypeSystem::get_ptr(itf).map(|p| p.ptr),
+        };
+
+        match opt {
+            Some(ptr) => ptr.as_ptr(),
+            None => std::ptr::null_mut(),
+        }
+    }
+}
+
 /// Common trait for type systems.
 pub trait TypeSystem: Clone + Copy
 {
@@ -18,7 +34,7 @@ pub trait TypeSystem: Clone + Copy
     fn key() -> TypeSystemName;
 
     /// Gets the type system pointer from a ComItf.
-    fn get_ptr<I: ?Sized>(itf: &ComItf<I>) -> crate::raw::InterfacePtr<Self, I>;
+    fn get_ptr<I: ?Sized>(itf: &ComItf<I>) -> Option<crate::raw::InterfacePtr<Self, I>>;
 
     /// Constructs a ComItf from a pointer.
     fn wrap_ptr<I: ?Sized>(ptr: crate::raw::InterfacePtr<Self, I>) -> ComItf<I>;
@@ -35,7 +51,7 @@ impl TypeSystem for AutomationTypeSystem
     }
 
     /// Gets the type system pointer from a ComItf.
-    fn get_ptr<I: ?Sized>(itf: &ComItf<I>) -> crate::raw::InterfacePtr<Self, I>
+    fn get_ptr<I: ?Sized>(itf: &ComItf<I>) -> Option<crate::raw::InterfacePtr<Self, I>>
     {
         itf.automation_ptr
     }
@@ -44,8 +60,8 @@ impl TypeSystem for AutomationTypeSystem
     fn wrap_ptr<I: ?Sized>(ptr: crate::raw::InterfacePtr<Self, I>) -> ComItf<I>
     {
         ComItf {
-            automation_ptr: ptr,
-            raw_ptr: crate::raw::InterfacePtr::null(),
+            automation_ptr: Some(ptr),
+            raw_ptr: None,
             phantom: std::marker::PhantomData,
         }
     }
@@ -62,7 +78,7 @@ impl TypeSystem for RawTypeSystem
     }
 
     /// Gets the type system pointer from a ComItf.
-    fn get_ptr<I: ?Sized>(itf: &ComItf<I>) -> crate::raw::InterfacePtr<Self, I>
+    fn get_ptr<I: ?Sized>(itf: &ComItf<I>) -> Option<crate::raw::InterfacePtr<Self, I>>
     {
         itf.raw_ptr
     }
@@ -71,8 +87,8 @@ impl TypeSystem for RawTypeSystem
     fn wrap_ptr<I: ?Sized>(ptr: crate::raw::InterfacePtr<Self, I>) -> ComItf<I>
     {
         ComItf {
-            automation_ptr: crate::raw::InterfacePtr::null(),
-            raw_ptr: ptr,
+            automation_ptr: None,
+            raw_ptr: Some(ptr),
             phantom: std::marker::PhantomData,
         }
     }
@@ -375,22 +391,6 @@ macro_rules! extern_ptr {
 
 extern_ptr!(mut);
 extern_ptr!(const);
-
-impl<TS: TypeSystem, I: crate::ComInterface + ?Sized> ForeignType
-    for crate::raw::InterfacePtr<TS, I>
-where
-    I: ForeignType,
-{
-    /// The name of the type.
-    fn type_name() -> &'static str
-    {
-        <I as ForeignType>::type_name()
-    }
-    fn indirection_level() -> u32
-    {
-        <I as ForeignType>::indirection_level() + 1
-    }
-}
 
 /// Defines the uninitialized values for out parameters when calling into
 /// Intercom interfaces.

--- a/intercom/src/type_system.rs
+++ b/intercom/src/type_system.rs
@@ -11,7 +11,7 @@ pub enum TypeSystemName
 
 impl TypeSystemName
 {
-    pub fn get_ptr<I: ?Sized>(&self, itf: &ComItf<I>) -> crate::raw::RawComPtr
+    pub fn get_ptr<I: ?Sized>(self, itf: &ComItf<I>) -> crate::raw::RawComPtr
     {
         let opt = match self {
             TypeSystemName::Automation => AutomationTypeSystem::get_ptr(itf).map(|p| p.ptr),

--- a/intercom/src/variant.rs
+++ b/intercom/src/variant.rs
@@ -76,8 +76,8 @@ impl Variant
                 )),
                 raw::var_type::CY => Variant::Currency(Currency(src.data.cyVal)),
                 raw::var_type::DATE => Variant::SystemTime(src.data.date.into()),
-                raw::var_type::UNKNOWN => match ComRc::wrap(src.data.punkVal) {
-                    Some(rc) => Variant::IUnknown(rc),
+                raw::var_type::UNKNOWN => match src.data.punkVal {
+                    Some(ptr) => Variant::IUnknown(ComRc::wrap(ptr)),
                     None => Variant::None,
                 },
                 _ => return Err(ComError::E_NOTIMPL),
@@ -101,8 +101,8 @@ impl Variant
                 )),
                 raw::var_type::DATE => Variant::SystemTime((*src.data.pdate).into()),
                 raw::var_type::CY => Variant::Currency(Currency(*src.data.pcyVal)),
-                raw::var_type::UNKNOWN => match ComRc::wrap(*src.data.ppunkVal) {
-                    Some(rc) => Variant::IUnknown(rc),
+                raw::var_type::UNKNOWN => match *src.data.ppunkVal {
+                    Some(ptr) => Variant::IUnknown(ComRc::wrap(ptr)),
                     None => Variant::None,
                 },
                 _ => return Err(ComError::E_NOTIMPL),
@@ -742,7 +742,7 @@ pub mod raw
     pub struct UserDefinedTypeValue
     {
         pub pvRecord: *mut std::ffi::c_void,
-        pub pRecInfo: crate::RawComPtr,
+        pub pRecInfo: crate::raw::RawComPtr,
     }
 
     #[repr(C)]
@@ -761,7 +761,7 @@ pub mod raw
         pub cyVal: i64,
         pub date: VariantDate,
         pub bstrVal: *mut u16,
-        pub punkVal: crate::raw::InterfacePtr<TS, dyn crate::IUnknown>,
+        pub punkVal: Option<crate::raw::InterfacePtr<TS, dyn crate::IUnknown>>,
         //*pdispVal : ComItf<IDispatch>,
         //parray : SafeArray,
         pub pbVal: *mut i8,
@@ -775,7 +775,7 @@ pub mod raw
         pub pcyVal: *mut i64,
         pub pdate: *mut VariantDate,
         pub pbstrVal: *mut *mut u16,
-        pub ppunkVal: *mut crate::raw::InterfacePtr<TS, dyn crate::IUnknown>,
+        pub ppunkVal: *mut Option<crate::raw::InterfacePtr<TS, dyn crate::IUnknown>>,
         //ppdispVal : *mut ComItf<IDispatch>,
         //pparray : *mut SafeArray,
         pub pvarVal: *mut Variant<TS>,

--- a/scripts/ci.bat
+++ b/scripts/ci.bat
@@ -11,10 +11,10 @@ mkdir build
 pushd build
 if %errorlevel% neq 0 exit /b %errorlevel%
 
-cmake ".." -DCMAKE_GENERATOR_PLATFORM=x64 -DCMAKE_BUILD_TYPE=Release
+cmake ".." -DCMAKE_GENERATOR_PLATFORM=x64 -DCMAKE_BUILD_TYPE=Debug
 if %errorlevel% neq 0 exit /b %errorlevel%
 
-cmake --build . --config Release
+cmake --build . --config Debug
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 popd
@@ -22,10 +22,10 @@ popd
 REM REM Build C# test suite
 pushd test\cs
 
-tlbimp ..\target\release\test_lib.dll /MACHINE:X64 /out:TestLib.Interop.dll
+tlbimp ..\target\debug\test_lib.dll /MACHINE:X64 /out:TestLib.Interop.dll
 
 nuget restore
-msbuild /p:Platform=x64 /p:Configuration=Release
+msbuild /p:Platform=x64 /p:Configuration=Debug
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 popd

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -24,7 +24,7 @@ if ( Test-Path env:APPVEYOR_JOB_ID ) {
 
 popd
 
-pushd test\cs\bin\x64\Release
+pushd test\cs\bin\x64\Debug
 
 if ( Test-Path env:APPVEYOR_JOB_ID ) {
     vstest.console /logger:Appveyor /platform:x64 cs.dll

--- a/test/cpp-raw/CMakeLists.txt
+++ b/test/cpp-raw/CMakeLists.txt
@@ -22,6 +22,7 @@ ${PROJECT_SOURCE_DIR}/stateful.cpp
 ${PROJECT_SOURCE_DIR}/strings.cpp
 ${PROJECT_SOURCE_DIR}/type_system_callbacks.cpp
 ${PROJECT_SOURCE_DIR}/variant.cpp
+${PROJECT_SOURCE_DIR}/nullable_parameters.cpp
 )
 
 include_directories("${PROJECT_BINARY_DIR}")

--- a/test/cpp-raw/nullable_parameters.cpp
+++ b/test/cpp-raw/nullable_parameters.cpp
@@ -1,0 +1,246 @@
+
+#include "../cpp-utility/os.hpp"
+#include "../cpp-utility/catch.hpp"
+
+#include "testlib.hpp"
+
+class CoCallback : public ICallback_Automation {
+public:
+    CoCallback(uint32_t value) {
+        this->value = value;
+        this->rc = 1;
+    }
+
+    virtual uint32_t Callback() {
+        return this->value;
+    }
+
+    uint32_t value;
+
+    uint32_t rc;
+
+    // Intercom shouldn't need these.
+    virtual intercom::HRESULT INTERCOM_CC QueryInterface( const intercom::IID& riid, void** out ) { return intercom::EC_NOTIMPL; }
+    virtual intercom::REF_COUNT_32 INTERCOM_CC AddRef() { rc++; return rc; }
+    virtual intercom::REF_COUNT_32 INTERCOM_CC Release() {
+        rc--;
+        int localRc = rc;
+        if( localRc == 0 )
+            delete this;
+        return localRc;
+    }
+};
+
+class CoNullableInterface : public INullableInterface_Automation {
+public:
+    virtual uint32_t NullableParameter(ICallback_Automation* pCb) {
+        if( pCb == nullptr )
+        {
+            return 0;
+        }
+        else
+        {
+            return pCb->Callback();
+        }
+    }
+
+    virtual intercom::HRESULT NonnullParameter(
+            ICallback_Automation* pCb,
+            uint32_t* out
+    ) {
+        if( pCb == nullptr )
+        {
+            return intercom::EC_POINTER;
+        }
+        else
+        {
+            *out = pCb->Callback();
+            return intercom::SC_OK;
+        }
+    }
+
+    virtual intercom::HRESULT NullableOutput(uint32_t value, ICallback_Automation** pCb) {
+        if( value == 0 )
+        {
+            *pCb = nullptr;
+        }
+        else
+        {
+            *pCb = new CoCallback(value);
+        }
+
+        return intercom::SC_OK;
+    }
+
+    virtual intercom::HRESULT NonnullOutput(
+            uint32_t value,
+            ICallback_Automation** pCb
+    ) {
+        if( value == 0 )
+            *pCb = nullptr;
+        else
+            *pCb = new CoCallback(value);
+        return intercom::SC_OK;
+    }
+
+    // Intercom shouldn't need these.
+    virtual intercom::HRESULT INTERCOM_CC QueryInterface( const intercom::IID& riid, void** out ) { return intercom::EC_NOTIMPL; }
+    virtual intercom::REF_COUNT_32 INTERCOM_CC AddRef() { return 1; }
+    virtual intercom::REF_COUNT_32 INTERCOM_CC Release() { return 1; }
+};
+
+TEST_CASE( "Nullable parameters" )
+{
+    // Initialize COM.
+    InitializeRuntime();
+
+    SECTION( "C++ to Rust" )
+    {
+        INullableInterface_Automation* pTests = nullptr;
+        intercom::HRESULT hr = CreateInstance(
+                CLSID_NullableTests,
+                IID_INullableInterface_Automation,
+                &pTests );
+
+        REQUIRE( hr == intercom::SC_OK );
+        REQUIRE( pTests != nullptr );
+
+        SECTION( "Nullable parameter" )
+        {
+            SECTION( "Non-null value" )
+            {
+                CoCallback cb(123);
+                REQUIRE( pTests->NullableParameter(&cb) == 123 );
+            }
+
+            SECTION( "Null value" )
+            {
+                REQUIRE( pTests->NullableParameter(nullptr) == 0 );
+            }
+        }
+
+        SECTION( "Non-null parameter" )
+        {
+            SECTION( "Non-null value" )
+            {
+                CoCallback cb(1234);
+                uint32_t output;
+                hr = pTests->NonnullParameter(&cb, &output);
+                REQUIRE( hr == intercom::SC_OK );
+                REQUIRE( output == 1234 );
+            }
+
+            SECTION( "Null value" )
+            {
+                uint32_t output;
+                hr = pTests->NonnullParameter(nullptr, &output);
+                REQUIRE( hr == intercom::EC_POINTER );
+            }
+        }
+
+        SECTION( "Nullable return value" )
+        {
+            SECTION( "Non-null value" )
+            {
+                ICallback_Automation* pCallback;
+                hr = pTests->NullableOutput(123, &pCallback);
+                REQUIRE( hr == intercom::SC_OK );
+                REQUIRE( pCallback->Callback() == 123 );
+                pCallback->Release();
+            }
+
+            SECTION( "Null value" )
+            {
+                ICallback_Automation* pCallback;
+                hr = pTests->NullableOutput(0, &pCallback);
+                REQUIRE( hr == intercom::SC_OK );
+                REQUIRE( pCallback == nullptr );
+            }
+        }
+
+        SECTION( "Non-null return value" )
+        {
+            SECTION( "Non-null value" )
+            {
+                ICallback_Automation* pCallback;
+                hr = pTests->NonnullOutput(123, &pCallback);
+                REQUIRE( hr == intercom::SC_OK );
+                REQUIRE( pCallback->Callback() == 123 );
+                pCallback->Release();
+            }
+        }
+
+        pTests->Release();
+    }
+
+
+    SECTION( "Rust to C++" )
+    {
+        INullableTests_Automation* pTests = nullptr;
+        intercom::HRESULT hr = CreateInstance(
+                CLSID_NullableTests,
+                IID_INullableTests_Automation,
+                &pTests );
+
+        REQUIRE( hr == intercom::SC_OK );
+        REQUIRE( pTests != nullptr );
+
+        CoNullableInterface impl;
+
+        SECTION( "Nullable parameter" )
+        {
+            SECTION( "Non-null value" )
+            {
+                hr = pTests->NullableParameter(123, &impl);
+                REQUIRE( hr == intercom::SC_OK );
+            }
+
+            SECTION( "Null value" )
+            {
+                hr = pTests->NullableParameter(0, &impl);
+                REQUIRE( hr == intercom::SC_OK );
+            }
+        }
+
+        SECTION( "Non-null parameter" )
+        {
+            SECTION( "Non-null value" )
+            {
+                hr = pTests->NonnullParameter(1234, &impl);
+                REQUIRE( hr == intercom::SC_OK );
+            }
+        }
+
+        SECTION( "Nullable return value" )
+        {
+            SECTION( "Non-null value" )
+            {
+                hr = pTests->NullableOutput(1234, &impl);
+                REQUIRE( hr == intercom::SC_OK );
+            }
+
+            SECTION( "Null value" )
+            {
+                hr = pTests->NullableOutput(0, &impl);
+                REQUIRE( hr == intercom::SC_OK );
+            }
+        }
+
+        SECTION( "Non-null return value" )
+        {
+            SECTION( "Non-null value" )
+            {
+                hr = pTests->NonnullOutput(1234, &impl);
+                REQUIRE( hr == intercom::SC_OK );
+            }
+
+            SECTION( "Null value" )
+            {
+                hr = pTests->NonnullOutput(0, &impl);
+                REQUIRE( hr == intercom::EC_POINTER );
+            }
+        }
+
+        pTests->Release();
+    }
+}

--- a/test/testlib/src/lib.rs
+++ b/test/testlib/src/lib.rs
@@ -8,6 +8,7 @@ extern crate winapi;
 pub mod alloc;
 pub mod error_info;
 pub mod interface_params;
+pub mod nullable_parameters;
 pub mod primitive;
 pub mod result;
 pub mod return_interfaces;
@@ -18,8 +19,9 @@ pub mod unicode;
 pub mod variant;
 
 // Declare available COM classes.
-com_library!(
+com_library! {
     module return_interfaces,
+    module nullable_parameters,
 
     class primitive::PrimitiveOperations,
     class stateful::StatefulOperations,
@@ -32,4 +34,4 @@ com_library!(
     class variant::VariantTests,
     class variant::VariantImpl,
     class unicode::UnicodeConversion,
-);
+}

--- a/test/testlib/src/nullable_parameters.rs
+++ b/test/testlib/src/nullable_parameters.rs
@@ -1,0 +1,133 @@
+use intercom::prelude::*;
+
+com_module! {
+    class DoCallback,
+    class NullableTests,
+}
+
+#[com_interface]
+pub trait ICallback
+{
+    fn callback(&self) -> u32;
+}
+
+#[com_class(ICallback)]
+#[derive(Default)]
+struct DoCallback(u32);
+
+#[com_impl]
+impl ICallback for DoCallback
+{
+    fn callback(&self) -> u32
+    {
+        self.0
+    }
+}
+
+#[com_interface]
+pub trait INullableInterface
+{
+    fn nullable_parameter(&self, itf: Option<&ComItf<dyn ICallback>>) -> u32;
+
+    fn nonnull_parameter(&self, itf: &ComItf<dyn ICallback>) -> ComResult<u32>;
+
+    fn nullable_output(&self, value: u32) -> ComResult<Option<ComRc<dyn ICallback>>>;
+
+    fn nonnull_output(&self, value: u32) -> ComResult<ComRc<dyn ICallback>>;
+}
+
+#[com_class(Self, INullableInterface)]
+#[derive(Default)]
+pub struct NullableTests;
+
+#[com_impl]
+#[com_interface]
+impl NullableTests
+{
+    fn nullable_parameter(&self, v: u32, itf: &ComItf<dyn INullableInterface>) -> ComResult<()>
+    {
+        let opt = if v == 0 {
+            None
+        } else {
+            Some(ComRc::from(ComBox::new(DoCallback(v))))
+        };
+
+        if itf.nullable_parameter(opt.as_ref().map(|rc| &**rc)) != v {
+            Err(ComError::E_FAIL)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn nonnull_parameter(&self, v: u32, itf: &ComItf<dyn INullableInterface>) -> ComResult<()>
+    {
+        let rc = ComRc::from(ComBox::new(DoCallback(v)));
+
+        if itf.nonnull_parameter(&*rc)? != v {
+            Err(ComError::E_FAIL)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn nullable_output(&self, value: u32, itf: &ComItf<dyn INullableInterface>) -> ComResult<()>
+    {
+        let cb = itf.nullable_output(value)?;
+        match cb {
+            None => {
+                if value != 0 {
+                    Err(ComError::E_INVALIDARG)
+                } else {
+                    Ok(())
+                }
+            }
+            Some(cb) => {
+                if value != 0 && cb.callback() == value {
+                    Ok(())
+                } else {
+                    Err(ComError::E_FAIL)
+                }
+            }
+        }
+    }
+
+    fn nonnull_output(&self, value: u32, itf: &ComItf<dyn INullableInterface>) -> ComResult<()>
+    {
+        let cb = itf.nonnull_output(value)?;
+        match cb.callback() == value {
+            true => Ok(()),
+            false => Err(ComError::E_FAIL),
+        }
+    }
+}
+
+#[com_impl]
+impl INullableInterface for NullableTests
+{
+    fn nullable_parameter(&self, itf: Option<&ComItf<dyn ICallback>>) -> u32
+    {
+        if let Some(itf) = itf {
+            itf.callback()
+        } else {
+            0
+        }
+    }
+
+    fn nonnull_parameter(&self, itf: &ComItf<dyn ICallback>) -> ComResult<u32>
+    {
+        Ok(itf.callback())
+    }
+
+    fn nullable_output(&self, value: u32) -> ComResult<Option<ComRc<dyn ICallback>>>
+    {
+        match value {
+            0 => Ok(None),
+            v => Ok(Some(ComRc::from(ComBox::new(DoCallback(v))))),
+        }
+    }
+
+    fn nonnull_output(&self, value: u32) -> ComResult<ComRc<dyn ICallback>>
+    {
+        Ok(ComRc::from(ComBox::new(DoCallback(value))))
+    }
+}


### PR DESCRIPTION
This makes the use of `InterfacePtr` a lot safer in Rust terms.

Also includes support for `Option<ComItf>`/`Option<ComRc>` to support null interface pointers.

Closes #140 