### PR TITLE
Allow specifying custom hooks for DllRegisterServer/DllUnregisterServer

### DIFF
--- a/intercom-attributes/tests/data/macro/com_library-hooks.rs
+++ b/intercom-attributes/tests/data/macro/com_library-hooks.rs
@@ -1,0 +1,24 @@
+extern crate intercom;
+use intercom::*;
+
+fn custom_load() -> ComResult<()>
+{
+    Ok(())
+}
+
+fn custom_register() -> ComResult<()>
+{
+    Ok(())
+}
+
+fn custom_unregister() -> ComResult<()>
+{
+    Ok(())
+}
+
+com_library!(
+    libid = "00000000-0000-0000-0000-000000000000",
+    on_load = custom_load,
+    on_register = custom_register,
+    on_unregister = custom_unregister,
+);

--- a/intercom-attributes/tests/data/macro/com_library-hooks.rs.stdout
+++ b/intercom-attributes/tests/data/macro/com_library-hooks.rs.stdout
@@ -6,23 +6,17 @@ use std::prelude::rust_2015::*;
 extern crate std;
 extern crate intercom;
 use intercom::*;
-use std::mem::MaybeUninit;
 
-pub mod some {
-    pub mod path {
-        use std::mem::MaybeUninit;
-        pub struct Type;
-        pub const CLSID_Type: i8 = 0i8;
-        pub(crate) fn get_intercom_coclass_info_for_Type() -> intercom::typelib::TypeInfo {
-            unsafe { MaybeUninit::uninit().assume_init() }
-        }
-    }
+fn custom_load() -> ComResult<()> {
+    Ok(())
 }
-pub struct SimpleType;
-pub const CLSID_SimpleType: i8 = 0i8;
 
-pub(crate) fn get_intercom_coclass_info_for_SimpleType() -> intercom::typelib::TypeInfo {
-    unsafe { MaybeUninit::uninit().assume_init() }
+fn custom_register() -> ComResult<()> {
+    Ok(())
+}
+
+fn custom_unregister() -> ComResult<()> {
+    Ok(())
 }
 
 #[allow(dead_code)]
@@ -33,12 +27,6 @@ pub unsafe fn __get_module_class_factory(
     pout: *mut intercom::raw::RawComPtr,
 ) -> Option<intercom::raw::HRESULT> {
     match *rclsid {
-        some::path::CLSID_Type => {
-            return Some(intercom::ClassFactory::<some::path::Type>::create(
-                riid, pout,
-            ))
-        }
-        CLSID_SimpleType => return Some(intercom::ClassFactory::<SimpleType>::create(riid, pout)),
         _ => {}
     };
     None
@@ -74,22 +62,14 @@ pub extern "system" fn DllMain(
     match reason {
         1 => unsafe {
             __INTERCOM_DLL_INSTANCE = dll_instance;
+            custom_load();
         },
         _ => {}
     }
     true
 }
 pub fn __gather_module_types() -> Vec<intercom::typelib::TypeInfo> {
-    <[_]>::into_vec(
-        #[rustc_box]
-        ::alloc::boxed::Box::new([
-            <some::path::Type as intercom::attributes::ComClassTypeInfo>::gather_type_info(),
-            <SimpleType as intercom::attributes::ComClassTypeInfo>::gather_type_info(),
-        ]),
-    )
-    .into_iter()
-    .flatten()
-    .collect()
+    ::alloc::vec::Vec::new().into_iter().flatten().collect()
 }
 #[no_mangle]
 pub unsafe extern "system" fn IntercomTypeLib(
@@ -172,6 +152,9 @@ pub unsafe extern "system" fn DllRegisterServer() -> intercom::raw::HRESULT {
     if let Err(hr) = intercom::registry::register(__INTERCOM_DLL_INSTANCE, tlib) {
         return hr;
     }
+    if let Err(hr) = custom_register() {
+        return hr;
+    }
     intercom::raw::S_OK
 }
 #[no_mangle]
@@ -194,6 +177,9 @@ pub unsafe extern "system" fn DllUnregisterServer() -> intercom::raw::HRESULT {
             .collect(),
     );
     if let Err(hr) = intercom::registry::unregister(__INTERCOM_DLL_INSTANCE, tlib) {
+        return hr;
+    }
+    if let Err(hr) = custom_unregister() {
         return hr;
     }
     intercom::raw::S_OK

--- a/intercom-common/src/model/comlibrary.rs
+++ b/intercom-common/src/model/comlibrary.rs
@@ -33,6 +33,8 @@ intercom_attribute!(
     ComLibraryAttr< ComLibraryAttrParam, LibraryItemType > {
         libid : LitStr,
         on_load : Path,
+        on_register : Path,
+        on_unregister : Path,
     }
 );
 
@@ -43,6 +45,8 @@ pub struct ComLibrary
     pub name: String,
     pub libid: GUID,
     pub on_load: Option<Path>,
+    pub on_register: Option<Path>,
+    pub on_unregister: Option<Path>,
     pub coclasses: Vec<Path>,
     pub interfaces: Vec<Path>,
     pub submodules: Vec<Path>,
@@ -63,6 +67,11 @@ impl ComLibrary
         };
 
         let on_load = attr.on_load().map_err(ParseError::ComLibrary)?.cloned();
+        let on_register = attr.on_register().map_err(ParseError::ComLibrary)?.cloned();
+        let on_unregister = attr
+            .on_unregister()
+            .map_err(ParseError::ComLibrary)?
+            .cloned();
 
         let mut coclasses = vec![];
         let mut interfaces = vec![];
@@ -78,6 +87,8 @@ impl ComLibrary
         Ok(ComLibrary {
             name: crate_name.to_owned(),
             on_load,
+            on_register,
+            on_unregister,
             coclasses,
             interfaces,
             submodules,


### PR DESCRIPTION
Specified in the `#[com_library]` attribute:

https://github.com/Rantanen/intercom/blob/41518eef1dd6984c130d6daf2218b9fb6e47c3bb/intercom-attributes/tests/data/macro/com_library-hooks.rs#L19-L24

Implements #188 