### PR TITLE
Allow Rust downgrade in CircleCI to ensure rustfmt

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,10 +15,11 @@ jobs:
                 command: |
                     rustc -vV
                     cargo -vV
+                    rustup -vV
             - run:
                 name: "Run rustfmt"
                 command: |
-                    rustup component add rustfmt-preview
+                    rustup toolchain install nightly --allow-downgrade -c rustfmt
                     cargo fmt -- --check
             - run:
                 name: "Cargo test"


### PR DESCRIPTION
Turns out `toolchain install` can be used to add a component while allowing downgrade.