### PR TITLE
Drop partially converted output values

### DIFF
--- a/intercom-attributes/tests/data/macro/com_interface.rs.stdout
+++ b/intercom-attributes/tests/data/macro/com_interface.rs.stdout
@@ -276,13 +276,18 @@ where
         let self_struct = &**self_combox;
         let __result = self_struct.com_result_method();
         Ok({
-            match __result {
-                Ok(v1) => {
-                    *__out = <u16 as intercom::type_system::ExternOutput<
+            match __result.and_then(|v1| {
+                let ____out_guard =
+                    intercom::type_system::OutputGuard::<
                         intercom::type_system::AutomationTypeSystem,
-                    >>::into_foreign_output(v1)?;
-                    intercom::raw::S_OK
-                }
+                        u16,
+                    >::wrap(<u16 as intercom::type_system::ExternOutput<
+                        intercom::type_system::AutomationTypeSystem,
+                    >>::into_foreign_output(v1)?);
+                *__out = ____out_guard.consume();
+                Ok(intercom::raw::S_OK)
+            }) {
+                Ok(s) => s,
                 Err(e) => {
                     *__out = intercom::type_system::ExternDefault::extern_default();
                     intercom::store_error(e).hresult
@@ -397,13 +402,18 @@ where
         let self_struct = &**self_combox;
         let __result = self_struct.rust_result_method();
         Ok({
-            match __result {
-                Ok(v1) => {
-                    *__out = <u16 as intercom::type_system::ExternOutput<
+            match __result.and_then(|v1| {
+                let ____out_guard =
+                    intercom::type_system::OutputGuard::<
                         intercom::type_system::AutomationTypeSystem,
-                    >>::into_foreign_output(v1)?;
-                    intercom::raw::S_OK
-                }
+                        u16,
+                    >::wrap(<u16 as intercom::type_system::ExternOutput<
+                        intercom::type_system::AutomationTypeSystem,
+                    >>::into_foreign_output(v1)?);
+                *__out = ____out_guard.consume();
+                Ok(intercom::raw::S_OK)
+            }) {
+                Ok(s) => s,
                 Err(e) => {
                     *__out = intercom::type_system::ExternDefault::extern_default();
                     intercom::store_error(e).hresult
@@ -531,13 +541,18 @@ where
             >>::from_foreign_parameter(b)?,
         );
         Ok({
-            match __result {
-                Ok(v1) => {
-                    *__out = <bool as intercom::type_system::ExternOutput<
+            match __result.and_then(|v1| {
+                let ____out_guard =
+                    intercom::type_system::OutputGuard::<
                         intercom::type_system::AutomationTypeSystem,
-                    >>::into_foreign_output(v1)?;
-                    intercom::raw::S_OK
-                }
+                        bool,
+                    >::wrap(<bool as intercom::type_system::ExternOutput<
+                        intercom::type_system::AutomationTypeSystem,
+                    >>::into_foreign_output(v1)?);
+                *__out = ____out_guard.consume();
+                Ok(intercom::raw::S_OK)
+            }) {
+                Ok(s) => s,
                 Err(e) => {
                     *__out = intercom::type_system::ExternDefault::extern_default();
                     intercom::store_error(e).hresult
@@ -731,13 +746,19 @@ where
                 intercom::type_system::AutomationTypeSystem,
             >>::from_foreign_parameter(itf)?);
         Ok({
-            match __result {
-                Ok(v1) => {
-                    *__out = <ComItf<dyn IUnknown> as intercom::type_system::ExternOutput<
+            match __result.and_then(|v1| {
+                let ____out_guard = intercom::type_system::OutputGuard::<
+                    intercom::type_system::AutomationTypeSystem,
+                    ComItf<dyn IUnknown>,
+                >::wrap(
+                    <ComItf<dyn IUnknown> as intercom::type_system::ExternOutput<
                         intercom::type_system::AutomationTypeSystem,
-                    >>::into_foreign_output(v1)?;
-                    intercom::raw::S_OK
-                }
+                    >>::into_foreign_output(v1)?,
+                );
+                *__out = ____out_guard.consume();
+                Ok(intercom::raw::S_OK)
+            }) {
+                Ok(s) => s,
                 Err(e) => {
                     *__out = intercom::type_system::ExternDefault::extern_default();
                     intercom::store_error(e).hresult
@@ -857,13 +878,18 @@ where
             intercom::type_system::AutomationTypeSystem,
         >>::from_foreign_parameter(input)?);
         Ok({
-            match __result {
-                Ok(v1) => {
-                    *__out = <bool as intercom::type_system::ExternOutput<
+            match __result.and_then(|v1| {
+                let ____out_guard =
+                    intercom::type_system::OutputGuard::<
                         intercom::type_system::AutomationTypeSystem,
-                    >>::into_foreign_output(v1)?;
-                    intercom::raw::S_OK
-                }
+                        bool,
+                    >::wrap(<bool as intercom::type_system::ExternOutput<
+                        intercom::type_system::AutomationTypeSystem,
+                    >>::into_foreign_output(v1)?);
+                *__out = ____out_guard.consume();
+                Ok(intercom::raw::S_OK)
+            }) {
+                Ok(s) => s,
                 Err(e) => {
                     *__out = intercom::type_system::ExternDefault::extern_default();
                     intercom::store_error(e).hresult
@@ -984,13 +1010,19 @@ where
                 intercom::type_system::AutomationTypeSystem,
             >>::from_foreign_parameter(input)?);
         Ok({
-            match __result {
-                Ok(v1) => {
-                    *__out = <Variant as intercom::type_system::ExternOutput<
+            match __result.and_then(|v1| {
+                let ____out_guard = intercom::type_system::OutputGuard::<
+                    intercom::type_system::AutomationTypeSystem,
+                    Variant,
+                >::wrap(
+                    <Variant as intercom::type_system::ExternOutput<
                         intercom::type_system::AutomationTypeSystem,
-                    >>::into_foreign_output(v1)?;
-                    intercom::raw::S_OK
-                }
+                    >>::into_foreign_output(v1)?,
+                );
+                *__out = ____out_guard.consume();
+                Ok(intercom::raw::S_OK)
+            }) {
+                Ok(s) => s,
                 Err(e) => {
                     *__out = intercom::type_system::ExternDefault::extern_default();
                     intercom::store_error(e).hresult
@@ -1574,13 +1606,19 @@ where
         let self_struct = &**self_combox;
         let __result = self_struct.com_result_method();
         Ok({
-            match __result {
-                Ok(v1) => {
-                    *__out = <u16 as intercom::type_system::ExternOutput<
+            match __result.and_then(|v1| {
+                let ____out_guard = intercom::type_system::OutputGuard::<
+                    intercom::type_system::RawTypeSystem,
+                    u16,
+                >::wrap(
+                    <u16 as intercom::type_system::ExternOutput<
                         intercom::type_system::RawTypeSystem,
-                    >>::into_foreign_output(v1)?;
-                    intercom::raw::S_OK
-                }
+                    >>::into_foreign_output(v1)?,
+                );
+                *__out = ____out_guard.consume();
+                Ok(intercom::raw::S_OK)
+            }) {
+                Ok(s) => s,
                 Err(e) => {
                     *__out = intercom::type_system::ExternDefault::extern_default();
                     intercom::store_error(e).hresult
@@ -1695,13 +1733,19 @@ where
         let self_struct = &**self_combox;
         let __result = self_struct.rust_result_method();
         Ok({
-            match __result {
-                Ok(v1) => {
-                    *__out = <u16 as intercom::type_system::ExternOutput<
+            match __result.and_then(|v1| {
+                let ____out_guard = intercom::type_system::OutputGuard::<
+                    intercom::type_system::RawTypeSystem,
+                    u16,
+                >::wrap(
+                    <u16 as intercom::type_system::ExternOutput<
                         intercom::type_system::RawTypeSystem,
-                    >>::into_foreign_output(v1)?;
-                    intercom::raw::S_OK
-                }
+                    >>::into_foreign_output(v1)?,
+                );
+                *__out = ____out_guard.consume();
+                Ok(intercom::raw::S_OK)
+            }) {
+                Ok(s) => s,
                 Err(e) => {
                     *__out = intercom::type_system::ExternDefault::extern_default();
                     intercom::store_error(e).hresult
@@ -1830,13 +1874,19 @@ where
                 >>::from_foreign_parameter(b)?,
             );
         Ok({
-            match __result {
-                Ok(v1) => {
-                    *__out = <bool as intercom::type_system::ExternOutput<
+            match __result.and_then(|v1| {
+                let ____out_guard = intercom::type_system::OutputGuard::<
+                    intercom::type_system::RawTypeSystem,
+                    bool,
+                >::wrap(
+                    <bool as intercom::type_system::ExternOutput<
                         intercom::type_system::RawTypeSystem,
-                    >>::into_foreign_output(v1)?;
-                    intercom::raw::S_OK
-                }
+                    >>::into_foreign_output(v1)?,
+                );
+                *__out = ____out_guard.consume();
+                Ok(intercom::raw::S_OK)
+            }) {
+                Ok(s) => s,
                 Err(e) => {
                     *__out = intercom::type_system::ExternDefault::extern_default();
                     intercom::store_error(e).hresult
@@ -2029,13 +2079,19 @@ where
                 intercom::type_system::RawTypeSystem,
             >>::from_foreign_parameter(itf)?);
         Ok({
-            match __result {
-                Ok(v1) => {
-                    *__out = <ComItf<dyn IUnknown> as intercom::type_system::ExternOutput<
+            match __result.and_then(|v1| {
+                let ____out_guard = intercom::type_system::OutputGuard::<
+                    intercom::type_system::RawTypeSystem,
+                    ComItf<dyn IUnknown>,
+                >::wrap(
+                    <ComItf<dyn IUnknown> as intercom::type_system::ExternOutput<
                         intercom::type_system::RawTypeSystem,
-                    >>::into_foreign_output(v1)?;
-                    intercom::raw::S_OK
-                }
+                    >>::into_foreign_output(v1)?,
+                );
+                *__out = ____out_guard.consume();
+                Ok(intercom::raw::S_OK)
+            }) {
+                Ok(s) => s,
                 Err(e) => {
                     *__out = intercom::type_system::ExternDefault::extern_default();
                     intercom::store_error(e).hresult
@@ -2155,13 +2211,19 @@ where
             intercom::type_system::RawTypeSystem,
         >>::from_foreign_parameter(input)?);
         Ok({
-            match __result {
-                Ok(v1) => {
-                    *__out = <bool as intercom::type_system::ExternOutput<
+            match __result.and_then(|v1| {
+                let ____out_guard = intercom::type_system::OutputGuard::<
+                    intercom::type_system::RawTypeSystem,
+                    bool,
+                >::wrap(
+                    <bool as intercom::type_system::ExternOutput<
                         intercom::type_system::RawTypeSystem,
-                    >>::into_foreign_output(v1)?;
-                    intercom::raw::S_OK
-                }
+                    >>::into_foreign_output(v1)?,
+                );
+                *__out = ____out_guard.consume();
+                Ok(intercom::raw::S_OK)
+            }) {
+                Ok(s) => s,
                 Err(e) => {
                     *__out = intercom::type_system::ExternDefault::extern_default();
                     intercom::store_error(e).hresult
@@ -2282,13 +2344,19 @@ where
                 intercom::type_system::RawTypeSystem,
             >>::from_foreign_parameter(input)?);
         Ok({
-            match __result {
-                Ok(v1) => {
-                    *__out = <Variant as intercom::type_system::ExternOutput<
+            match __result.and_then(|v1| {
+                let ____out_guard = intercom::type_system::OutputGuard::<
+                    intercom::type_system::RawTypeSystem,
+                    Variant,
+                >::wrap(
+                    <Variant as intercom::type_system::ExternOutput<
                         intercom::type_system::RawTypeSystem,
-                    >>::into_foreign_output(v1)?;
-                    intercom::raw::S_OK
-                }
+                    >>::into_foreign_output(v1)?,
+                );
+                *__out = ____out_guard.consume();
+                Ok(intercom::raw::S_OK)
+            }) {
+                Ok(s) => s,
                 Err(e) => {
                     *__out = intercom::type_system::ExternDefault::extern_default();
                     intercom::store_error(e).hresult
@@ -2802,9 +2870,10 @@ impl<I: intercom::attributes::ComInterface + Foo + ?Sized> Foo for intercom::Com
                 };
                 Ok({
                     if __result == intercom::raw::S_OK || __result == intercom::raw::S_FALSE {
-                        Ok(<bool as intercom::type_system::ExternOutput<
+                        let ____out_guard = <bool as intercom::type_system::ExternOutput<
                             intercom::type_system::AutomationTypeSystem,
-                        >>::from_foreign_output(__out)?)
+                        >>::from_foreign_output(__out);
+                        Ok(____out_guard?)
                     } else {
                         return Err(intercom::load_error(self, &__intercom_iid, __result));
                     }
@@ -2859,9 +2928,10 @@ impl<I: intercom::attributes::ComInterface + Foo + ?Sized> Foo for intercom::Com
                 };
                 Ok({
                     if __result == intercom::raw::S_OK || __result == intercom::raw::S_FALSE {
-                        Ok(<bool as intercom::type_system::ExternOutput<
+                        let ____out_guard = <bool as intercom::type_system::ExternOutput<
                             intercom::type_system::RawTypeSystem,
-                        >>::from_foreign_output(__out)?)
+                        >>::from_foreign_output(__out);
+                        Ok(____out_guard?)
                     } else {
                         return Err(intercom::load_error(self, &__intercom_iid, __result));
                     }
@@ -2941,9 +3011,10 @@ impl<I: intercom::attributes::ComInterface + Foo + ?Sized> Foo for intercom::Com
                 };
                 Ok({
                     if __result == intercom::raw::S_OK || __result == intercom::raw::S_FALSE {
-                        Ok(<u16 as intercom::type_system::ExternOutput<
+                        let ____out_guard = <u16 as intercom::type_system::ExternOutput<
                             intercom::type_system::AutomationTypeSystem,
-                        >>::from_foreign_output(__out)?)
+                        >>::from_foreign_output(__out);
+                        Ok(____out_guard?)
                     } else {
                         return Err(intercom::load_error(self, &__intercom_iid, __result));
                     }
@@ -2991,9 +3062,10 @@ impl<I: intercom::attributes::ComInterface + Foo + ?Sized> Foo for intercom::Com
                 };
                 Ok({
                     if __result == intercom::raw::S_OK || __result == intercom::raw::S_FALSE {
-                        Ok(<u16 as intercom::type_system::ExternOutput<
+                        let ____out_guard = <u16 as intercom::type_system::ExternOutput<
                             intercom::type_system::RawTypeSystem,
-                        >>::from_foreign_output(__out)?)
+                        >>::from_foreign_output(__out);
+                        Ok(____out_guard?)
                     } else {
                         return Err(intercom::load_error(self, &__intercom_iid, __result));
                     }
@@ -3077,11 +3149,11 @@ impl<I: intercom::attributes::ComInterface + Foo + ?Sized> Foo for intercom::Com
                 };
                 Ok({
                     if __result == intercom::raw::S_OK || __result == intercom::raw::S_FALSE {
-                        Ok(
+                        let ____out_guard =
                             <ComItf<dyn IUnknown> as intercom::type_system::ExternOutput<
                                 intercom::type_system::AutomationTypeSystem,
-                            >>::from_foreign_output(__out)?,
-                        )
+                            >>::from_foreign_output(__out);
+                        Ok(____out_guard?)
                     } else {
                         return Err(intercom::load_error(self, &__intercom_iid, __result));
                     }
@@ -3141,11 +3213,11 @@ impl<I: intercom::attributes::ComInterface + Foo + ?Sized> Foo for intercom::Com
                 };
                 Ok({
                     if __result == intercom::raw::S_OK || __result == intercom::raw::S_FALSE {
-                        Ok(
+                        let ____out_guard =
                             <ComItf<dyn IUnknown> as intercom::type_system::ExternOutput<
                                 intercom::type_system::RawTypeSystem,
-                            >>::from_foreign_output(__out)?,
-                        )
+                            >>::from_foreign_output(__out);
+                        Ok(____out_guard?)
                     } else {
                         return Err(intercom::load_error(self, &__intercom_iid, __result));
                     }
@@ -3238,9 +3310,10 @@ impl<I: intercom::attributes::ComInterface + Foo + ?Sized> Foo for intercom::Com
                 };
                 Ok({
                     if __result == intercom::raw::S_OK || __result == intercom::raw::S_FALSE {
-                        Ok(<bool as intercom::type_system::ExternOutput<
+                        let ____out_guard = <bool as intercom::type_system::ExternOutput<
                             intercom::type_system::AutomationTypeSystem,
-                        >>::from_foreign_output(__out)?)
+                        >>::from_foreign_output(__out);
+                        Ok(____out_guard?)
                     } else {
                         return Err(intercom::load_error(self, &__intercom_iid, __result));
                     }
@@ -3299,9 +3372,10 @@ impl<I: intercom::attributes::ComInterface + Foo + ?Sized> Foo for intercom::Com
                 };
                 Ok({
                     if __result == intercom::raw::S_OK || __result == intercom::raw::S_FALSE {
-                        Ok(<bool as intercom::type_system::ExternOutput<
+                        let ____out_guard = <bool as intercom::type_system::ExternOutput<
                             intercom::type_system::RawTypeSystem,
-                        >>::from_foreign_output(__out)?)
+                        >>::from_foreign_output(__out);
+                        Ok(____out_guard?)
                     } else {
                         return Err(intercom::load_error(self, &__intercom_iid, __result));
                     }
@@ -3381,9 +3455,10 @@ impl<I: intercom::attributes::ComInterface + Foo + ?Sized> Foo for intercom::Com
                 };
                 Ok({
                     if __result == intercom::raw::S_OK || __result == intercom::raw::S_FALSE {
-                        Ok(<u16 as intercom::type_system::ExternOutput<
+                        let ____out_guard = <u16 as intercom::type_system::ExternOutput<
                             intercom::type_system::AutomationTypeSystem,
-                        >>::from_foreign_output(__out)?)
+                        >>::from_foreign_output(__out);
+                        Ok(____out_guard?)
                     } else {
                         return Err(intercom::load_error(self, &__intercom_iid, __result));
                     }
@@ -3431,9 +3506,10 @@ impl<I: intercom::attributes::ComInterface + Foo + ?Sized> Foo for intercom::Com
                 };
                 Ok({
                     if __result == intercom::raw::S_OK || __result == intercom::raw::S_FALSE {
-                        Ok(<u16 as intercom::type_system::ExternOutput<
+                        let ____out_guard = <u16 as intercom::type_system::ExternOutput<
                             intercom::type_system::RawTypeSystem,
-                        >>::from_foreign_output(__out)?)
+                        >>::from_foreign_output(__out);
+                        Ok(____out_guard?)
                     } else {
                         return Err(intercom::load_error(self, &__intercom_iid, __result));
                     }
@@ -3842,9 +3918,10 @@ impl<I: intercom::attributes::ComInterface + Foo + ?Sized> Foo for intercom::Com
                 };
                 Ok({
                     if __result == intercom::raw::S_OK || __result == intercom::raw::S_FALSE {
-                        Ok(<Variant as intercom::type_system::ExternOutput<
+                        let ____out_guard = <Variant as intercom::type_system::ExternOutput<
                             intercom::type_system::AutomationTypeSystem,
-                        >>::from_foreign_output(__out)?)
+                        >>::from_foreign_output(__out);
+                        Ok(____out_guard?)
                     } else {
                         return Err(intercom::load_error(self, &__intercom_iid, __result));
                     }
@@ -3900,9 +3977,10 @@ impl<I: intercom::attributes::ComInterface + Foo + ?Sized> Foo for intercom::Com
                 };
                 Ok({
                     if __result == intercom::raw::S_OK || __result == intercom::raw::S_FALSE {
-                        Ok(<Variant as intercom::type_system::ExternOutput<
+                        let ____out_guard = <Variant as intercom::type_system::ExternOutput<
                             intercom::type_system::RawTypeSystem,
-                        >>::from_foreign_output(__out)?)
+                        >>::from_foreign_output(__out);
+                        Ok(____out_guard?)
                     } else {
                         return Err(intercom::load_error(self, &__intercom_iid, __result));
                     }

--- a/intercom-common/src/tyhandlers.rs
+++ b/intercom-common/src/tyhandlers.rs
@@ -142,8 +142,12 @@ impl TypeHandler
             Direction::In => quote_spanned!(span=>
                     #maybe_ref <#ty as #tr<#ts>>
                         ::from_foreign_parameter(#ident)#unwrap#maybe_as_ref),
+
+            // Output variables do not use #unwrap to avoid jumping out before all parameters have
+            // been converted from foreign output. This ensures all parameters are brought under
+            // Rust's memory management.
             Direction::Out | Direction::Retval => quote_spanned!(span=>
-                    <#ty as #tr<#ts>>::from_foreign_output(#ident)#unwrap),
+                    <#ty as #tr<#ts>>::from_foreign_output(#ident)),
         }
     }
 

--- a/intercom/src/type_system.rs
+++ b/intercom/src/type_system.rs
@@ -156,6 +156,24 @@ pub unsafe trait ExternOutput<TS: TypeSystem>: Sized
     /// the memory. The caller must ensure that it owns the source parameter
     /// and is allowed to pass the ownership in this way.
     unsafe fn from_foreign_output(source: Self::ForeignType) -> ComResult<Self>;
+
+    /// # Safety
+    ///
+    /// The source ownership is transferred to the function invoker. In case of
+    /// pointers, the function (or the `Self` type) is given the ownership of
+    /// the memory. The caller must ensure that it owns the source parameter
+    /// and is allowed to pass the ownership in this way.
+    unsafe fn drop_foreign_output(source: Self::ForeignType)
+    {
+        // Default implementation just converts this back to the original.
+        //
+        // The `from_foreign_output` is supposed to ensure unused memory isn't leaked and dropping
+        // the return value will clean up the remaining memory.
+        //
+        // Type-specific implementation can clean up the source memory without going through the
+        // trouble of creating  new `Self` value.
+        let _ = Self::from_foreign_output(source);
+    }
 }
 
 /// Defines a type that may be used as a parameter type in Intercom interfaces.
@@ -209,6 +227,51 @@ pub unsafe trait InfallibleExternOutput<TS: TypeSystem>: Sized
     /// the memory. The caller must ensure that it owns the source parameter
     /// and is allowed to pass the ownership in this way.
     unsafe fn from_foreign_output(source: Self::ForeignType) -> Self;
+}
+
+/// Holds a conversion result and returns it back to the original type
+pub struct OutputGuard<TS, TType>
+where
+    TS: TypeSystem,
+    TType: ExternOutput<TS>,
+{
+    value: std::mem::ManuallyDrop<TType::ForeignType>,
+}
+
+impl<TS, TType> OutputGuard<TS, TType>
+where
+    TS: TypeSystem,
+    TType: ExternOutput<TS>,
+{
+    pub fn wrap(value: TType::ForeignType) -> OutputGuard<TS, TType>
+    {
+        OutputGuard {
+            value: std::mem::ManuallyDrop::new(value),
+        }
+    }
+
+    pub fn consume(self) -> TType::ForeignType
+    {
+        unsafe {
+            let value = std::ptr::read(&self.value);
+            std::mem::forget(self);
+            std::mem::ManuallyDrop::into_inner(value)
+        }
+    }
+}
+
+impl<TS, TType> Drop for OutputGuard<TS, TType>
+where
+    TS: TypeSystem,
+    TType: ExternOutput<TS>,
+{
+    fn drop(&mut self)
+    {
+        unsafe {
+            let v = std::mem::ManuallyDrop::take(&mut self.value);
+            TType::drop_foreign_output(v);
+        }
+    }
 }
 
 /// A quick macro for implementing ExternInput/etc. for various basic types

--- a/test/cpp-raw/CMakeLists.txt
+++ b/test/cpp-raw/CMakeLists.txt
@@ -23,6 +23,7 @@ ${PROJECT_SOURCE_DIR}/strings.cpp
 ${PROJECT_SOURCE_DIR}/type_system_callbacks.cpp
 ${PROJECT_SOURCE_DIR}/variant.cpp
 ${PROJECT_SOURCE_DIR}/nullable_parameters.cpp
+${PROJECT_SOURCE_DIR}/output_memory.cpp
 )
 
 include_directories("${PROJECT_BINARY_DIR}")

--- a/test/cpp-raw/output_memory.cpp
+++ b/test/cpp-raw/output_memory.cpp
@@ -114,9 +114,9 @@ TEST_CASE( "OutputMemory" )
             REQUIRE( inputObject.references == 0 );
 
             // We'll want to require these as well, but they aren't implemented currently.
-            // REQUIRE( o1 == nullptr );
-            // REQUIRE( o2 == nullptr );
-            // REQUIRE( o3 == nullptr );
+            REQUIRE( o1 == nullptr );
+            REQUIRE( o2 == nullptr );
+            REQUIRE( o3 == nullptr );
         }
     }
 

--- a/test/cpp-raw/output_memory.cpp
+++ b/test/cpp-raw/output_memory.cpp
@@ -1,0 +1,126 @@
+
+#include "../cpp-utility/os.hpp"
+#include "../dependencies/catch.hpp"
+#include <iostream>
+using namespace std;
+
+#include "testlib.hpp"
+
+struct OutputTests : public IOutputMemoryTests_Automation
+{
+    int references = 0;
+    int addRefs = 0;
+    int releases = 0;
+
+    virtual intercom::HRESULT INTERCOM_CC Succeed(
+        IUnknown* input,
+        OUT IUnknown** o1,
+        OUT IUnknown** o2
+    )
+    {
+        return intercom::EC_NOTIMPL;
+    }
+
+    virtual intercom::HRESULT INTERCOM_CC Fail(
+        IUnknown* input,
+        OUT IUnknown** o1,
+        OUT void** o2,
+        OUT IUnknown** o3
+    )
+    {
+        return intercom::EC_NOTIMPL;
+    }
+
+    virtual intercom::HRESULT INTERCOM_CC CallSucceed(
+        IOutputMemoryTests_Automation* itf,
+        IUnknown* input
+    )
+    {
+        return intercom::EC_NOTIMPL;
+    }
+
+    virtual intercom::HRESULT INTERCOM_CC CallFail(
+        IOutputMemoryTests_Automation* itf,
+        IUnknown* input
+    )
+    {
+        return intercom::EC_NOTIMPL;
+    }
+
+    virtual intercom::HRESULT INTERCOM_CC QueryInterface( const intercom::IID& riid, void** out ) { return intercom::EC_NOTIMPL; }
+    virtual intercom::REF_COUNT_32 INTERCOM_CC AddRef() { ++addRefs; return ++references; }
+    virtual intercom::REF_COUNT_32 INTERCOM_CC Release() { ++releases; return --references; }
+};
+
+TEST_CASE( "OutputMemory" )
+{
+    // Initialize COM.
+    InitializeRuntime();
+
+    // Get the IPrimitiveOperations interface.
+    IOutputMemoryTests_Automation* pTests = nullptr;
+    intercom::HRESULT hr = CreateInstance(
+            CLSID_OutputMemoryTests,
+            IID_IOutputMemoryTests_Automation,
+            &pTests );
+
+    REQUIRE( hr == intercom::SC_OK );
+    REQUIRE( pTests != nullptr );
+
+    SECTION( "Success" )
+    {
+        OutputTests inputObject;
+        REQUIRE( inputObject.references == 0 );
+
+        SECTION( "Rust to foreign" )
+        {
+            // Intentionally assigned garbage values. Existing values should be
+            // ignored by callee.
+            IUnknown* o1 = (IUnknown*)-1;
+            IUnknown* o2 = (IUnknown*)1;
+            REQUIRE( intercom::SC_OK == pTests->Succeed(&inputObject, OUT &o1, OUT &o2) );
+
+            REQUIRE( inputObject.addRefs == 2 );
+            REQUIRE( inputObject.releases == 0 );
+            REQUIRE( inputObject.references == 2 );
+
+            REQUIRE( o1 == &inputObject );
+            REQUIRE( o2 == &inputObject );
+            REQUIRE( o2->Release() == 1 );
+            REQUIRE( o1->Release() == 0 );
+
+            REQUIRE( inputObject.addRefs == 2 );
+            REQUIRE( inputObject.releases == 2 );
+            REQUIRE( inputObject.references == 0 );
+        }
+    }
+
+    SECTION( "Fail" )
+    {
+        OutputTests inputObject;
+        REQUIRE( inputObject.references == 0 );
+
+        SECTION( "Rust to foreign" )
+        {
+            // Intentionally assigned garbage values. Existing values should be
+            // ignored by callee.
+            IUnknown* o1 = (IUnknown*)-1;
+            void* o2 = (void*)0x08080808;
+            IUnknown* o3 = (IUnknown*)1;
+            REQUIRE( intercom::EC_FAIL == pTests->Fail(&inputObject, OUT &o1, OUT &o2, OUT &o3) );
+
+            REQUIRE( inputObject.addRefs == 2 );
+            REQUIRE( inputObject.releases == 2 );
+            REQUIRE( inputObject.references == 0 );
+
+            // We'll want to require these as well, but they aren't implemented currently.
+            // REQUIRE( o1 == nullptr );
+            // REQUIRE( o2 == nullptr );
+            // REQUIRE( o3 == nullptr );
+        }
+    }
+
+    REQUIRE( pTests->Release() == 0 );
+
+    UninitializeRuntime();
+}

--- a/test/testlib/src/lib.rs
+++ b/test/testlib/src/lib.rs
@@ -9,6 +9,7 @@ pub mod alloc;
 pub mod error_info;
 pub mod interface_params;
 pub mod nullable_parameters;
+pub mod output_memory;
 pub mod primitive;
 pub mod result;
 pub mod return_interfaces;
@@ -34,4 +35,5 @@ com_library! {
     class variant::VariantTests,
     class variant::VariantImpl,
     class unicode::UnicodeConversion,
+    class output_memory::OutputMemoryTests,
 }

--- a/test/testlib/src/output_memory.rs
+++ b/test/testlib/src/output_memory.rs
@@ -1,0 +1,88 @@
+use intercom::prelude::*;
+use intercom::type_system::{ExternOutput, TypeSystem};
+use intercom::IUnknown;
+use std::ffi::c_void;
+
+#[com_class(IOutputMemoryTests)]
+#[derive(Default)]
+pub struct OutputMemoryTests;
+
+#[com_interface]
+pub trait IOutputMemoryTests
+{
+    fn succeed(
+        &self,
+        input: &ComItf<dyn IUnknown>,
+    ) -> ComResult<(ComRc<dyn IUnknown>, ComRc<dyn IUnknown>)>;
+
+    fn fail(
+        &self,
+        input: &ComItf<dyn IUnknown>,
+    ) -> ComResult<(ComRc<dyn IUnknown>, FailingType, ComRc<dyn IUnknown>)>;
+
+    fn call_succeed(
+        &self,
+        itf: &ComItf<dyn IOutputMemoryTests>,
+        input: &ComItf<dyn IUnknown>,
+    ) -> ComResult<()>;
+
+    fn call_fail(
+        &self,
+        itf: &ComItf<dyn IOutputMemoryTests>,
+        input: &ComItf<dyn IUnknown>,
+    ) -> ComResult<()>;
+}
+
+impl IOutputMemoryTests for OutputMemoryTests
+{
+    fn succeed(
+        &self,
+        input: &ComItf<dyn IUnknown>,
+    ) -> ComResult<(ComRc<dyn IUnknown>, ComRc<dyn IUnknown>)>
+    {
+        Ok((input.into(), input.into()))
+    }
+
+    fn fail(
+        &self,
+        input: &ComItf<dyn IUnknown>,
+    ) -> ComResult<(ComRc<dyn IUnknown>, FailingType, ComRc<dyn IUnknown>)>
+    {
+        Ok((input.into(), FailingType, input.into()))
+    }
+
+    fn call_succeed(
+        &self,
+        itf: &ComItf<dyn IOutputMemoryTests>,
+        input: &ComItf<dyn IUnknown>,
+    ) -> ComResult<()>
+    {
+        itf.succeed(input).map(|_| ())
+    }
+
+    fn call_fail(
+        &self,
+        itf: &ComItf<dyn IOutputMemoryTests>,
+        input: &ComItf<dyn IUnknown>,
+    ) -> ComResult<()>
+    {
+        itf.fail(input).map(|_| ())
+    }
+}
+
+/// A type that fails all conversions.
+pub struct FailingType;
+unsafe impl<TS: TypeSystem> ExternOutput<TS> for FailingType
+{
+    type ForeignType = *mut c_void;
+
+    fn into_foreign_output(self) -> ComResult<Self::ForeignType>
+    {
+        Err(ComError::E_FAIL)
+    }
+
+    unsafe fn from_foreign_output(_: Self::ForeignType) -> ComResult<Self>
+    {
+        Err(ComError::E_FAIL)
+    }
+}


### PR DESCRIPTION
When handling `ExternOutput` conversions, Intercom currently does these conversions one by one. As these conversions may fail, at the moment of failure (which is handled with `?` by interrupting the conversions) some of the values may be converted and some aren't.

Foreign representations that require manual memory management (`Release` calls for COM pointers for example) will leak if the error occurs while such values exist.

The new implementation fixes this in two ways depending on the scenario where the `ExternOutput` values occur.

### Rust-to-Foreign invocations

In Rust-to-Foreign invocations the function `ExternOutput` values are created in the foreign function and the ownership is handed to Rust. In this case it is enough to ensure that _all_ `ExternOutput` values are converted to managed Rust types before unwrapping the returned `ComResult`s with `?`.

### Rust-from-Foreign invocations

In Rust-from-Foreign invocations the `ExternOutput` values are created in Rust and converted to foreign types when returned to the foreign functions. If these conversions fail, Intercom must ensure that all previously converted values are released properly. The values that have yet to be converted are still managed by Rust memory management and will be released as normal.

The implementation here involves `OutputGuard<TType>` type that holds the `TType::ForeignType` values. During normal return handling the foreign value is moved out of the `OutputGuard` without any cleanup but if the `OutputGuard` is dropped without consuming (as is the case if `?` returns while existing `OutputGuard`s are in scope), the `OutputGuard` cleans up the `ForeignType`s. By default this means converting the `TType::ForeignType` back to `TType`, which should already handle memory for the successful Rust-to-Foreign scenario.

It is possible for a `TType` to override the default behavior by providing their own `drop_foreign_output` implementation. Currently this isn't used, but it is likely that various String-types would put this into use to avoid things like the overhead of the UTF-8 validation when no actual `String` value is needed.