### PR TITLE
Implement ExternType to back ExternInput/Output

### DIFF
--- a/intercom-attributes/src/lib.rs
+++ b/intercom-attributes/src/lib.rs
@@ -135,11 +135,21 @@ pub fn named_type_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStr
     }
 }
 
+/// Derives the implementation of the trait ExternType for a type.
+#[proc_macro_derive(ExternType)]
+pub fn derive_extern_type(input: proc_macro::TokenStream) -> proc_macro::TokenStream
+{
+    match expand_derive_extern_type(input) {
+        Ok(t) => t,
+        Err(e) => panic!("{}", e),
+    }
+}
+
 /// Derives the implementation of the trait ExternInput for a type.
 #[proc_macro_derive(ExternInput)]
-pub fn derive_extern_parameter(input: proc_macro::TokenStream) -> proc_macro::TokenStream
+pub fn derive_extern_input(input: proc_macro::TokenStream) -> proc_macro::TokenStream
 {
-    match expand_derive_extern_parameter(input) {
+    match expand_derive_extern_input(input) {
         Ok(t) => t,
         Err(e) => panic!("{}", e),
     }

--- a/intercom-attributes/tests/data/macro/com_interface.rs.stdout
+++ b/intercom-attributes/tests/data/macro/com_interface.rs.stdout
@@ -95,9 +95,9 @@ where
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_arg_method_Automation<I, S>(
     self_vtable: intercom::raw::RawComPtr,
-    a: <u16 as intercom::type_system::InfallibleExternInput<
-        intercom::type_system::AutomationTypeSystem,
-    >>::ForeignType,
+    a:
+                                                             <u16 as
+                                                             intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType,
 ) -> ()
 where
     I: ?Sized,
@@ -160,17 +160,16 @@ where
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_simple_result_method_Automation<I, S>(
-    self_vtable: intercom::raw::RawComPtr,
-) -> <u16 as intercom::type_system::InfallibleExternOutput<
-    intercom::type_system::AutomationTypeSystem,
->>::ForeignType
-where
-    I: ?Sized,
-    S: intercom::attributes::ComClassInterface<I, intercom::type_system::AutomationTypeSystem>
-        + intercom::attributes::ComClass
-        + Foo,
-{
+unsafe extern "system" fn __Foo_simple_result_method_Automation<I,
+                                                                S>(self_vtable:
+                                                                       intercom::raw::RawComPtr)
+ ->
+     <u16 as
+     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
+ where I: ?Sized,
+ S: intercom::attributes::ComClassInterface<I,
+                                            intercom::type_system::AutomationTypeSystem> +
+intercom::attributes::ComClass + Foo{
     let offset = <S as intercom::attributes::ComClassInterface<
         I,
         intercom::type_system::AutomationTypeSystem,
@@ -229,10 +228,10 @@ where
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_com_result_method_Automation<I, S>(
     self_vtable: intercom::raw::RawComPtr,
-    __out: *mut <u16 as intercom::type_system::ExternOutput<
+    __out: *mut <u16 as intercom::type_system::ExternType<
         intercom::type_system::AutomationTypeSystem,
     >>::ForeignType,
-) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
     intercom::type_system::AutomationTypeSystem,
 >>::ForeignType
 where
@@ -268,7 +267,7 @@ where
         )
     });
     let result: Result<
-        <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+        <intercom::raw::HRESULT as intercom::type_system::ExternType<
             intercom::type_system::AutomationTypeSystem,
         >>::ForeignType,
         intercom::ComError,
@@ -342,7 +341,7 @@ where
                     ),
                 )
             });
-            <<intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+            <<intercom::raw::HRESULT as intercom::type_system::ExternType<
                 intercom::type_system::AutomationTypeSystem,
             >>::ForeignType as intercom::ErrorValue>::from_error(intercom::store_error(
                 err,
@@ -355,10 +354,10 @@ where
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_rust_result_method_Automation<I, S>(
     self_vtable: intercom::raw::RawComPtr,
-    __out: *mut <u16 as intercom::type_system::ExternOutput<
+    __out: *mut <u16 as intercom::type_system::ExternType<
         intercom::type_system::AutomationTypeSystem,
     >>::ForeignType,
-) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
     intercom::type_system::AutomationTypeSystem,
 >>::ForeignType
 where
@@ -394,7 +393,7 @@ where
         )
     });
     let result: Result<
-        <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+        <intercom::raw::HRESULT as intercom::type_system::ExternType<
             intercom::type_system::AutomationTypeSystem,
         >>::ForeignType,
         intercom::ComError,
@@ -468,7 +467,7 @@ where
                     ),
                 )
             });
-            <<intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+            <<intercom::raw::HRESULT as intercom::type_system::ExternType<
                 intercom::type_system::AutomationTypeSystem,
             >>::ForeignType as intercom::ErrorValue>::from_error(intercom::store_error(
                 err,
@@ -483,14 +482,14 @@ unsafe extern "system" fn __Foo_complete_method_Automation<I, S>(
     self_vtable: intercom::raw::RawComPtr,
     a:
                                                                   <u16 as
-                                                                  intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
+                                                                  intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType,
     b:
                                                                   <i16 as
-                                                                  intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
-    __out: *mut <bool as intercom::type_system::ExternOutput<
+                                                                  intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType,
+    __out: *mut <bool as intercom::type_system::ExternType<
         intercom::type_system::AutomationTypeSystem,
     >>::ForeignType,
-) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
     intercom::type_system::AutomationTypeSystem,
 >>::ForeignType
 where
@@ -526,7 +525,7 @@ where
         )
     });
     let result: Result<
-        <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+        <intercom::raw::HRESULT as intercom::type_system::ExternType<
             intercom::type_system::AutomationTypeSystem,
         >>::ForeignType,
         intercom::ComError,
@@ -607,7 +606,7 @@ where
                     ),
                 )
             });
-            <<intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+            <<intercom::raw::HRESULT as intercom::type_system::ExternType<
                 intercom::type_system::AutomationTypeSystem,
             >>::ForeignType as intercom::ErrorValue>::from_error(intercom::store_error(
                 err,
@@ -618,20 +617,19 @@ where
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_string_method_Automation<I, S>(
-    self_vtable: intercom::raw::RawComPtr,
-    msg: <String as intercom::type_system::InfallibleExternInput<
-        intercom::type_system::AutomationTypeSystem,
-    >>::ForeignType,
-) -> <String as intercom::type_system::InfallibleExternOutput<
-    intercom::type_system::AutomationTypeSystem,
->>::ForeignType
-where
-    I: ?Sized,
-    S: intercom::attributes::ComClassInterface<I, intercom::type_system::AutomationTypeSystem>
-        + intercom::attributes::ComClass
-        + Foo,
-{
+unsafe extern "system" fn __Foo_string_method_Automation<I,
+                                                         S>(self_vtable:
+                                                                intercom::raw::RawComPtr,
+                                                            msg:
+                                                                <String as
+                                                                intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType)
+ ->
+     <String as
+     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
+ where I: ?Sized,
+ S: intercom::attributes::ComClassInterface<I,
+                                            intercom::type_system::AutomationTypeSystem> +
+intercom::attributes::ComClass + Foo{
     let offset = <S as intercom::attributes::ComClassInterface<
         I,
         intercom::type_system::AutomationTypeSystem,
@@ -693,13 +691,13 @@ where
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_comitf_method_Automation<I, S>(
     self_vtable: intercom::raw::RawComPtr,
-    itf: <ComItf<dyn Foo> as intercom::type_system::ExternInput<
+    itf: <ComItf<dyn Foo> as intercom::type_system::ExternType<
         intercom::type_system::AutomationTypeSystem,
     >>::ForeignType,
-    __out: *mut <ComItf<dyn IUnknown> as intercom::type_system::ExternOutput<
+    __out: *mut <ComItf<dyn IUnknown> as intercom::type_system::ExternType<
         intercom::type_system::AutomationTypeSystem,
     >>::ForeignType,
-) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
     intercom::type_system::AutomationTypeSystem,
 >>::ForeignType
 where
@@ -735,7 +733,7 @@ where
         )
     });
     let result: Result<
-        <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+        <intercom::raw::HRESULT as intercom::type_system::ExternType<
             intercom::type_system::AutomationTypeSystem,
         >>::ForeignType,
         intercom::ComError,
@@ -813,7 +811,7 @@ where
                     ),
                 )
             });
-            <<intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+            <<intercom::raw::HRESULT as intercom::type_system::ExternType<
                 intercom::type_system::AutomationTypeSystem,
             >>::ForeignType as intercom::ErrorValue>::from_error(intercom::store_error(
                 err,
@@ -826,13 +824,13 @@ where
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_bool_method_Automation<I, S>(
     self_vtable: intercom::raw::RawComPtr,
-    input: <bool as intercom::type_system::ExternInput<
+    input: <bool as intercom::type_system::ExternType<
         intercom::type_system::AutomationTypeSystem,
     >>::ForeignType,
-    __out: *mut <bool as intercom::type_system::ExternOutput<
+    __out: *mut <bool as intercom::type_system::ExternType<
         intercom::type_system::AutomationTypeSystem,
     >>::ForeignType,
-) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
     intercom::type_system::AutomationTypeSystem,
 >>::ForeignType
 where
@@ -868,7 +866,7 @@ where
         )
     });
     let result: Result<
-        <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+        <intercom::raw::HRESULT as intercom::type_system::ExternType<
             intercom::type_system::AutomationTypeSystem,
         >>::ForeignType,
         intercom::ComError,
@@ -944,7 +942,7 @@ where
                     ),
                 )
             });
-            <<intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+            <<intercom::raw::HRESULT as intercom::type_system::ExternType<
                 intercom::type_system::AutomationTypeSystem,
             >>::ForeignType as intercom::ErrorValue>::from_error(intercom::store_error(
                 err,
@@ -957,13 +955,13 @@ where
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_variant_method_Automation<I, S>(
     self_vtable: intercom::raw::RawComPtr,
-    input: <Variant as intercom::type_system::ExternInput<
+    input: <Variant as intercom::type_system::ExternType<
         intercom::type_system::AutomationTypeSystem,
     >>::ForeignType,
-    __out: *mut <Variant as intercom::type_system::ExternOutput<
+    __out: *mut <Variant as intercom::type_system::ExternType<
         intercom::type_system::AutomationTypeSystem,
     >>::ForeignType,
-) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
     intercom::type_system::AutomationTypeSystem,
 >>::ForeignType
 where
@@ -999,7 +997,7 @@ where
         )
     });
     let result: Result<
-        <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+        <intercom::raw::HRESULT as intercom::type_system::ExternType<
             intercom::type_system::AutomationTypeSystem,
         >>::ForeignType,
         intercom::ComError,
@@ -1077,7 +1075,7 @@ where
                     ),
                 )
             });
-            <<intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+            <<intercom::raw::HRESULT as intercom::type_system::ExternType<
                 intercom::type_system::AutomationTypeSystem,
             >>::ForeignType as intercom::ErrorValue>::from_error(intercom::store_error(
                 err,
@@ -1100,85 +1098,85 @@ pub struct __FooAutomationVTable {
                                                   intercom::raw::RawComPtr,
                                               a:
                                                   <u16 as
-                                                  intercom::type_system::InfallibleExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
+                                                  intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType)
                         -> (),
     pub simple_result_method: unsafe extern "system" fn(self_vtable:
                                                             intercom::raw::RawComPtr)
                                   ->
                                       <u16 as
-                                      intercom::type_system::InfallibleExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
+                                      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType,
     pub com_result_method: unsafe extern "system" fn(self_vtable:
                                                          intercom::raw::RawComPtr,
                                                      __out:
                                                          *mut <u16 as
-                                                              intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
+                                                              intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType)
                                ->
                                    <intercom::raw::HRESULT as
-                                   intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
+                                   intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType,
     pub rust_result_method: unsafe extern "system" fn(self_vtable:
                                                           intercom::raw::RawComPtr,
                                                       __out:
                                                           *mut <u16 as
-                                                               intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
+                                                               intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType)
                                 ->
                                     <intercom::raw::HRESULT as
-                                    intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
+                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType,
     pub complete_method: unsafe extern "system" fn(self_vtable:
                                                        intercom::raw::RawComPtr,
                                                    a:
                                                        <u16 as
-                                                       intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
+                                                       intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType,
                                                    b:
                                                        <i16 as
-                                                       intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
+                                                       intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType,
                                                    __out:
                                                        *mut <bool as
-                                                            intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
+                                                            intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType)
                              ->
                                  <intercom::raw::HRESULT as
-                                 intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
+                                 intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType,
     pub string_method: unsafe extern "system" fn(self_vtable:
                                                      intercom::raw::RawComPtr,
                                                  msg:
                                                      <String as
-                                                     intercom::type_system::InfallibleExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
+                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType)
                            ->
                                <String as
-                               intercom::type_system::InfallibleExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
+                               intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType,
     pub comitf_method: unsafe extern "system" fn(self_vtable:
                                                      intercom::raw::RawComPtr,
                                                  itf:
                                                      <ComItf<dyn Foo> as
-                                                     intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
+                                                     intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType,
                                                  __out:
                                                      *mut <ComItf<dyn IUnknown>
                                                           as
-                                                          intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
+                                                          intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType)
                            ->
                                <intercom::raw::HRESULT as
-                               intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
+                               intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType,
     pub bool_method: unsafe extern "system" fn(self_vtable:
                                                    intercom::raw::RawComPtr,
                                                input:
                                                    <bool as
-                                                   intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
+                                                   intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType,
                                                __out:
                                                    *mut <bool as
-                                                        intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
+                                                        intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType)
                          ->
                              <intercom::raw::HRESULT as
-                             intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
+                             intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType,
     pub variant_method: unsafe extern "system" fn(self_vtable:
                                                       intercom::raw::RawComPtr,
                                                   input:
                                                       <Variant as
-                                                      intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
+                                                      intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType,
                                                   __out:
                                                       *mut <Variant as
-                                                           intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
+                                                           intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType)
                             ->
                                 <intercom::raw::HRESULT as
-                                intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
+                                intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType,
 }
 #[automatically_derived]
 #[allow(unused_qualifications)]
@@ -1200,113 +1198,116 @@ impl ::core::clone::Clone for __FooAutomationVTable {
             let _: ::core::clone::AssertParamIsClone<
                 unsafe extern "system" fn(
                     self_vtable: intercom::raw::RawComPtr,
-                    a: <u16 as intercom::type_system::InfallibleExternInput<
+                    a: <u16 as intercom::type_system::ExternType<
                         intercom::type_system::AutomationTypeSystem,
                     >>::ForeignType,
                 ) -> (),
             >;
-            let _:
-                    ::core::clone::AssertParamIsClone<unsafe extern "system" fn(self_vtable:
-                                                                                    intercom::raw::RawComPtr)
-                                                          ->
-                                                              <u16 as
-                                                              intercom::type_system::InfallibleExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType>;
-            let _:
-                    ::core::clone::AssertParamIsClone<unsafe extern "system" fn(self_vtable:
-                                                                                    intercom::raw::RawComPtr,
-                                                                                __out:
-                                                                                    *mut <u16
-                                                                                         as
-                                                                                         intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
-                                                          ->
-                                                              <intercom::raw::HRESULT
-                                                              as
-                                                              intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType>;
+            let _: ::core::clone::AssertParamIsClone<
+                unsafe extern "system" fn(
+                    self_vtable: intercom::raw::RawComPtr,
+                )
+                    -> <u16 as intercom::type_system::ExternType<
+                    intercom::type_system::AutomationTypeSystem,
+                >>::ForeignType,
+            >;
             let _:
                     ::core::clone::AssertParamIsClone<unsafe extern "system" fn(self_vtable:
                                                                                     intercom::raw::RawComPtr,
                                                                                 __out:
                                                                                     *mut <u16
                                                                                          as
-                                                                                         intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
+                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType)
                                                           ->
                                                               <intercom::raw::HRESULT
                                                               as
-                                                              intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType>;
+                                                              intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType>;
+            let _:
+                    ::core::clone::AssertParamIsClone<unsafe extern "system" fn(self_vtable:
+                                                                                    intercom::raw::RawComPtr,
+                                                                                __out:
+                                                                                    *mut <u16
+                                                                                         as
+                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType)
+                                                          ->
+                                                              <intercom::raw::HRESULT
+                                                              as
+                                                              intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType>;
             let _:
                     ::core::clone::AssertParamIsClone<unsafe extern "system" fn(self_vtable:
                                                                                     intercom::raw::RawComPtr,
                                                                                 a:
                                                                                     <u16
                                                                                     as
-                                                                                    intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
+                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType,
                                                                                 b:
                                                                                     <i16
                                                                                     as
-                                                                                    intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
+                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType,
                                                                                 __out:
                                                                                     *mut <bool
                                                                                          as
-                                                                                         intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
+                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType)
                                                           ->
                                                               <intercom::raw::HRESULT
                                                               as
-                                                              intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType>;
-            let _:
-                    ::core::clone::AssertParamIsClone<unsafe extern "system" fn(self_vtable:
-                                                                                    intercom::raw::RawComPtr,
-                                                                                msg:
-                                                                                    <String
-                                                                                    as
-                                                                                    intercom::type_system::InfallibleExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
-                                                          ->
-                                                              <String as
-                                                              intercom::type_system::InfallibleExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType>;
+                                                              intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType>;
+            let _: ::core::clone::AssertParamIsClone<
+                unsafe extern "system" fn(
+                    self_vtable: intercom::raw::RawComPtr,
+                    msg: <String as intercom::type_system::ExternType<
+                        intercom::type_system::AutomationTypeSystem,
+                    >>::ForeignType,
+                )
+                    -> <String as intercom::type_system::ExternType<
+                    intercom::type_system::AutomationTypeSystem,
+                >>::ForeignType,
+            >;
             let _:
                     ::core::clone::AssertParamIsClone<unsafe extern "system" fn(self_vtable:
                                                                                     intercom::raw::RawComPtr,
                                                                                 itf:
                                                                                     <ComItf<dyn Foo>
                                                                                     as
-                                                                                    intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
+                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType,
                                                                                 __out:
                                                                                     *mut <ComItf<dyn IUnknown>
                                                                                          as
-                                                                                         intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
+                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType)
                                                           ->
                                                               <intercom::raw::HRESULT
                                                               as
-                                                              intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType>;
+                                                              intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType>;
             let _:
                     ::core::clone::AssertParamIsClone<unsafe extern "system" fn(self_vtable:
                                                                                     intercom::raw::RawComPtr,
                                                                                 input:
                                                                                     <bool
                                                                                     as
-                                                                                    intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
+                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType,
                                                                                 __out:
                                                                                     *mut <bool
                                                                                          as
-                                                                                         intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
+                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType)
                                                           ->
                                                               <intercom::raw::HRESULT
                                                               as
-                                                              intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType>;
+                                                              intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType>;
             let _:
                     ::core::clone::AssertParamIsClone<unsafe extern "system" fn(self_vtable:
                                                                                     intercom::raw::RawComPtr,
                                                                                 input:
                                                                                     <Variant
                                                                                     as
-                                                                                    intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType,
+                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType,
                                                                                 __out:
                                                                                     *mut <Variant
                                                                                          as
-                                                                                         intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType)
+                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType)
                                                           ->
                                                               <intercom::raw::HRESULT
                                                               as
-                                                              intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType>;
+                                                              intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType>;
             *self
         }
     }
@@ -1427,9 +1428,9 @@ where
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_arg_method_Raw<I, S>(
     self_vtable: intercom::raw::RawComPtr,
-    a: <u16 as intercom::type_system::InfallibleExternInput<
-        intercom::type_system::RawTypeSystem,
-    >>::ForeignType,
+    a:
+                                                      <u16 as
+                                                      intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType,
 ) -> ()
 where
     I: ?Sized,
@@ -1492,16 +1493,15 @@ where
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_simple_result_method_Raw<I,
-                                                         S>(self_vtable:
-                                                                intercom::raw::RawComPtr)
- ->
-     <u16 as
-     intercom::type_system::InfallibleExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
- where I: ?Sized,
- S: intercom::attributes::ComClassInterface<I,
-                                            intercom::type_system::RawTypeSystem> +
-intercom::attributes::ComClass + Foo{
+unsafe extern "system" fn __Foo_simple_result_method_Raw<I, S>(
+    self_vtable: intercom::raw::RawComPtr,
+) -> <u16 as intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
+where
+    I: ?Sized,
+    S: intercom::attributes::ComClassInterface<I, intercom::type_system::RawTypeSystem>
+        + intercom::attributes::ComClass
+        + Foo,
+{
     let offset = <S as intercom::attributes::ComClassInterface<
         I,
         intercom::type_system::RawTypeSystem,
@@ -1559,10 +1559,10 @@ intercom::attributes::ComClass + Foo{
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_com_result_method_Raw<I, S>(
     self_vtable: intercom::raw::RawComPtr,
-    __out: *mut <u16 as intercom::type_system::ExternOutput<
-        intercom::type_system::RawTypeSystem,
-    >>::ForeignType,
-) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+    __out:
+                                                             *mut <u16 as
+                                                                  intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType,
+) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
     intercom::type_system::RawTypeSystem,
 >>::ForeignType
 where
@@ -1598,7 +1598,7 @@ where
         )
     });
     let result: Result<
-        <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+        <intercom::raw::HRESULT as intercom::type_system::ExternType<
             intercom::type_system::RawTypeSystem,
         >>::ForeignType,
         intercom::ComError,
@@ -1673,7 +1673,7 @@ where
                     ),
                 )
             });
-            <<intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+            <<intercom::raw::HRESULT as intercom::type_system::ExternType<
                 intercom::type_system::RawTypeSystem,
             >>::ForeignType as intercom::ErrorValue>::from_error(intercom::store_error(
                 err,
@@ -1686,10 +1686,10 @@ where
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_rust_result_method_Raw<I, S>(
     self_vtable: intercom::raw::RawComPtr,
-    __out: *mut <u16 as intercom::type_system::ExternOutput<
-        intercom::type_system::RawTypeSystem,
-    >>::ForeignType,
-) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+    __out:
+                                                              *mut <u16 as
+                                                                   intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType,
+) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
     intercom::type_system::RawTypeSystem,
 >>::ForeignType
 where
@@ -1725,7 +1725,7 @@ where
         )
     });
     let result: Result<
-        <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+        <intercom::raw::HRESULT as intercom::type_system::ExternType<
             intercom::type_system::RawTypeSystem,
         >>::ForeignType,
         intercom::ComError,
@@ -1800,7 +1800,7 @@ where
                     ),
                 )
             });
-            <<intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+            <<intercom::raw::HRESULT as intercom::type_system::ExternType<
                 intercom::type_system::RawTypeSystem,
             >>::ForeignType as intercom::ErrorValue>::from_error(intercom::store_error(
                 err,
@@ -1815,14 +1815,14 @@ unsafe extern "system" fn __Foo_complete_method_Raw<I, S>(
     self_vtable: intercom::raw::RawComPtr,
     a:
                                                            <u16 as
-                                                           intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
+                                                           intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType,
     b:
                                                            <i16 as
-                                                           intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
-    __out: *mut <bool as intercom::type_system::ExternOutput<
-        intercom::type_system::RawTypeSystem,
-    >>::ForeignType,
-) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+                                                           intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType,
+    __out:
+                                                           *mut <bool as
+                                                                intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType,
+) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
     intercom::type_system::RawTypeSystem,
 >>::ForeignType
 where
@@ -1858,7 +1858,7 @@ where
         )
     });
     let result: Result<
-        <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+        <intercom::raw::HRESULT as intercom::type_system::ExternType<
             intercom::type_system::RawTypeSystem,
         >>::ForeignType,
         intercom::ComError,
@@ -1941,7 +1941,7 @@ where
                     ),
                 )
             });
-            <<intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+            <<intercom::raw::HRESULT as intercom::type_system::ExternType<
                 intercom::type_system::RawTypeSystem,
             >>::ForeignType as intercom::ErrorValue>::from_error(intercom::store_error(
                 err,
@@ -1952,19 +1952,18 @@ where
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[doc(hidden)]
-unsafe extern "system" fn __Foo_string_method_Raw<I,
-                                                  S>(self_vtable:
-                                                         intercom::raw::RawComPtr,
-                                                     msg:
+unsafe extern "system" fn __Foo_string_method_Raw<I, S>(
+    self_vtable: intercom::raw::RawComPtr,
+    msg:
                                                          <String as
-                                                         intercom::type_system::InfallibleExternInput<intercom::type_system::RawTypeSystem>>::ForeignType)
- ->
-     <String as
-     intercom::type_system::InfallibleExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
- where I: ?Sized,
- S: intercom::attributes::ComClassInterface<I,
-                                            intercom::type_system::RawTypeSystem> +
-intercom::attributes::ComClass + Foo{
+                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType,
+) -> <String as intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
+where
+    I: ?Sized,
+    S: intercom::attributes::ComClassInterface<I, intercom::type_system::RawTypeSystem>
+        + intercom::attributes::ComClass
+        + Foo,
+{
     let offset = <S as intercom::attributes::ComClassInterface<
         I,
         intercom::type_system::RawTypeSystem,
@@ -2026,13 +2025,13 @@ intercom::attributes::ComClass + Foo{
 #[doc(hidden)]
 unsafe extern "system" fn __Foo_comitf_method_Raw<I, S>(
     self_vtable: intercom::raw::RawComPtr,
-    itf: <ComItf<dyn Foo> as intercom::type_system::ExternInput<
+    itf: <ComItf<dyn Foo> as intercom::type_system::ExternType<
         intercom::type_system::RawTypeSystem,
     >>::ForeignType,
-    __out: *mut <ComItf<dyn IUnknown> as intercom::type_system::ExternOutput<
+    __out: *mut <ComItf<dyn IUnknown> as intercom::type_system::ExternType<
         intercom::type_system::RawTypeSystem,
     >>::ForeignType,
-) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
     intercom::type_system::RawTypeSystem,
 >>::ForeignType
 where
@@ -2068,7 +2067,7 @@ where
         )
     });
     let result: Result<
-        <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+        <intercom::raw::HRESULT as intercom::type_system::ExternType<
             intercom::type_system::RawTypeSystem,
         >>::ForeignType,
         intercom::ComError,
@@ -2146,7 +2145,7 @@ where
                     ),
                 )
             });
-            <<intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+            <<intercom::raw::HRESULT as intercom::type_system::ExternType<
                 intercom::type_system::RawTypeSystem,
             >>::ForeignType as intercom::ErrorValue>::from_error(intercom::store_error(
                 err,
@@ -2161,11 +2160,11 @@ unsafe extern "system" fn __Foo_bool_method_Raw<I, S>(
     self_vtable: intercom::raw::RawComPtr,
     input:
                                                        <bool as
-                                                       intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
-    __out: *mut <bool as intercom::type_system::ExternOutput<
-        intercom::type_system::RawTypeSystem,
-    >>::ForeignType,
-) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+                                                       intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType,
+    __out:
+                                                       *mut <bool as
+                                                            intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType,
+) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
     intercom::type_system::RawTypeSystem,
 >>::ForeignType
 where
@@ -2201,7 +2200,7 @@ where
         )
     });
     let result: Result<
-        <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+        <intercom::raw::HRESULT as intercom::type_system::ExternType<
             intercom::type_system::RawTypeSystem,
         >>::ForeignType,
         intercom::ComError,
@@ -2278,7 +2277,7 @@ where
                     ),
                 )
             });
-            <<intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+            <<intercom::raw::HRESULT as intercom::type_system::ExternType<
                 intercom::type_system::RawTypeSystem,
             >>::ForeignType as intercom::ErrorValue>::from_error(intercom::store_error(
                 err,
@@ -2293,11 +2292,11 @@ unsafe extern "system" fn __Foo_variant_method_Raw<I, S>(
     self_vtable: intercom::raw::RawComPtr,
     input:
                                                           <Variant as
-                                                          intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
-    __out: *mut <Variant as intercom::type_system::ExternOutput<
+                                                          intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType,
+    __out: *mut <Variant as intercom::type_system::ExternType<
         intercom::type_system::RawTypeSystem,
     >>::ForeignType,
-) -> <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+) -> <intercom::raw::HRESULT as intercom::type_system::ExternType<
     intercom::type_system::RawTypeSystem,
 >>::ForeignType
 where
@@ -2333,7 +2332,7 @@ where
         )
     });
     let result: Result<
-        <intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+        <intercom::raw::HRESULT as intercom::type_system::ExternType<
             intercom::type_system::RawTypeSystem,
         >>::ForeignType,
         intercom::ComError,
@@ -2411,7 +2410,7 @@ where
                     ),
                 )
             });
-            <<intercom::raw::HRESULT as intercom::type_system::ExternOutput<
+            <<intercom::raw::HRESULT as intercom::type_system::ExternType<
                 intercom::type_system::RawTypeSystem,
             >>::ForeignType as intercom::ErrorValue>::from_error(intercom::store_error(
                 err,
@@ -2434,85 +2433,85 @@ pub struct __FooRawVTable {
                                                   intercom::raw::RawComPtr,
                                               a:
                                                   <u16 as
-                                                  intercom::type_system::InfallibleExternInput<intercom::type_system::RawTypeSystem>>::ForeignType)
+                                                  intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType)
                         -> (),
     pub simple_result_method: unsafe extern "system" fn(self_vtable:
                                                             intercom::raw::RawComPtr)
                                   ->
                                       <u16 as
-                                      intercom::type_system::InfallibleExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType,
+                                      intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType,
     pub com_result_method: unsafe extern "system" fn(self_vtable:
                                                          intercom::raw::RawComPtr,
                                                      __out:
                                                          *mut <u16 as
-                                                              intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType)
+                                                              intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType)
                                ->
                                    <intercom::raw::HRESULT as
-                                   intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType,
+                                   intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType,
     pub rust_result_method: unsafe extern "system" fn(self_vtable:
                                                           intercom::raw::RawComPtr,
                                                       __out:
                                                           *mut <u16 as
-                                                               intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType)
+                                                               intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType)
                                 ->
                                     <intercom::raw::HRESULT as
-                                    intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType,
+                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType,
     pub complete_method: unsafe extern "system" fn(self_vtable:
                                                        intercom::raw::RawComPtr,
                                                    a:
                                                        <u16 as
-                                                       intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
+                                                       intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType,
                                                    b:
                                                        <i16 as
-                                                       intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
+                                                       intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType,
                                                    __out:
                                                        *mut <bool as
-                                                            intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType)
+                                                            intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType)
                              ->
                                  <intercom::raw::HRESULT as
-                                 intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType,
+                                 intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType,
     pub string_method: unsafe extern "system" fn(self_vtable:
                                                      intercom::raw::RawComPtr,
                                                  msg:
                                                      <String as
-                                                     intercom::type_system::InfallibleExternInput<intercom::type_system::RawTypeSystem>>::ForeignType)
+                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType)
                            ->
                                <String as
-                               intercom::type_system::InfallibleExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType,
+                               intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType,
     pub comitf_method: unsafe extern "system" fn(self_vtable:
                                                      intercom::raw::RawComPtr,
                                                  itf:
                                                      <ComItf<dyn Foo> as
-                                                     intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
+                                                     intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType,
                                                  __out:
                                                      *mut <ComItf<dyn IUnknown>
                                                           as
-                                                          intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType)
+                                                          intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType)
                            ->
                                <intercom::raw::HRESULT as
-                               intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType,
+                               intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType,
     pub bool_method: unsafe extern "system" fn(self_vtable:
                                                    intercom::raw::RawComPtr,
                                                input:
                                                    <bool as
-                                                   intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
+                                                   intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType,
                                                __out:
                                                    *mut <bool as
-                                                        intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType)
+                                                        intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType)
                          ->
                              <intercom::raw::HRESULT as
-                             intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType,
+                             intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType,
     pub variant_method: unsafe extern "system" fn(self_vtable:
                                                       intercom::raw::RawComPtr,
                                                   input:
                                                       <Variant as
-                                                      intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
+                                                      intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType,
                                                   __out:
                                                       *mut <Variant as
-                                                           intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType)
+                                                           intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType)
                             ->
                                 <intercom::raw::HRESULT as
-                                intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType,
+                                intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType,
 }
 #[automatically_derived]
 #[allow(unused_qualifications)]
@@ -2534,113 +2533,116 @@ impl ::core::clone::Clone for __FooRawVTable {
             let _: ::core::clone::AssertParamIsClone<
                 unsafe extern "system" fn(
                     self_vtable: intercom::raw::RawComPtr,
-                    a: <u16 as intercom::type_system::InfallibleExternInput<
+                    a: <u16 as intercom::type_system::ExternType<
                         intercom::type_system::RawTypeSystem,
                     >>::ForeignType,
                 ) -> (),
             >;
-            let _:
-                    ::core::clone::AssertParamIsClone<unsafe extern "system" fn(self_vtable:
-                                                                                    intercom::raw::RawComPtr)
-                                                          ->
-                                                              <u16 as
-                                                              intercom::type_system::InfallibleExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType>;
-            let _:
-                    ::core::clone::AssertParamIsClone<unsafe extern "system" fn(self_vtable:
-                                                                                    intercom::raw::RawComPtr,
-                                                                                __out:
-                                                                                    *mut <u16
-                                                                                         as
-                                                                                         intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType)
-                                                          ->
-                                                              <intercom::raw::HRESULT
-                                                              as
-                                                              intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType>;
+            let _: ::core::clone::AssertParamIsClone<
+                unsafe extern "system" fn(
+                    self_vtable: intercom::raw::RawComPtr,
+                )
+                    -> <u16 as intercom::type_system::ExternType<
+                    intercom::type_system::RawTypeSystem,
+                >>::ForeignType,
+            >;
             let _:
                     ::core::clone::AssertParamIsClone<unsafe extern "system" fn(self_vtable:
                                                                                     intercom::raw::RawComPtr,
                                                                                 __out:
                                                                                     *mut <u16
                                                                                          as
-                                                                                         intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType)
+                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType)
                                                           ->
                                                               <intercom::raw::HRESULT
                                                               as
-                                                              intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType>;
+                                                              intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType>;
+            let _:
+                    ::core::clone::AssertParamIsClone<unsafe extern "system" fn(self_vtable:
+                                                                                    intercom::raw::RawComPtr,
+                                                                                __out:
+                                                                                    *mut <u16
+                                                                                         as
+                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType)
+                                                          ->
+                                                              <intercom::raw::HRESULT
+                                                              as
+                                                              intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType>;
             let _:
                     ::core::clone::AssertParamIsClone<unsafe extern "system" fn(self_vtable:
                                                                                     intercom::raw::RawComPtr,
                                                                                 a:
                                                                                     <u16
                                                                                     as
-                                                                                    intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
+                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType,
                                                                                 b:
                                                                                     <i16
                                                                                     as
-                                                                                    intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
+                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType,
                                                                                 __out:
                                                                                     *mut <bool
                                                                                          as
-                                                                                         intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType)
+                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType)
                                                           ->
                                                               <intercom::raw::HRESULT
                                                               as
-                                                              intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType>;
-            let _:
-                    ::core::clone::AssertParamIsClone<unsafe extern "system" fn(self_vtable:
-                                                                                    intercom::raw::RawComPtr,
-                                                                                msg:
-                                                                                    <String
-                                                                                    as
-                                                                                    intercom::type_system::InfallibleExternInput<intercom::type_system::RawTypeSystem>>::ForeignType)
-                                                          ->
-                                                              <String as
-                                                              intercom::type_system::InfallibleExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType>;
+                                                              intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType>;
+            let _: ::core::clone::AssertParamIsClone<
+                unsafe extern "system" fn(
+                    self_vtable: intercom::raw::RawComPtr,
+                    msg: <String as intercom::type_system::ExternType<
+                        intercom::type_system::RawTypeSystem,
+                    >>::ForeignType,
+                )
+                    -> <String as intercom::type_system::ExternType<
+                    intercom::type_system::RawTypeSystem,
+                >>::ForeignType,
+            >;
             let _:
                     ::core::clone::AssertParamIsClone<unsafe extern "system" fn(self_vtable:
                                                                                     intercom::raw::RawComPtr,
                                                                                 itf:
                                                                                     <ComItf<dyn Foo>
                                                                                     as
-                                                                                    intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
+                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType,
                                                                                 __out:
                                                                                     *mut <ComItf<dyn IUnknown>
                                                                                          as
-                                                                                         intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType)
+                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType)
                                                           ->
                                                               <intercom::raw::HRESULT
                                                               as
-                                                              intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType>;
+                                                              intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType>;
             let _:
                     ::core::clone::AssertParamIsClone<unsafe extern "system" fn(self_vtable:
                                                                                     intercom::raw::RawComPtr,
                                                                                 input:
                                                                                     <bool
                                                                                     as
-                                                                                    intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
+                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType,
                                                                                 __out:
                                                                                     *mut <bool
                                                                                          as
-                                                                                         intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType)
+                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType)
                                                           ->
                                                               <intercom::raw::HRESULT
                                                               as
-                                                              intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType>;
+                                                              intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType>;
             let _:
                     ::core::clone::AssertParamIsClone<unsafe extern "system" fn(self_vtable:
                                                                                     intercom::raw::RawComPtr,
                                                                                 input:
                                                                                     <Variant
                                                                                     as
-                                                                                    intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType,
+                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType,
                                                                                 __out:
                                                                                     *mut <Variant
                                                                                          as
-                                                                                         intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType)
+                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType)
                                                           ->
                                                               <intercom::raw::HRESULT
                                                               as
-                                                              intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType>;
+                                                              intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType>;
             *self
         }
     }
@@ -2855,7 +2857,7 @@ impl<I: intercom::attributes::ComInterface + Foo + ?Sized> Foo for intercom::Com
                 >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<ComResult<bool>, intercom::ComError> = (|| unsafe {
-                let mut __out: <bool as intercom::type_system::ExternOutput<
+                let mut __out: <bool as intercom::type_system::ExternType<
                     intercom::type_system::AutomationTypeSystem,
                 >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).bool_method)(
@@ -2915,7 +2917,7 @@ impl<I: intercom::attributes::ComInterface + Foo + ?Sized> Foo for intercom::Com
                 >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<ComResult<bool>, intercom::ComError> = (|| unsafe {
-                let mut __out: <bool as intercom::type_system::ExternOutput<
+                let mut __out: <bool as intercom::type_system::ExternType<
                     intercom::type_system::RawTypeSystem,
                 >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).bool_method)(
@@ -3007,7 +3009,7 @@ impl<I: intercom::attributes::ComInterface + Foo + ?Sized> Foo for intercom::Com
                 >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<ComResult<u16>, intercom::ComError> = (|| unsafe {
-                let mut __out: <u16 as intercom::type_system::ExternOutput<
+                let mut __out: <u16 as intercom::type_system::ExternType<
                     intercom::type_system::AutomationTypeSystem,
                 >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).com_result_method)(comptr.ptr.as_ptr(), &mut __out);
@@ -3060,7 +3062,7 @@ impl<I: intercom::attributes::ComInterface + Foo + ?Sized> Foo for intercom::Com
                 >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<ComResult<u16>, intercom::ComError> = (|| unsafe {
-                let mut __out: <u16 as intercom::type_system::ExternOutput<
+                let mut __out: <u16 as intercom::type_system::ExternType<
                     intercom::type_system::RawTypeSystem,
                 >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).com_result_method)(comptr.ptr.as_ptr(), &mut __out);
@@ -3142,7 +3144,7 @@ impl<I: intercom::attributes::ComInterface + Foo + ?Sized> Foo for intercom::Com
                 ComResult<ComItf<dyn IUnknown>>,
                 intercom::ComError,
             > = (|| unsafe {
-                let mut __out: <ComItf<dyn IUnknown> as intercom::type_system::ExternOutput<
+                let mut __out: <ComItf<dyn IUnknown> as intercom::type_system::ExternType<
                     intercom::type_system::AutomationTypeSystem,
                 >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).comitf_method)(
@@ -3208,7 +3210,7 @@ impl<I: intercom::attributes::ComInterface + Foo + ?Sized> Foo for intercom::Com
                 ComResult<ComItf<dyn IUnknown>>,
                 intercom::ComError,
             > = (|| unsafe {
-                let mut __out: <ComItf<dyn IUnknown> as intercom::type_system::ExternOutput<
+                let mut __out: <ComItf<dyn IUnknown> as intercom::type_system::ExternType<
                     intercom::type_system::RawTypeSystem,
                 >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).comitf_method)(
@@ -3303,7 +3305,7 @@ impl<I: intercom::attributes::ComInterface + Foo + ?Sized> Foo for intercom::Com
                 >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<ComResult<bool>, intercom::ComError> = (|| unsafe {
-                let mut __out: <bool as intercom::type_system::ExternOutput<
+                let mut __out: <bool as intercom::type_system::ExternType<
                     intercom::type_system::AutomationTypeSystem,
                 >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).complete_method)(
@@ -3367,7 +3369,7 @@ impl<I: intercom::attributes::ComInterface + Foo + ?Sized> Foo for intercom::Com
                 >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<ComResult<bool>, intercom::ComError> = (|| unsafe {
-                let mut __out: <bool as intercom::type_system::ExternOutput<
+                let mut __out: <bool as intercom::type_system::ExternType<
                     intercom::type_system::RawTypeSystem,
                 >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).complete_method)(
@@ -3463,7 +3465,7 @@ impl<I: intercom::attributes::ComInterface + Foo + ?Sized> Foo for intercom::Com
                 >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<Result<u16, i32>, intercom::ComError> = (|| unsafe {
-                let mut __out: <u16 as intercom::type_system::ExternOutput<
+                let mut __out: <u16 as intercom::type_system::ExternType<
                     intercom::type_system::AutomationTypeSystem,
                 >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).rust_result_method)(comptr.ptr.as_ptr(), &mut __out);
@@ -3516,7 +3518,7 @@ impl<I: intercom::attributes::ComInterface + Foo + ?Sized> Foo for intercom::Com
                 >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<Result<u16, i32>, intercom::ComError> = (|| unsafe {
-                let mut __out: <u16 as intercom::type_system::ExternOutput<
+                let mut __out: <u16 as intercom::type_system::ExternType<
                     intercom::type_system::RawTypeSystem,
                 >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).rust_result_method)(comptr.ptr.as_ptr(), &mut __out);
@@ -3935,7 +3937,7 @@ impl<I: intercom::attributes::ComInterface + Foo + ?Sized> Foo for intercom::Com
                 >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<ComResult<Variant>, intercom::ComError> = (|| unsafe {
-                let mut __out: <Variant as intercom::type_system::ExternOutput<
+                let mut __out: <Variant as intercom::type_system::ExternType<
                     intercom::type_system::AutomationTypeSystem,
                 >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).variant_method)(
@@ -3996,7 +3998,7 @@ impl<I: intercom::attributes::ComInterface + Foo + ?Sized> Foo for intercom::Com
                 >>::VTable;
             #[allow(unused_unsafe)]
             let __intercom_result: Result<ComResult<Variant>, intercom::ComError> = (|| unsafe {
-                let mut __out: <Variant as intercom::type_system::ExternOutput<
+                let mut __out: <Variant as intercom::type_system::ExternType<
                     intercom::type_system::RawTypeSystem,
                 >>::ForeignType = intercom::type_system::ExternDefault::extern_default();
                 let __result = ((**vtbl).variant_method)(
@@ -4129,13 +4131,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::InfallibleExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::InfallibleExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
@@ -4148,13 +4150,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                ty:
                                                                                                                                                                                                    <<u16
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
                                                                                                                                                                                                        intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                indirection_level:
                                                                                                                                                                                                    <<u16
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
                                                                                                                                                                                                        intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                direction:
@@ -4169,13 +4171,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                ty:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
                                                                                                                                                                                                        intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                indirection_level:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
                                                                                                                                                                                                        intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                direction:
@@ -4187,13 +4189,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
@@ -4206,13 +4208,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                ty:
                                                                                                                                                                                                    <<i32
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
                                                                                                                                                                                                        intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                indirection_level:
                                                                                                                                                                                                    <<i32
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
                                                                                                                                                                                                        intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                direction:
@@ -4224,13 +4226,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
@@ -4243,13 +4245,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                ty:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
                                                                                                                                                                                                        intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                indirection_level:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
                                                                                                                                                                                                        intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                direction:
@@ -4261,13 +4263,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
@@ -4277,13 +4279,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<i16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<i16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
@@ -4293,13 +4295,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<bool
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<bool
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
@@ -4312,13 +4314,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                ty:
                                                                                                                                                                                                    <<String
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
                                                                                                                                                                                                        intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                indirection_level:
                                                                                                                                                                                                    <<String
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
                                                                                                                                                                                                        intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                direction:
@@ -4330,13 +4332,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<String
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::InfallibleExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<String
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::InfallibleExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
@@ -4349,13 +4351,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                ty:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
                                                                                                                                                                                                        intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                indirection_level:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
                                                                                                                                                                                                        intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                direction:
@@ -4367,13 +4369,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<ComItf<dyn Foo>
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<ComItf<dyn Foo>
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
@@ -4383,13 +4385,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<ComItf<dyn IUnknown>
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<ComItf<dyn IUnknown>
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
@@ -4402,13 +4404,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                ty:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
                                                                                                                                                                                                        intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                indirection_level:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
                                                                                                                                                                                                        intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                direction:
@@ -4420,13 +4422,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<bool
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<bool
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
@@ -4436,13 +4438,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<bool
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<bool
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
@@ -4455,13 +4457,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                ty:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
                                                                                                                                                                                                        intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                indirection_level:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
                                                                                                                                                                                                        intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                direction:
@@ -4473,13 +4475,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<Variant
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<Variant
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
@@ -4489,13 +4491,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<Variant
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<Variant
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
@@ -4551,13 +4553,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::InfallibleExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::InfallibleExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
@@ -4570,13 +4572,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                ty:
                                                                                                                                                                                                    <<u16
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
                                                                                                                                                                                                        intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                indirection_level:
                                                                                                                                                                                                    <<u16
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
                                                                                                                                                                                                        intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                direction:
@@ -4591,13 +4593,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                ty:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
                                                                                                                                                                                                        intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                indirection_level:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
                                                                                                                                                                                                        intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                direction:
@@ -4609,13 +4611,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
@@ -4628,13 +4630,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                ty:
                                                                                                                                                                                                    <<i32
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
                                                                                                                                                                                                        intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                indirection_level:
                                                                                                                                                                                                    <<i32
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
                                                                                                                                                                                                        intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                direction:
@@ -4646,13 +4648,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
@@ -4665,13 +4667,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                ty:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
                                                                                                                                                                                                        intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                indirection_level:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
                                                                                                                                                                                                        intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                direction:
@@ -4683,13 +4685,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<u16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
@@ -4699,13 +4701,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<i16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<i16
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
@@ -4715,13 +4717,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<bool
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<bool
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
@@ -4734,13 +4736,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                ty:
                                                                                                                                                                                                    <<String
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
                                                                                                                                                                                                        intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                indirection_level:
                                                                                                                                                                                                    <<String
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
                                                                                                                                                                                                        intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                direction:
@@ -4752,13 +4754,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<String
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::InfallibleExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<String
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::InfallibleExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
@@ -4771,13 +4773,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                ty:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
                                                                                                                                                                                                        intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                indirection_level:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
                                                                                                                                                                                                        intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                direction:
@@ -4789,13 +4791,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<ComItf<dyn Foo>
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<ComItf<dyn Foo>
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
@@ -4805,13 +4807,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<ComItf<dyn IUnknown>
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<ComItf<dyn IUnknown>
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
@@ -4824,13 +4826,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                ty:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
                                                                                                                                                                                                        intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                indirection_level:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
                                                                                                                                                                                                        intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                direction:
@@ -4842,13 +4844,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<bool
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<bool
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
@@ -4858,13 +4860,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<bool
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<bool
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
@@ -4877,13 +4879,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                ty:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
                                                                                                                                                                                                        intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                indirection_level:
                                                                                                                                                                                                    <<intercom::raw::HRESULT
                                                                                                                                                                                                     as
-                                                                                                                                                                                                    intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                    intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                        as
                                                                                                                                                                                                        intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                direction:
@@ -4895,13 +4897,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<Variant
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<Variant
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:
@@ -4911,13 +4913,13 @@ impl intercom::attributes::ComInterfaceTypeInfo for dyn Foo {
                                                                                                                                                                                                                     ty:
                                                                                                                                                                                                                         <<Variant
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::type_name().into(),
                                                                                                                                                                                                                     indirection_level:
                                                                                                                                                                                                                         <<Variant
                                                                                                                                                                                                                          as
-                                                                                                                                                                                                                         intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>>::ForeignType
+                                                                                                                                                                                                                         intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>>::ForeignType
                                                                                                                                                                                                                             as
                                                                                                                                                                                                                             intercom::type_system::ForeignType>::indirection_level(),
                                                                                                                                                                                                                     direction:

--- a/intercom-attributes/tests/data/ui/span-externtype-error.rs.stderr
+++ b/intercom-attributes/tests/data/ui/span-externtype-error.rs.stderr
@@ -1,51 +1,39 @@
-error[E0277]: the trait bound `NotExternType: intercom::type_system::InfallibleExternInput<intercom::type_system::AutomationTypeSystem>` is not satisfied
+error[E0277]: the trait bound `NotExternType: intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>` is not satisfied
   --> span-externtype-error.rs:12:5
    |
 12 |     fn arg_type(&self, bad_type: NotExternType);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `intercom::type_system::InfallibleExternInput<intercom::type_system::AutomationTypeSystem>` is not implemented for `NotExternType`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>` is not implemented for `NotExternType`
 
-error[E0277]: the trait bound `NotExternType: intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>` is not satisfied
+error[E0277]: the trait bound `NotExternType: intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>` is not satisfied
   --> span-externtype-error.rs:14:5
    |
 14 |     fn ret_type(&self) -> ComResult<NotExternType>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>` is not implemented for `NotExternType`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>` is not implemented for `NotExternType`
 
-error[E0277]: the trait bound `NotExternType: intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>` is not satisfied
+error[E0277]: the trait bound `NotExternType: intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>` is not satisfied
   --> span-externtype-error.rs:16:5
    |
 16 |     fn all_type(&self, bad_type: NotExternType) -> ComResult<NotExternType>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `intercom::type_system::ExternInput<intercom::type_system::AutomationTypeSystem>` is not implemented for `NotExternType`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `intercom::type_system::ExternType<intercom::type_system::AutomationTypeSystem>` is not implemented for `NotExternType`
 
-error[E0277]: the trait bound `NotExternType: intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>` is not satisfied
-  --> span-externtype-error.rs:16:5
-   |
-16 |     fn all_type(&self, bad_type: NotExternType) -> ComResult<NotExternType>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `intercom::type_system::ExternOutput<intercom::type_system::AutomationTypeSystem>` is not implemented for `NotExternType`
-
-error[E0277]: the trait bound `NotExternType: intercom::type_system::InfallibleExternInput<intercom::type_system::RawTypeSystem>` is not satisfied
+error[E0277]: the trait bound `NotExternType: intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>` is not satisfied
   --> span-externtype-error.rs:12:5
    |
 12 |     fn arg_type(&self, bad_type: NotExternType);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `intercom::type_system::InfallibleExternInput<intercom::type_system::RawTypeSystem>` is not implemented for `NotExternType`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>` is not implemented for `NotExternType`
 
-error[E0277]: the trait bound `NotExternType: intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>` is not satisfied
+error[E0277]: the trait bound `NotExternType: intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>` is not satisfied
   --> span-externtype-error.rs:14:5
    |
 14 |     fn ret_type(&self) -> ComResult<NotExternType>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>` is not implemented for `NotExternType`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>` is not implemented for `NotExternType`
 
-error[E0277]: the trait bound `NotExternType: intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>` is not satisfied
+error[E0277]: the trait bound `NotExternType: intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>` is not satisfied
   --> span-externtype-error.rs:16:5
    |
 16 |     fn all_type(&self, bad_type: NotExternType) -> ComResult<NotExternType>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `intercom::type_system::ExternInput<intercom::type_system::RawTypeSystem>` is not implemented for `NotExternType`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `intercom::type_system::ExternType<intercom::type_system::RawTypeSystem>` is not implemented for `NotExternType`
 
-error[E0277]: the trait bound `NotExternType: intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>` is not satisfied
-  --> span-externtype-error.rs:16:5
-   |
-16 |     fn all_type(&self, bad_type: NotExternType) -> ComResult<NotExternType>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `intercom::type_system::ExternOutput<intercom::type_system::RawTypeSystem>` is not implemented for `NotExternType`
-
-error: aborting due to 8 previous errors
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/intercom-cli/src/embed/setup_configuration.rs
+++ b/intercom-cli/src/embed/setup_configuration.rs
@@ -18,7 +18,7 @@ const CLSID_SetupConfiguration: GUID = GUID {
 };
 
 #[repr(C)]
-#[derive(Default, ForeignType, ExternOutput, ExternInput, Debug)]
+#[derive(Default, ForeignType, ExternType, ExternOutput, ExternInput, Debug)]
 pub struct FILETIME
 {
     low_part: u32,

--- a/intercom-cli/src/generators/cpp_header.hbs
+++ b/intercom-cli/src/generators/cpp_header.hbs
@@ -19,8 +19,7 @@ namespace {{lib_name}}
     using f64 = double;
     using usize = size_t;
     using Variant = intercom::VARIANT;
-    using InBSTR = intercom::BSTR;
-    using OutBSTR = intercom::BSTR;
+    using BSTR = intercom::BSTR;
 
     class Descriptor
     {

--- a/intercom-cli/src/generators/idl.hbs
+++ b/intercom-cli/src/generators/idl.hbs
@@ -18,8 +18,6 @@ library {{lib_name}}
     typedef float f32;
     typedef double f64;
     typedef size_t usize;
-    typedef BSTR InBSTR;
-    typedef BSTR OutBSTR;
 
 {{#each interfaces}}
     interface {{name}};

--- a/intercom-common/src/attributes/mod.rs
+++ b/intercom-common/src/attributes/mod.rs
@@ -11,5 +11,6 @@ pub use self::com_library::expand_com_module;
 
 mod type_info;
 pub use self::type_info::expand_bidirectional_type_info;
+pub use self::type_info::expand_derive_extern_input;
 pub use self::type_info::expand_derive_extern_output;
-pub use self::type_info::expand_derive_extern_parameter;
+pub use self::type_info::expand_derive_extern_type;

--- a/intercom-common/src/methodinfo.rs
+++ b/intercom-common/src/methodinfo.rs
@@ -269,12 +269,9 @@ impl ComMethodInfo
 
     pub fn get_parameters_tokenstream(&self) -> TokenStream
     {
-        let infallible = self.returnhandler.is_infallible();
         let in_out_args = self.raw_com_args().into_iter().map(|com_arg| {
             let name = &com_arg.name;
-            let com_ty = &com_arg
-                .handler
-                .com_ty(com_arg.span, com_arg.dir, infallible);
+            let com_ty = &com_arg.handler.com_ty(com_arg.span);
             let dir = match com_arg.dir {
                 Direction::In => quote!(),
                 Direction::Out | Direction::Retval => quote_spanned!(com_arg.span => *mut ),

--- a/intercom-common/src/returnhandlers.rs
+++ b/intercom-common/src/returnhandlers.rs
@@ -23,11 +23,8 @@ pub trait ReturnHandler: ::std::fmt::Debug
     /// The return type for COM implementation.
     fn com_ty(&self) -> Type
     {
-        tyhandlers::get_ty_handler(&self.rust_ty(), TypeContext::new(self.type_system())).com_ty(
-            self.return_type_span(),
-            Direction::Retval,
-            self.is_infallible(),
-        )
+        tyhandlers::get_ty_handler(&self.rust_ty(), TypeContext::new(self.type_system()))
+            .com_ty(self.return_type_span())
     }
 
     /// Gets the return statement for converting the COM result into Rust
@@ -165,7 +162,7 @@ impl ReturnHandler for ErrorResultHandler
         let ts = self.type_system.as_typesystem_type(self.span);
         syn::parse2(quote_spanned!(self.span=>
             < intercom::raw::HRESULT as
-                intercom::type_system::ExternOutput< #ts >>
+                intercom::type_system::ExternType< #ts >>
                     ::ForeignType ))
         .unwrap()
     }

--- a/intercom-common/src/tyhandlers.rs
+++ b/intercom-common/src/tyhandlers.rs
@@ -115,13 +115,15 @@ impl TypeHandler
     }
 
     /// The COM type.
-    pub fn com_ty(&self, span: Span, dir: Direction, infallible: bool) -> Type
+    pub fn com_ty(&self, span: Span) -> Type
     {
         // Construct bits for the quote.
         let ty = &self.ty;
         let ts = self.context.type_system.as_typesystem_type(span);
-        let (tr, _unwrap) = resolve_type_handling(dir, infallible, span);
-        syn::parse2(quote_spanned!(span => <#ty as #tr<#ts>>::ForeignType)).unwrap()
+        syn::parse2(
+            quote_spanned!(span => <#ty as intercom::type_system::ExternType<#ts>>::ForeignType),
+        )
+        .unwrap()
     }
 
     /// Converts a COM parameter named by the ident into a Rust type.

--- a/intercom/src/alloc.rs
+++ b/intercom/src/alloc.rs
@@ -1,5 +1,5 @@
 use super::*;
-use intercom::raw::OutBSTR;
+use intercom::raw::BSTR;
 use std::os::raw;
 
 /// A memory allocator to be used for allocating/deallocating memory shared
@@ -27,7 +27,7 @@ pub trait IAllocator: crate::IUnknown
     /// to the given `len`. The returned value must be freed using BSTR aware
     /// free function, such as the `free_bstr` in this interface or the
     /// `SysFreeString` function on Windows.
-    unsafe fn alloc_bstr(&self, text: *const u16, len: u32) -> OutBSTR;
+    unsafe fn alloc_bstr(&self, text: *const u16, len: u32) -> BSTR;
 
     /// Frees a BSTR value.
     ///
@@ -38,7 +38,7 @@ pub trait IAllocator: crate::IUnknown
     /// # Safety
     ///
     /// The function is safe as long as the `bstr` is a valid BSTR value.
-    unsafe fn free_bstr(&self, bstr: OutBSTR);
+    unsafe fn free_bstr(&self, bstr: BSTR);
 
     /// Allocates a segment of memory that is safe to pass through intercom
     /// interfaces.
@@ -68,12 +68,12 @@ pub trait IAllocator: crate::IUnknown
 
 impl IAllocator for Allocator
 {
-    unsafe fn alloc_bstr(&self, text: *const u16, len: u32) -> OutBSTR
+    unsafe fn alloc_bstr(&self, text: *const u16, len: u32) -> BSTR
     {
-        OutBSTR(os::alloc_bstr(text, len))
+        BSTR(os::alloc_bstr(text, len))
     }
 
-    unsafe fn free_bstr(&self, bstr: OutBSTR)
+    unsafe fn free_bstr(&self, bstr: BSTR)
     {
         os::free_bstr(bstr.0)
     }

--- a/intercom/src/comitf.rs
+++ b/intercom/src/comitf.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::attributes::ComInterface;
 use crate::interfaces::RawIUnknown;
 use crate::type_system::{
-    AutomationTypeSystem, ExternInput, InfallibleExternInput, RawTypeSystem, TypeSystem,
+    AutomationTypeSystem, ExternInput, ExternType, InfallibleExternInput, RawTypeSystem, TypeSystem,
 };
 use std::marker::PhantomData;
 
@@ -198,12 +198,25 @@ impl<T: ComInterface + ?Sized> std::ops::Deref for ComItf<T>
     }
 }
 
-unsafe impl<'a, TS: TypeSystem, I: ComInterface + ?Sized> ExternInput<TS> for &'a crate::ComItf<I>
+unsafe impl<'a, TS: TypeSystem, I: ComInterface + ?Sized> ExternType<TS> for &'a crate::ComItf<I>
 where
     I: ForeignType,
 {
     type ForeignType = Option<crate::raw::InterfacePtr<TS, I>>;
+}
 
+unsafe impl<'a, TS: TypeSystem, I: ComInterface + ?Sized> ExternType<TS>
+    for Option<&'a crate::ComItf<I>>
+where
+    I: ForeignType,
+{
+    type ForeignType = Option<crate::raw::InterfacePtr<TS, I>>;
+}
+
+unsafe impl<'a, TS: TypeSystem, I: ComInterface + ?Sized> ExternInput<TS> for &'a crate::ComItf<I>
+where
+    I: ForeignType,
+{
     type Lease = ();
     unsafe fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
     {
@@ -225,8 +238,6 @@ unsafe impl<'a, TS: TypeSystem, I: ComInterface + ?Sized> ExternInput<TS>
 where
     I: ForeignType,
 {
-    type ForeignType = Option<crate::raw::InterfacePtr<TS, I>>;
-
     type Lease = ();
     unsafe fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, Self::Lease)>
     {
@@ -251,8 +262,6 @@ unsafe impl<'a, TS: TypeSystem, I: ComInterface + ?Sized> InfallibleExternInput<
 where
     I: ForeignType,
 {
-    type ForeignType = Option<crate::raw::InterfacePtr<TS, I>>;
-
     type Lease = ();
     unsafe fn into_foreign_parameter(self) -> (Self::ForeignType, Self::Lease)
     {

--- a/intercom/src/error.rs
+++ b/intercom/src/error.rs
@@ -3,7 +3,9 @@ use std::error::Error;
 
 use super::*;
 use crate::attributes::{ComInterface, ComInterfaceVariant};
-use crate::type_system::{AutomationTypeSystem, ExternOutput, RawTypeSystem, TypeSystem};
+use crate::type_system::{
+    AutomationTypeSystem, ExternOutput, ExternType, RawTypeSystem, TypeSystem,
+};
 
 /// Error structure containing the available information on a COM error.
 #[derive(Debug)]
@@ -43,10 +45,13 @@ impl std::fmt::Display for ComError
     }
 }
 
-unsafe impl<TS: TypeSystem> ExternOutput<TS> for ComError
+unsafe impl<TS: TypeSystem> ExternType<TS> for ComError
 {
     type ForeignType = raw::HRESULT;
+}
 
+unsafe impl<TS: TypeSystem> ExternOutput<TS> for ComError
+{
     fn into_foreign_output(self) -> ComResult<Self::ForeignType>
     {
         Ok(self.hresult)
@@ -61,10 +66,13 @@ unsafe impl<TS: TypeSystem> ExternOutput<TS> for ComError
     }
 }
 
-unsafe impl<TS: TypeSystem> ExternOutput<TS> for std::io::Error
+unsafe impl<TS: TypeSystem> ExternType<TS> for std::io::Error
 {
     type ForeignType = raw::HRESULT;
+}
 
+unsafe impl<TS: TypeSystem> ExternOutput<TS> for std::io::Error
+{
     fn into_foreign_output(self) -> ComResult<Self::ForeignType>
     {
         let com_error: ComError = ComError::from(self);

--- a/intercom/src/lib.rs
+++ b/intercom/src/lib.rs
@@ -153,22 +153,16 @@ pub mod raw
 
     pub type RawComPtr = *mut c_void;
 
-    #[derive(Clone, Copy, intercom_attributes::ExternInput, intercom_attributes::ForeignType)]
-    #[repr(transparent)]
-    pub struct InBSTR(pub *const u16);
-
     #[derive(
         Clone,
         Copy,
+        intercom_attributes::ExternType,
         intercom_attributes::ExternInput,
         intercom_attributes::ExternOutput,
         intercom_attributes::ForeignType,
     )]
     #[repr(transparent)]
-    pub struct OutBSTR(pub *mut u16);
-
-    pub type InCStr = *const std::os::raw::c_char;
-    pub type OutCStr = *mut std::os::raw::c_char;
+    pub struct BSTR(pub *mut u16);
 
     #[repr(transparent)]
     #[derive(PartialEq, Eq)]

--- a/intercom/src/typelib/mod.rs
+++ b/intercom/src/typelib/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     com_class, com_interface, type_system::TypeSystemName, ComBox, ComError, ComItf, ComRc,
-    ComResult, GUID,
+    ComResult, ExternOutput, ExternType, ForeignType, GUID,
 };
 
 use std::borrow::Cow;
@@ -62,7 +62,7 @@ pub enum TypeInfo
     Interface(ComBox<Interface>),
 }
 
-#[derive(intercom::ExternOutput, intercom::ForeignType, Debug)]
+#[derive(ExternType, ExternOutput, ForeignType, Debug)]
 #[repr(C)]
 pub enum TypeInfoKind
 {
@@ -110,7 +110,7 @@ pub struct Interface
     pub options: InterfaceOptions,
 }
 
-#[derive(Debug, Clone, Default, intercom::ExternOutput, intercom::ForeignType)]
+#[derive(Debug, Clone, Default, ExternType, ExternOutput, ForeignType)]
 #[repr(C)]
 pub struct InterfaceOptions
 {
@@ -167,7 +167,7 @@ pub struct Arg
     pub direction: Direction,
 }
 
-#[derive(Debug, Clone, Copy, intercom::ExternOutput, intercom::ForeignType, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, ExternType, ExternOutput, ForeignType, PartialEq, Eq)]
 #[repr(C)]
 pub enum Direction
 {

--- a/intercom/src/variant.rs
+++ b/intercom/src/variant.rs
@@ -1,5 +1,5 @@
 use crate::attributes::{ComInterface, HasInterface};
-use crate::type_system::{ExternInput, ExternOutput, TypeSystem};
+use crate::type_system::{ExternInput, ExternOutput, ExternType, TypeSystem};
 use crate::*;
 use intercom_attributes::ForeignType;
 use std::convert::TryFrom;
@@ -120,10 +120,13 @@ impl Default for Variant
     }
 }
 
-unsafe impl<TS: TypeSystem> ExternInput<TS> for Variant
+unsafe impl<TS: TypeSystem> ExternType<TS> for Variant
 {
     type ForeignType = raw::Variant<TS>;
+}
 
+unsafe impl<TS: TypeSystem> ExternInput<TS> for Variant
+{
     type Lease = ();
     unsafe fn into_foreign_parameter(self) -> ComResult<(Self::ForeignType, ())>
     {
@@ -139,8 +142,6 @@ unsafe impl<TS: TypeSystem> ExternInput<TS> for Variant
 
 unsafe impl<TS: TypeSystem> ExternOutput<TS> for Variant
 {
-    type ForeignType = raw::Variant<TS>;
-
     fn into_foreign_output(self) -> ComResult<Self::ForeignType>
     {
         Self::ForeignType::try_from(self)

--- a/test/testlib/src/error_info.rs
+++ b/test/testlib/src/error_info.rs
@@ -109,11 +109,15 @@ impl IErrorSource for ErrorTests
 #[derive(Debug)]
 pub struct TestError(raw::HRESULT, String);
 
-unsafe impl<TS: intercom::type_system::TypeSystem> intercom::type_system::ExternOutput<TS>
+unsafe impl<TS: intercom::type_system::TypeSystem> intercom::type_system::ExternType<TS>
     for TestError
 {
     type ForeignType = raw::HRESULT;
+}
 
+unsafe impl<TS: intercom::type_system::TypeSystem> intercom::type_system::ExternOutput<TS>
+    for TestError
+{
     fn into_foreign_output(self) -> ComResult<Self::ForeignType>
     {
         Ok(self.0)

--- a/test/testlib/src/output_memory.rs
+++ b/test/testlib/src/output_memory.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::type_complexity)]
 
 use intercom::prelude::*;
-use intercom::type_system::{ExternType, ExternOutput, TypeSystem};
+use intercom::type_system::{ExternOutput, ExternType, TypeSystem};
 use intercom::IUnknown;
 use std::ffi::c_void;
 

--- a/test/testlib/src/output_memory.rs
+++ b/test/testlib/src/output_memory.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::type_complexity)]
 
 use intercom::prelude::*;
-use intercom::type_system::{ExternOutput, TypeSystem};
+use intercom::type_system::{ExternType, ExternOutput, TypeSystem};
 use intercom::IUnknown;
 use std::ffi::c_void;
 
@@ -74,10 +74,13 @@ impl IOutputMemoryTests for OutputMemoryTests
 
 /// A type that fails all conversions.
 pub struct FailingType;
-unsafe impl<TS: TypeSystem> ExternOutput<TS> for FailingType
+unsafe impl<TS: TypeSystem> ExternType<TS> for FailingType
 {
     type ForeignType = *mut c_void;
+}
 
+unsafe impl<TS: TypeSystem> ExternOutput<TS> for FailingType
+{
     fn into_foreign_output(self) -> ComResult<Self::ForeignType>
     {
         Err(ComError::E_FAIL)


### PR DESCRIPTION
The main goal here is to have ExternInput/ExternOutput share the foreign type. So each Rust type can only have one foreign type, which is used for both input and output purposes.

This does result in some curiosities, such as "input strings" being `*mut c_char`, despite the callee not being allowed to modify them. Essentially the constant-ness of types is removed from the type system, instead the `ForeignType` is now intended to convey the ABI types, which should be compatible between input/output to allow reusing (future) compound types.

--------------

Some history!

At the start none of the type system was codified in traits. This was changed in one of the largest Intercom changes during 2018-2019 when the `ExternType` trait was added in MR #119. This trait allowed specifying input/output types in the Rust type system, which simplified a lot of the generated code as it could just use `Foo::ExternOutputType` instead of having to resolve the concrete type at (proc macro) runtime.

The initial implementation just implemented conversions between various types and had it all work through (unsafe) From/Into calls. Later it was discovered that the type conversions _really_ wanted to know whether the types were coming to Rust (and thus would be managed by Rust's memory model) or if they were being sent out of Rust (and thus their memory wouldn't be managed anymore).

This resulted in splitting `ExternType` into the current `ExternInput` and `ExternOutput` in #141. The new traits included the conversion implmementation per-type instead of just relying on generic Into/From implementation.

And finally we're back to adding `ExternType` trait again. Now for a different purpose though. We till have `ExternInput` and `ExternOutput` that define how the type conversions are done, but both of these traits now require `ExternType` to be implemented as the `ExternType` defines a single associated type to be used as the COM foreign type independent of whether the value is being used as input or output value.